### PR TITLE
Safer method visibility restoration

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -46,7 +46,7 @@ module Mocha
     def restore_original_method
       if @original_method && @original_method.owner == stubbee
         stubbee.send(:define_method, method, @original_method)
-        stubbee.send(@original_visibility, method)
+        Module.instance_method(@original_visibility).bind(stubbee).call(method)
       end
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -77,7 +77,7 @@ module Mocha
         end
       end
       if @original_visibility
-        stubbee.__metaclass__.send(@original_visibility, method)
+        Module.instance_method(@original_visibility).bind(stubbee.__metaclass__).call(method)
       end
     end
 


### PR DESCRIPTION
This fixes errors when `public` or `private` is redefined, for example as a named_scope on an ActiveRecord model.

/cc @floehopper #109
