### PR TITLE
Alias `Object#method` to `Object#_method`

### DIFF
--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -36,7 +36,7 @@ module Mocha
     def hide_original_method
       if method_exists?(method)
         begin
-          @original_method = stubbee.method(method)
+          @original_method = stubbee._method(method)
           if @original_method && @original_method.owner == stubbee.__metaclass__
             @original_visibility = :public
             if stubbee.__metaclass__.protected_instance_methods.include?(method)

--- a/lib/mocha/object.rb
+++ b/lib/mocha/object.rb
@@ -13,6 +13,9 @@ module Mocha
   module ObjectMethods
 
     # @private
+    alias_method :_method, :method
+
+    # @private
     def mocha
       @mocha ||= Mocha::Mockery.instance.mock_impersonating(self)
     end

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -24,6 +24,13 @@ class ClassMethodTest < Test::Unit::TestCase
     assert_nothing_raised { method.hide_original_method }
   end
 
+  def test_should_not_raise_error_hiding_method_in_class_that_implement_method_method
+    klass = Class.new { def self.method; end }
+    method = ClassMethod.new(klass, :method)
+
+    assert_nothing_raised { method.hide_original_method }
+  end
+
   def test_should_define_a_new_method_which_should_call_mocha_method_missing
     klass = Class.new { def self.method_x; end }
     mocha = build_mock

--- a/test/unit/object_test.rb
+++ b/test/unit/object_test.rb
@@ -84,4 +84,9 @@ class ObjectTest < Test::Unit::TestCase
     assert_raise(Mocha::ExpectationError) { object.expects(:the_spanish_inquisition) }
   end
 
+  def test_should_alias_object_method
+    klass = Class.new { def self.method_x; end }
+    assert_equal klass._method(:method_x), klass.method(:method_x)
+  end
+
 end


### PR DESCRIPTION
This will fix the problem when using Mocha to stub an object that reimplement `#method` method.

Please see https://github.com/rails/rails/pull/5907 for detail.
