### PR TITLE
Rename Mock#expectations to Mock#__expectations__ to avoid conflicts

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -142,13 +142,17 @@ module Mocha # :nodoc:
       instance_eval(&block) if block
     end
 
-    attr_reader :everything_stubbed, :expectations
+    attr_reader :everything_stubbed
 
     alias_method :__expects__, :expects
 
     alias_method :__stubs__, :stubs
 
     alias_method :quacks_like, :responds_like
+
+    def __expectations__
+      @expectations
+    end
 
     def stub_everything
       @everything_stubbed = true

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -149,7 +149,7 @@ module Mocha
     private
     
     def expectations
-      mocks.map { |mock| mock.expectations.to_a }.flatten
+      mocks.map { |mock| mock.__expectations__.to_a }.flatten
     end
     
     def unsatisfied_expectations

--- a/test/acceptance/stub_any_instance_method_test.rb
+++ b/test/acceptance/stub_any_instance_method_test.rb
@@ -84,7 +84,7 @@ class StubAnyInstanceMethodTest < Test::Unit::TestCase
       klass.any_instance.stubs(:my_instance_method).returns(:new_return_value)
     end
 
-    assert_equal 0, klass.any_instance.mocha.expectations.length
+    assert_equal 0, klass.any_instance.mocha.__expectations__.length
   end
   
   def test_should_be_able_to_stub_a_superclass_method

--- a/test/acceptance/stub_module_method_test.rb
+++ b/test/acceptance/stub_module_method_test.rb
@@ -54,7 +54,7 @@ class StubModuleMethodTest < Test::Unit::TestCase
     run_as_test do
       mod.stubs(:my_module_method)
     end
-    assert_equal 0, mod.mocha.expectations.length
+    assert_equal 0, mod.mocha.__expectations__.length
   end  
   
   def test_should_be_able_to_stub_a_superclass_method

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -20,7 +20,7 @@ class MockTest < Test::Unit::TestCase
    mock = build_mock
    expectation = mock.expects(:method1)
    assert_not_nil expectation
-   assert_equal [expectation], mock.expectations.to_a
+   assert_equal [expectation], mock.__expectations__.to_a
   end
   
   def test_should_not_stub_everything_by_default
@@ -67,7 +67,7 @@ class MockTest < Test::Unit::TestCase
     mock = build_mock
     expectation1 = mock.expects(:method1)
     expectation2 = mock.expects(:method2)
-    assert_equal [expectation1, expectation2].to_set, mock.expectations.to_set
+    assert_equal [expectation1, expectation2].to_set, mock.__expectations__.to_set
   end
   
   def test_should_pass_backtrace_into_expectation
@@ -88,7 +88,7 @@ class MockTest < Test::Unit::TestCase
     mock = build_mock
     stub1 = mock.stubs(:method1)
     stub2 = mock.stubs(:method2)
-    assert_equal [stub1, stub2].to_set, mock.expectations.to_set
+    assert_equal [stub1, stub2].to_set, mock.__expectations__.to_set
   end
   
   def test_should_invoke_expectation_and_return_result


### PR DESCRIPTION
I have a project that has a legitimate instance method named "expectations" that I would like to stub, which seems impossible with Mocha's current setup. Since Mock#expectations is an internal Mocha method, to me it seems like a good idea to use an internal name in order to avoid conflicts.

`Mock#stubs` and `Mock#expects` are already protected against masking by aliasing `Mock#__stubs__` and `Mock#__expects__`, so I used the same naming style. Since it seems rare that a user would call `Mock#expectations` directly, I just renamed the getter to `Mock#__expectations__` instead of aliasing it.

Thoughts?

Thanks,
viking
