### PR TITLE
Change eval for better debugging

### DIFF
--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -54,11 +54,11 @@ module Mocha
     end
 
     def define_new_method
-      stubbee.__metaclass__.class_eval(%{
+      stubbee.__metaclass__.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
         def #{method}(*args, &block)
           mocha.method_missing(:#{method}, *args, &block)
         end
-      }, __FILE__, __LINE__)
+      CODE
       if @original_visibility
         Module.instance_method(@original_visibility).bind(stubbee.__metaclass__).call(method)
       end


### PR DESCRIPTION
I had to debug some minitest & mocha code today, and end-up getting inside that method that was really hard to debug. If we change the eval we can have a better debugging experience.
