### PR TITLE
Exception raised when required out of order

### DIFF
--- a/lib/mocha.rb
+++ b/lib/mocha.rb
@@ -1,3 +1,15 @@
+def test_unit_required
+    defined?(Test) && defined?(Test::Unit) && defined?(Test::Unit::TestCase)
+end
+
+def minitest_required
+    defined?(MiniTest) && defined?(MiniTest::Unit) && defined?(MiniTest::Unit::TestCase)
+end
+
+unless test_unit_required || minitest_required
+    raise RuntimeError, "Must require mocha *after* requring a test framework."
+end
+
 require 'mocha/version'
 require 'mocha_standalone'
 require 'mocha/configuration'


### PR DESCRIPTION
I got bitten by the "must require mocha after test/unit" issue. The problem is that you get an error about mock() not being defined; so it's unclear what's going wrong. It was also mysterious because it would work when running as part of a Rake::TestTask, but not when running the file individually.

I added some code to raise an exception when mocha.rb is imported without a testing framework. I think it's more helpful this way; let me know if you want it handled in a different way.
