### PR TITLE
Mocha::Expectation#returns_self

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -284,6 +284,21 @@ module Mocha # :nodoc:
       self
     end
 
+    # :call-seq: returns_self -> expectation
+    #
+    # Modifies expectation so that when the expected method is called, it returns the mock. This is a convenience method.
+    # The following snippets are equivalent:
+    #   object_1 = mock()
+    #   object_1.stubs(:stubbed_method).returns(object_1)
+    #   object_1.stubbed_method # => object_1
+    #
+    #   object_2 = mock { stubs(:stubbed_method).returns_self }
+    #   object_2.stubbed_method # => object_2
+    def returns_self
+      @return_values += ReturnValues.build(@mock)
+      self
+    end
+
     # :call-seq: raises(exception = RuntimeError, message = nil) -> expectation
     #
     # Modifies expectation so that when the expected method is called, it raises the specified +exception+ with the specified +message+ i.e. calls Kernel#raise(exception, message).

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -182,6 +182,14 @@ class ExpectationTest < Test::Unit::TestCase
     expectation = new_expectation.returns()
     assert_nil expectation.invoke
   end
+
+  def test_should_return_self
+    object = "foo"
+    expectation = Expectation.new(object, :expected_method)
+    result = expectation.returns_self
+    assert_equal expectation, result
+    assert_same object, expectation.invoke
+  end
   
   def test_should_raise_runtime_exception
     expectation = new_expectation.raises


### PR DESCRIPTION
I added this method because I found myself doing this when stubbing out Sequel datasets:

```
dataset = stub('Sequel dataset', :all => [{:bar => 123}, {:bar => 456}])
dataset.stubs(:select).returns(dataset)
database = stub('Sequel database')
database.stubs(:[]).with(:foo).returns(dataset)
database[:foo].select(:junk).all #=> [{:bar=>123}, {:bar=>456}]
```

Instead, I thought it'd be nice to be able to do something like this:

```
database = stub('Sequel database')
database.stubs(:[]).with(:foo).returns(stub(:all => [{:bar => 123}, {:bar => 456}]) { stubs(:select).returns_self })
database[:foo].select(:junk).all #=> [{:bar=>123}, {:bar=>456}]
```

Thoughts?
