### PR TITLE
Use require instead of load with test/unit/version

### DIFF
--- a/lib/mocha/integration/test_unit.rb
+++ b/lib/mocha/integration/test_unit.rb
@@ -16,7 +16,7 @@ module Mocha
         return false unless defined?(::Test::Unit::TestCase) && !(defined?(::MiniTest::Unit::TestCase) && (::Test::Unit::TestCase < ::MiniTest::Unit::TestCase))
 
         test_unit_version = begin
-          load 'test/unit/version.rb'
+          require 'test/unit/version'
           Gem::Version.new(::Test::Unit::VERSION)
         rescue LoadError
           Gem::Version.new('1.0.0')


### PR DESCRIPTION
Other gems also require test/unit/version. When this gem loads the
same file it over writes the constant and causes a warning. If there is any way possible I would also like this back ported to the 0.12.X version.
