### PR TITLE
Use Gem::Requirement for version comparison. Fixes #50

### DIFF
--- a/lib/mocha/integration/mini_test.rb
+++ b/lib/mocha/integration/mini_test.rb
@@ -22,27 +22,27 @@ if !MiniTest::Unit::TestCase.ancestors.include?(Mocha::API)
         remove_method :run
 
         mini_test_version = begin
-          MiniTest::Unit::VERSION
+          Gem::Version.new(MiniTest::Unit::VERSION)
         rescue LoadError
-          'unknown'
+          Gem::Version.new('0.0.0')
         end
 
         $stderr.puts "Detected MiniTest version: #{mini_test_version}" if $options['debug']
 
-        if (mini_test_version >= '1.3.0') && (mini_test_version <= '1.3.1')
+        if Gem::Requirement.new('>= 1.3.0', '<= 1.3.1') =~ mini_test_version
           include Mocha::Integration::MiniTest::Version13
-        elsif (mini_test_version == '1.4.0')
+        elsif Gem::Requirement.new('1.4.0') =~ mini_test_version
           include Mocha::Integration::MiniTest::Version140
-        elsif (mini_test_version == '1.4.1')
+        elsif Gem::Requirement.new('1.4.1') =~ mini_test_version
           include Mocha::Integration::MiniTest::Version141
-        elsif (mini_test_version >= '1.4.2') && (mini_test_version <= '1.7.2')
+        elsif Gem::Requirement.new('>= 1.4.2', '<= 1.7.2') =~ mini_test_version
           include Mocha::Integration::MiniTest::Version142To172
-        elsif (mini_test_version == '2.0.0')
+        elsif Gem::Requirement.new('2.0.0') =~ mini_test_version
           include Mocha::Integration::MiniTest::Version200
-        elsif (mini_test_version >= '2.0.1') && (mini_test_version <= '2.2.2')
+        elsif Gem::Requirement.new('>= 2.0.1', '<= 2.2.2') =~ mini_test_version
           include Mocha::Integration::MiniTest::Version201To222
-        elsif (mini_test_version >= '2.3.0')
-          $stderr.puts "*** MiniTest integration has not been verified but patching anyway ***" if (mini_test_version > '2.6.2') && $options['debug']
+        elsif Gem::Requirement.new('>= 2.3.0') =~ mini_test_version
+          $stderr.puts "*** MiniTest integration has not been verified but patching anyway ***" if (Gem::Requirement.new('> 2.6.2') =~ mini_test_version) && $options['debug']
           include Mocha::Integration::MiniTest::Version230To262
         else
           $stderr.puts "*** No Mocha integration for MiniTest version ***" if $options['debug']

--- a/lib/mocha/integration/test_unit.rb
+++ b/lib/mocha/integration/test_unit.rb
@@ -21,9 +21,9 @@ if !Test::Unit::TestCase.ancestors.include?(Mocha::API)
 
         test_unit_version = begin
           load 'test/unit/version.rb'
-          Test::Unit::VERSION
+          Gem::Version.new(Test::Unit::VERSION)
         rescue LoadError
-          '1.x'
+          Gem::Version.new('1.x')
         end
 
         if $options['debug']
@@ -31,19 +31,19 @@ if !Test::Unit::TestCase.ancestors.include?(Mocha::API)
           $stderr.puts "Detected Test::Unit version: #{test_unit_version}"
         end
 
-        if (test_unit_version == '1.x') || (test_unit_version == '1.2.3')
+        if (test_unit_version == Gem::Version.new('1.x') || (test_unit_version == Gem::Version.new('1.2.3'))
           if RUBY_VERSION < '1.8.6'
             include Mocha::Integration::TestUnit::RubyVersion185AndBelow
           else
             include Mocha::Integration::TestUnit::RubyVersion186AndAbove
           end
-        elsif (test_unit_version == '2.0.0')
+        elsif Gem::Requirement.new('2.0.0') =~ test_unit_version
           include Mocha::Integration::TestUnit::GemVersion200
-        elsif (test_unit_version >= '2.0.1') && (test_unit_version <= '2.0.2')
+        elsif Gem::Requirement.new('>= 2.0.1', '<= 2.0.2') =~ test_unit_version
           include Mocha::Integration::TestUnit::GemVersion201To202
-        elsif (test_unit_version >= '2.0.3') && (test_unit_version <= '2.2.0')
+        elsif Gem::Requirement.new('>= 2.0.3', '<= 2.2.0') =~ test_unit_version
           include Mocha::Integration::TestUnit::GemVersion203To220
-        elsif (test_unit_version >= '2.3.0')
+        elsif Gem::Requirement.new('>= 2.3.0') =~ test_unit_version
           $stderr.puts "*** Test::Unit integration has not been verified but patching anyway ***" if (test_unit_version > '2.4.0') && $options['debug']
           include Mocha::Integration::TestUnit::GemVersion230To240
         else


### PR DESCRIPTION
This pull request fixes #50.

And considering newer Rubies shipping Rubygems as part of the standard library, I think it's safe to assume presence of rubygems nowadays.
