### PR TITLE
Implemented restrict_to_instance_of

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -198,10 +198,15 @@ module Mocha
     end
 
     # @private
+    def restrict_to_class_includes?(method_name)
+      @restrict_to_class.instance_methods.map(&:to_sym).include?(method_name.to_sym)
+    end
+
+    # @private
     def raise_no_method_error_if_restricted(method)
       if @responder and not @responder.respond_to?(method)
         raise NoMethodError, "undefined method `#{method}' for #{self.mocha_inspect} which responds like #{@responder.mocha_inspect}"
-      elsif @restrict_to_class and not @restrict_to_class.instance_methods.include?(method)
+      elsif @restrict_to_class and not restrict_to_class_includes?(method)
         raise NoMethodError, "undefined method `#{method}' for #{self.mocha_inspect} which responds like an instance of #{@restrict_to_class}"
       end
     end
@@ -224,7 +229,7 @@ module Mocha
 
     # @private
     def respond_to?(symbol, include_private = false)
-      if @restrict_to_class and not @restrict_to_class.instance_methods.include?(symbol)
+      if @restrict_to_class and not restrict_to_class_includes?(symbol)
         false
       elsif @responder then
         if @responder.method(:respond_to?).arity > 1

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -310,7 +310,7 @@ class MockTest < Test::Unit::TestCase
     assert_raises(NoMethodError) { mock.not_existent }
   end
 
-  def test_should_not_raise_no_method_error_if_restricted_clss_instance_methods_includes_invoked_method
+  def test_should_not_raise_no_method_error_if_restricted_class_instance_methods_includes_invoked_method
     klass = Class.new do
       define_method(:invoked_method) { true }
     end


### PR DESCRIPTION
This new method in `mock.rb` restricts methods being mocked to the methods included in the `instance_methods` of the class passed in as argument.

The reasoning behind this, is because sometimes you can't easily instantiate a new object of that class and pass that into `responds_like`, can be because you have lot's of dependencies on that class, because it's computationally expensive, etc etc.

If you like the idea I will write documentation for this new method. If you think the implementation could be better I am happy to update the pull request.

Thanks!
