### PR TITLE
Make ExpectationError inherit from Exception, rather than StandardError

### DIFF
--- a/lib/mocha/expectation_error.rb
+++ b/lib/mocha/expectation_error.rb
@@ -2,7 +2,7 @@ require 'mocha/backtrace_filter'
 
 module Mocha
 
-  class ExpectationError < StandardError
+  class ExpectationError < Exception
     
     def initialize(message = nil, backtrace = [])
       super(message)


### PR DESCRIPTION
Re: http://floehopper.lighthouseapp.com/projects/22289/tickets/1-mochaexpectationerror-exception we would also like to see this behavior incorporated into a release of mocha. It is currently not possible to detect failed expectations that happen within a block that does a bare rescue. For instance:

``` ruby
    describe User
      it "does not call name from display_name" do
        User.any_instance.expects(:name).never
        User.display_name
      end
    end

    class User
      def name
        'bob'
      end

      def display_name
        name
      rescue
        puts "This was caused by Mocha::ExpectationError"
      end
    end
```

This test would print the text in the rescue, and pass. However, if `ExpectationError` inherits from `Exception`, you would have to explicitly rescue `Exception` for this behavior to happen, which is known to be dangerous.
