### PR TITLE
Mock#respond_to? doesn't work with a string argument

### DIFF
--- a/lib/mocha/method_matcher.rb
+++ b/lib/mocha/method_matcher.rb
@@ -9,7 +9,7 @@ module Mocha
     end
 
     def match?(actual_method_name)
-      @expected_method_name == actual_method_name
+      @expected_method_name == actual_method_name.to_sym
     end
 
     def mocha_inspect

--- a/test/unit/method_matcher_test.rb
+++ b/test/unit/method_matcher_test.rb
@@ -10,6 +10,11 @@ class MethodMatcherTest < Test::Unit::TestCase
     assert method_matcher.match?(:method_name)
   end
 
+  def test_should_match_if_actual_method_name_is_expected_method_name_as_string
+    method_matcher = MethodMatcher.new(:method_name)
+    assert method_matcher.match?('method_name')
+  end
+
   def test_should_not_match_if_actual_method_name_is_not_same_as_expected_method_name
     method_matcher = MethodMatcher.new(:method_name)
     assert !method_matcher.match?(:different_method_name)

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -214,6 +214,12 @@ class MockTest < Test::Unit::TestCase
     assert_equal true, mock.respond_to?(:method1)
   end
 
+  def test_should_respond_to_expected_method_as_string
+    mock = build_mock
+    mock.expects(:method1)
+    assert_equal true, mock.respond_to?('method1')
+  end
+
   def test_should_not_respond_to_unexpected_method
     mock = build_mock
     assert_equal false, mock.respond_to?(:method1)


### PR DESCRIPTION
Hi,

I ran into the following behaviour today, where a mocha mock will answer `#respond_to?` correctly when passed a symbol, but not when passed a string:

``` ruby
require 'rspec'
require 'mocha'

RSpec.configure do |config|
  config.mock_with :mocha
end

describe "#respond_to? issue" do
  subject { stub(:gentle_persuasion => :the_truth) }

  # passes
  it "responds correctly to symbol call" do
    subject.should respond_to :gentle_persuasion
  end

  # fails
  it "responds correctly to string call" do
    subject.should respond_to 'gentle_persuasion'
  end
end
```

I believe the second assertion should pass too, to match `Object#respond_to?`'s usual behaviour. A patch and tests are attached - give me shout if there's anything you'd like done differently...

Cheers,
Simon
