### PR TITLE
Make it possible to use YAML to serialize and deserialize a mock object

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -209,6 +209,7 @@ module Mocha
 
     # @private
     def respond_to?(symbol, include_private = false)
+      return false if instance_variables.empty?
       if @responder then
         if @responder.method(:respond_to?).arity > 1
           @responder.respond_to?(symbol, include_private)

--- a/test/acceptance/stub_serialization_test.rb
+++ b/test/acceptance/stub_serialization_test.rb
@@ -1,0 +1,27 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+require 'mocha'
+require 'yaml'
+
+class StubSerializationTest < Test::Unit::TestCase
+
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_should_serialize_and_unserialize_successfully
+    test_result = run_as_test do
+      before = mock('before')
+      before.stubs(:bar).returns('bar')
+      dump = YAML.dump(before)
+      after = YAML.load(dump)
+      assert_equal 'bar', after.bar
+    end
+    assert_passed(test_result)
+  end
+end


### PR DESCRIPTION
Previously this was raising an exception because Mock#respond_to? was
being called before the instance of Mock has been re-hydrated i.e. none
of its instance variables had been set :-

```
NoMethodError: undefined method `matches_method?' for nil:NilClass
```

from gems/mocha-0.10.5/lib/mocha/mock.rb:185:in `respond_to?'

Note that I would not recommend using stubs in this way, but I decided
it was a shame that an exception was raised unnecessarily.

Note also that any expectations set on the original instance of Mock
will not be satisfied by invoking method on the re-hydrated instance of
Mock, because the two instances are completely different. This might be
solved by de-registering the Mock object when an instance with the same
"identitifer" is registered, but then I start wondering whether the
whole thing is a silly idea and we'd be better off raising an exception
if anyone attempts to serialize an instance of Mock.
