### PR TITLE
Fixed inappropriately scoped PASSTHROUGH_EXCEPTIONS rescue.

### DIFF
--- a/lib/mocha/integration/mini_test/version_142_and_above.rb
+++ b/lib/mocha/integration/mini_test/version_142_and_above.rb
@@ -35,7 +35,7 @@ module Mocha
             ensure
               begin
                 self.teardown
-              rescue *PASSTHROUGH_EXCEPTIONS
+              rescue *::MiniTest::Unit::TestCase::PASSTHROUGH_EXCEPTIONS
                 raise
               rescue Exception => e
                 result = runner.puke(self.class, self.__name__, Mocha::Integration::MiniTest.translate(e))


### PR DESCRIPTION
I found this tasty beast waiting for me as a result of a bad teardown in some test code:

<pre>
1) Error:
test_user_must_have_a_username(UserTest):
NameError: uninitialized constant Mocha::Integration::MiniTest::Version142AndAbove::PASSTHROUGH_EXCEPTIONS
    /home/blt/Documents/projects/rails3apps/itsbeendays/vendor/gems/ruby/1.9.1/gems/mocha-0.9.9/lib/mocha/integration/mini_test/version_142_and_above.rb:38:in `rescue in run'
    /home/blt/Documents/projects/rails3apps/itsbeendays/vendor/gems/ruby/1.9.1/gems/mocha-0.9.9/lib/mocha/integration/mini_test/version_142_and_above.rb:36:in `run'
    /home/blt/Documents/projects/rails3apps/itsbeendays/vendor/gems/ruby/1.9.1/gems/activesupport-3.0.1/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /home/blt/Documents/projects/rails3apps/itsbeendays/vendor/gems/ruby/1.9.1/gems/activesupport-3.0.1/lib/active_support/callbacks.rb:413:in `_run_setup_callbacks'
    /home/blt/Documents/projects/rails3apps/itsbeendays/vendor/gems/ruby/1.9.1/gems/activesupport-3.0.1/lib/active_support/testing/setup_and_teardown.rb:34:in `run'
</pre>


Applying the patch I'm giving to you results in:

<pre>
1) Error:
test_user_must_have_a_username(UserTest):
DataObjects::IntegrityError: column id is not unique (...)
</pre>


Far more helpful.
