### PR TITLE
Implement procs as parameter matchers

### DIFF
--- a/lib/mocha/parameter_matchers.rb
+++ b/lib/mocha/parameter_matchers.rb
@@ -6,6 +6,7 @@ module Mocha
 end
 
 require 'mocha/parameter_matchers/object'
+require 'mocha/parameter_matchers/proc'
 
 require 'mocha/parameter_matchers/all_of'
 require 'mocha/parameter_matchers/any_of'

--- a/lib/mocha/parameter_matchers/proc.rb
+++ b/lib/mocha/parameter_matchers/proc.rb
@@ -1,0 +1,38 @@
+module Mocha
+
+  module ParameterMatchers
+
+    # Parameter matcher which matches when proc returns truthy when given actual parameter.
+    class Proc < Base
+
+      # @private
+      def initialize(_proc)
+        @_proc = _proc
+      end
+
+      # @private
+      def matches?(available_parameters)
+        parameter = available_parameters.shift
+        @_proc.call(parameter)
+      end
+
+      # @private
+      def mocha_inspect
+        "proc"
+      end
+
+    end
+  end
+
+  module ProcMethods
+    # @private
+    def to_matcher
+      Mocha::ParameterMatchers::Proc.new(self)
+    end
+  end
+end
+
+# @private
+class Proc
+  include Mocha::ProcMethods
+end

--- a/test/acceptance/parameter_matcher_test.rb
+++ b/test/acceptance/parameter_matcher_test.rb
@@ -297,4 +297,36 @@ class ParameterMatcherTest < Test::Unit::TestCase
     assert_passed(test_result)
   end
 
+  def test_should_match_with_proc_returning_truthy
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(proc { |parameter| parameter })
+      mock.method(true)
+    end
+    assert_passed(test_result)
+
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(proc { |parameter| parameter })
+      mock.method(1)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_not_match_with_proc_returning_falsy
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(proc { |parameter| parameter })
+      mock.method(false)
+    end
+    assert_failed(test_result)
+
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(proc { |parameter| parameter })
+      mock.method(nil)
+    end
+    assert_failed(test_result)
+  end
+
 end

--- a/test/unit/parameter_matchers/proc_test.rb
+++ b/test/unit/parameter_matchers/proc_test.rb
@@ -1,0 +1,28 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+require 'mocha/parameter_matchers/proc'
+require 'mocha/inspect'
+
+class ProcTest < Test::Unit::TestCase
+
+  include Mocha::ParameterMatchers
+
+  def test_should_match_returning_truthy
+    matcher = Proc.new(proc { |parameter| parameter })
+    assert matcher.matches?([true])
+    assert matcher.matches?([1])
+    assert matcher.matches?([''])
+  end
+
+  def test_should_not_match_returning_falsy
+    matcher = Proc.new(proc { |parameter| parameter })
+    assert !matcher.matches?([false])
+    assert !matcher.matches?([nil])
+  end
+
+  def test_should_describe_matcher
+    matcher = Proc.new(proc {})
+    assert_equal "proc", matcher.mocha_inspect
+  end
+
+end


### PR DESCRIPTION
This allows you to build arbitrarily complex matchers without needing a
full matcher object.

Example:

``` ruby
matcher1 = proc { |parameter| something_complex?(parameter) }
matcher2 = proc { |parameter| something_else_complex?(parameter) }
mock.expects(:method).with(matcher1, matcher2)
```
