### PR TITLE
#returns with block

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -249,6 +249,7 @@ module Mocha # :nodoc:
     end
 
     # :call-seq: returns(value) -> expectation
+    #            returns(&block) -> expectation
     #            returns(*values) -> expectation
     #
     # Modifies expectation so that when the expected method is called, it returns the specified +value+.
@@ -256,6 +257,12 @@ module Mocha # :nodoc:
     #   object.stubs(:stubbed_method).returns('result')
     #   object.stubbed_method # => 'result'
     #   object.stubbed_method # => 'result'
+    # If a block or a Proc is passed, the Proc will be evaluated at runtime.
+    #   object = mock()
+    #   object.stubs(:stubbed_method).returns { Time.now }
+    #   object.stubbed_method # => 'Mon Dec 27 10:13:44 +0100 2010'
+    #   sleep(6)
+    #   object.stubbed_method # => 'Mon Dec 27 10:13:50 +0100 2010'
     # If multiple +values+ are given, these are returned in turn on consecutive calls to the method.
     #   object = mock()
     #   object.stubs(:stubbed_method).returns(1, 2)
@@ -279,8 +286,12 @@ module Mocha # :nodoc:
     #   x, y = object.expected_method
     #   x # => 1
     #   y # => 2
-    def returns(*values)
-      @return_values += ReturnValues.build(*values)
+    def returns(*values, &block)
+      @return_values += if block_given?
+        ReturnValues.build(block)
+      else
+        ReturnValues.build(*values)
+      end
       self
     end
 

--- a/lib/mocha/single_return_value.rb
+++ b/lib/mocha/single_return_value.rb
@@ -9,7 +9,11 @@ module Mocha # :nodoc:
     end
     
     def evaluate
-      @value
+      if @value.is_a?(Proc)
+        @value.call
+      else
+        @value
+      end
     end
     
   end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -151,7 +151,22 @@ class ExpectationTest < Test::Unit::TestCase
     expectation = new_expectation.returns(99)
     assert_equal 99, expectation.invoke
   end
-  
+
+  def test_should_return_evaluated_block
+    expectation = new_expectation.returns { 10 + 10 }
+    assert_equal 20, expectation.invoke
+  end
+
+  def test_should_return_evaluated_block_if_block_and_values_are_supplied
+    expectation = new_expectation.returns(30) { 10 + 10 }
+    assert_equal 20, expectation.invoke
+  end
+
+  def test_should_return_evaluated_lambda
+    expectation = new_expectation.returns(proc { 20 + 20 })
+    assert_equal 40, expectation.invoke
+  end
+
   def test_should_return_same_specified_value_multiple_times
     expectation = new_expectation.returns(99)
     assert_equal 99, expectation.invoke

--- a/test/unit/return_values_test.rb
+++ b/test/unit/return_values_test.rb
@@ -45,10 +45,11 @@ class ReturnValuesTest < Test::Unit::TestCase
   end
   
   def test_should_build_single_return_values_for_each_values
-    values = ReturnValues.build('value_1', 'value_2', 'value_3').values
+    values = ReturnValues.build('value_1', 'value_2', 'value_3', proc { "value_#{4}" }).values
     assert_equal 'value_1', values[0].evaluate
     assert_equal 'value_2', values[1].evaluate
     assert_equal 'value_3', values[2].evaluate
+    assert_equal 'value_4', values[3].evaluate
   end
   
   def test_should_combine_two_sets_of_return_values

--- a/test/unit/single_return_value_test.rb
+++ b/test/unit/single_return_value_test.rb
@@ -10,5 +10,20 @@ class SingleReturnValueTest < Test::Unit::TestCase
     value = SingleReturnValue.new('value')
     assert_equal 'value', value.evaluate
   end
-  
+
+  def test_should_evaluate_block
+    klass = Class.new do
+      def single_block(&block)
+        SingleReturnValue.new(block)
+      end
+    end
+    value = klass.new.single_block { 'value from block' }
+    assert_equal 'value from block', value.evaluate
+  end
+
+  def test_should_evaluate_proc
+    value = SingleReturnValue.new(proc { "value from proc" })
+    assert_equal 'value from proc', value.evaluate
+  end
+
 end


### PR DESCRIPTION
This patch adds the ability to supply a block/proc to `#returns`. The result will be evaluated at runtime and returned.

```
object.expects(:method).returns { 1 + 1 }
object.method # => 2

object.expects(:method).returns(proc { 2 + 2 })
object.method # => 4
```
