### PR TITLE
multiple_yields with Hash instances

### DIFF
--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -147,6 +147,13 @@ class ExpectationTest < Test::Unit::TestCase
     assert_equal [[1, 2, 3], [4, 5], [6, 7]], yielded_parameters
   end
 
+  def test_should_yield_multiple_times_with_hashes_correctly
+    expectation = new_expectation().multiple_yields({:one => "1"}, {:two => "2"})
+    yielded_parameters = []
+    expectation.invoke() { |*parameters| yielded_parameters << parameters }
+    assert_equal [{:one => "1"}, {:two => "2"}], yielded_parameters
+  end
+
   def test_should_return_specified_value
     expectation = new_expectation.returns(99)
     assert_equal 99, expectation.invoke


### PR DESCRIPTION
When trying to do a multiple yields with hashes, the hashes come back as arrays (almost like `to_a` was called?).

I don't know the internals of mocha, but in the attached pull request I wrote a red test which is failing in MRI 1.8.7 and 1.9.2 (and maybe others).

Awesome stuff otherwise! Thanks.

```
  1) Failure:
test_should_yield_multiple_times_with_hashes_correctly(ExpectationTest) [test/unit/expectation_test.rb:154]:
<[{:one=>"1"}, {:two=>"2"}]> expected but was
<[[[:one, "1"]], [[:two, "2"]]]>.
```
