### PR TITLE
require "mocha/setup" in test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ if defined?(::Minitest) || defined?(MiniTest)
   rescue LoadError
     MiniTest::Unit.autorun
   end
+  require 'mocha/setup'
   class Mocha::TestCase < defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase
     def assert_nothing_raised(exception = StandardError)
       yield
@@ -37,6 +38,7 @@ if defined?(::Minitest) || defined?(MiniTest)
   end
 else
   require 'test/unit'
+  require 'mocha/setup'
   class Mocha::TestCase < Test::Unit::TestCase
     def test_dummy
       # Some versions (?) of Test::Unit try to run this base class as a test case


### PR DESCRIPTION
When running the tests individually (outside of rake or bundler, as in #121), the tests fail because we don't require mocha/setup before referring to classes named "Mocha".

<pre>
ruby -e 'Dir.glob('\''./test/{unit,acceptance}/**/*_test.rb'\'').each {|t| req
uire t}'
/builddir/build/BUILDROOT/rubygem-mocha-0.14.0-1.fc19.i386/usr/share/gems/gems/mocha-0.14.0/test/test_helper.rb:26:in `<top (required)>': uninitialized constant Mocha (NameError)
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
        from /builddir/build/BUILDROOT/rubygem-mocha-0.14.0-1.fc19.i386/usr/share/gems/gems/mocha-0.14.0/test/unit/parameters_matcher_test.rb:1:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:51:in `require'
        from -e:1:in `block in <main>'
        from -e:1:in `each'
        from -e:1:in `<main>'
</pre>


This pull request loads "mocha/setup" in the test_helper so that the tests can run again.
