### PR TITLE
fix incorrect behaviour when mocks is empty

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -44,7 +44,7 @@ module Mocha
     end
 
     def verify(assertion_counter = nil)
-      unless mocks.all? { |mock| mock.__verified__?(assertion_counter) }
+      if mocks.any? { |mock| !mock.__verified__?(assertion_counter) }
         message = "not all expectations were satisfied\n#{mocha_inspect}"
         if unsatisfied_expectations.empty?
           backtrace = caller


### PR DESCRIPTION
i found this bug when try patch Enumerable module

now we have bug in ruby

```
1.9.3p194 :001 >  [].all?(&:undefined_mathod) 
 => true 
```
