### PR TITLE
stubbing superclass class methods makes subclass class methods inaccessible

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -496,6 +496,29 @@ module Mocha
       self
     end
 
+    # Allows the expectation to match for subclasses
+    #
+    # Only applies to expectations on class methods.
+    #
+    # @param [value] to allow this expectation to match for subclasses
+    # @return [Expectation] the same expectation, thereby allowing invocations of other {Expectation} methods to be chained.
+    #
+    # @example
+    # class A
+    #   def self.something
+    #     'A'
+    #   end
+    # end
+    # class B < A
+    # end
+    #
+    # A.stubs(:something).including_subclass.returns('stub')
+    # B.something => "stub"
+    def including_subclasses(value = true)
+      @including_subclasses = value
+      self
+    end
+
     # @private
     attr_reader :backtrace
 
@@ -507,6 +530,7 @@ module Mocha
       @ordering_constraints = []
       @side_effects = []
       @cardinality, @invocation_count = Cardinality.exactly(1), 0
+      @including_subclasses = false
       @return_values = ReturnValues.new
       @yield_parameters = YieldParameters.new
       @backtrace = backtrace || caller
@@ -555,6 +579,11 @@ module Mocha
     # @private
     def satisfied?
       @cardinality.satisfied?(@invocation_count)
+    end
+
+    # @private
+    def including_subclasses?
+      @including_subclasses
     end
 
     # @private

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -197,7 +197,9 @@ module Mocha
     def initialize(mockery, name = nil, &block)
       @mockery = mockery
       @name = name || DefaultName.new(self)
-      @expectations = ExpectationList.new
+      klass = name.instance_variable_get(:@object) if name.is_a?(ImpersonatingName)
+      klass = nil unless klass.is_a?(Class)
+      @expectations = ExpectationList.new(klass)
       @everything_stubbed = false
       @responder = nil
       instance_eval(&block) if block

--- a/test/acceptance/stub_class_method_defined_on_superclass_test.rb
+++ b/test/acceptance/stub_class_method_defined_on_superclass_test.rb
@@ -72,4 +72,17 @@ class StubClassMethodDefinedOnSuperclassTest < Test::Unit::TestCase
     end
     assert_equal :original_return_value, klass.send(:my_class_method)
   end
+
+  def test_should_allow_including_subclasses_in_stub
+    superklass = Class.new do
+      class << self
+        def my_class_method
+          :original_return_value
+        end
+      end
+    end
+    klass = Class.new(superklass)
+    superklass.stubs(:my_class_method).including_subclasses.returns(:new_return_value)
+    assert_equal :new_return_value, klass.my_class_method
+  end
 end


### PR DESCRIPTION
normally, stubbing a class method on a superclass simply makes
calling that method on a subclass be an unexpected invocation.
now you can optionally use the same stub for all subclasses
