### PR TITLE
Rescue SystemStackError during mocha_inspect

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -4,9 +4,13 @@ module Mocha
 
   module ObjectMethods
     def mocha_inspect
+      begin
+        return inspect unless inspect =~ /#</
+      rescue SystemStackError
+      end
       address = self.__id__ * 2
       address += 0x100000000 if address < 0
-      inspect =~ /#</ ? "#<#{self.class}:0x#{'%x' % address}>" : inspect
+      "#<#{self.class}:0x#{'%x' % address}>"
     end
   end
 

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/inspect'
 require 'method_definer'
+require 'mocha/object_methods'
+require 'mocha/expectation_error_factory'
 
 class ObjectInspectTest < Mocha::TestCase
 
@@ -12,6 +14,16 @@ class ObjectInspectTest < Mocha::TestCase
     object.attribute = 'instance_variable'
     assert_match Regexp.new("^#<Object:0x[0-9A-Fa-f]{1,8}.*>$"), object.mocha_inspect
     assert_no_match(/instance_variable/, object.mocha_inspect)
+  end
+
+  def test_should_return_default_string_representation_of_object_when_stack_error_caused_by_mocks_in_inspect
+    object = Object.new.extend(Mocha::ObjectMethods)
+    object.expects(:inspect).once.returns('custom inspect')
+    assert_equal 'custom inspect', object.inspect
+    error = assert_raise(Mocha::ExpectationErrorFactory.exception_class) do
+      object.mocha_inspect
+    end
+    assert_match Regexp.new("#<Object:0x[0-9A-Fa-f]{1,8}.*>"), error.message
   end
 
   def test_should_return_customized_string_representation_of_object
@@ -28,7 +40,6 @@ class ObjectInspectTest < Mocha::TestCase
     object.replace_instance_method(:id) { calls << :id; return 1 } if RUBY_VERSION < '1.9'
     object.replace_instance_method(:object_id) { calls << :object_id; return 1 }
     object.replace_instance_method(:__id__) { calls << :__id__; return 1 }
-    object.replace_instance_method(:inspect) { "object-description" }
 
     object.mocha_inspect
 


### PR DESCRIPTION
If an expectation is set on #inspect or a method that inspect calls and an unexpected invocation occurs, a SystemStackError occurs.

This happens because the unexpected invocation causes mocha_inspect to be called which calls inspect which causes another unexpected invocation, which again causes mocha_inspect to be called, on and on until eventually a stack overflow occurs.

This diff changes mocha_inspect to fall back to using the default string representation of an object if a SystemStackError occurs. 

It might be preferable to raise a different kind of error after rescuing the SystemStackError, I'm not sure. A different error might be preferable because rescuing the SystemStackError in this way causes an expectation error like the following:

```
unexpected invocation: #<Object:0x230f910>.inspect()
unsatisfied expectations:
- expected exactly once, invoked 1390 times: #<Object:0x230f910>.inspect(any_parameters)
```

The invocation count of 1390 could be confusing when there's probably only one extraneous invocation that's causing the problem. I chose the rescue route because although 1390 may be confusing, it is still clear that some kind of unexpected invocation is occurring which is much more useful than the SystemStackError and useless backtrace that greeted me when I ran into this issue.

If you think raising a different error is a better approach or there is anything else here that needs fixing, let me know and I'll update the pull request.
