### PR TITLE
Fixes Travis link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Mocha [![build status](https://secure.travis-ci.org/freerange/mocha.png)](https://secure.travis-ci.org/freerange/mocha.png)
+## Mocha [![build status](https://secure.travis-ci.org/freerange/mocha.png)](https://secure.travis-ci.org/freerange/mocha)
 
 ### Description
 


### PR DESCRIPTION
Changes Travis link from a link to the image:

`https://secure.travis-ci.org/freerange/mocha.png`

 to a link to the Travis page for Mocha:

`https://secure.travis-ci.org/freerange/mocha`
