### PR TITLE
Consider stubs on superclass receivers if none exist on primary receiver.

### DIFF
--- a/lib/mocha/expectation_list.rb
+++ b/lib/mocha/expectation_list.rb
@@ -2,8 +2,8 @@ module Mocha
 
   class ExpectationList
 
-    def initialize
-      @expectations = []
+    def initialize(expectations = [])
+      @expectations = expectations
     end
 
     def add(expectation)
@@ -45,6 +45,10 @@ module Mocha
 
     def any?
       @expectations.any?
+    end
+
+    def +(other)
+      self.class.new(self.to_a + other.to_a)
     end
 
     private

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -1,6 +1,7 @@
 require 'mocha/central'
 require 'mocha/mock'
 require 'mocha/names'
+require 'mocha/receivers'
 require 'mocha/state_machine'
 require 'mocha/logger'
 require 'mocha/configuration'
@@ -40,11 +41,11 @@ module Mocha
     end
 
     def mock_impersonating(object, &block)
-      add_mock(Mock.new(self, ImpersonatingName.new(object), &block))
+      add_mock(Mock.new(self, ImpersonatingName.new(object), ObjectReceiver.new(object), &block))
     end
 
     def mock_impersonating_any_instance_of(klass, &block)
-      add_mock(Mock.new(self, ImpersonatingAnyInstanceName.new(klass), &block))
+      add_mock(Mock.new(self, ImpersonatingAnyInstanceName.new(klass), AnyInstanceReceiver.new(klass), &block))
     end
 
     def new_state_machine(name)

--- a/lib/mocha/receivers.rb
+++ b/lib/mocha/receivers.rb
@@ -1,0 +1,49 @@
+module Mocha
+
+  class ObjectReceiver
+
+    def initialize(object)
+      @object = object
+    end
+
+    def mocks
+      object, mocks = @object, []
+      while object do
+        mocks << object.mocha
+        object = object.is_a?(Class) ? object.superclass : nil
+      end
+      mocks
+    end
+
+  end
+
+  class AnyInstanceReceiver
+
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def mocks
+      klass, mocks = @klass, []
+      while klass do
+        mocks << klass.any_instance.mocha
+        klass = klass.superclass
+      end
+      mocks
+    end
+
+  end
+
+  class DefaultReceiver
+
+    def initialize(mock)
+      @mock = mock
+    end
+
+    def mocks
+      [@mock]
+    end
+
+  end
+
+end

--- a/test/acceptance/stub_any_instance_method_defined_on_superclass_test.rb
+++ b/test/acceptance/stub_any_instance_method_defined_on_superclass_test.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+require 'mocha/setup'
+
+class StubAnyInstanceMethodDefinedOnSuperclassTest < Mocha::TestCase
+
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_should_stub_method_and_leave_it_unchanged_after_test
+    superklass = Class.new do
+      def my_superclass_method
+        :original_return_value
+      end
+      public :my_superclass_method
+    end
+    klass = Class.new(superklass)
+    instance = klass.new
+    assert_snapshot_unchanged(instance) do
+      test_result = run_as_test do
+        superklass.any_instance.stubs(:my_superclass_method).returns(:new_return_value)
+        assert_equal :new_return_value, instance.my_superclass_method
+      end
+      assert_passed(test_result)
+    end
+    assert_equal :original_return_value, instance.my_superclass_method
+  end
+end

--- a/test/acceptance/stub_class_method_defined_on_superclass_test.rb
+++ b/test/acceptance/stub_class_method_defined_on_superclass_test.rb
@@ -13,7 +13,7 @@ class StubClassMethodDefinedOnSuperclassTest < Mocha::TestCase
     teardown_acceptance_test
   end
 
-  def test_should_stub_public_method_and_leave_it_unchanged_after_test
+  def test_should_stub_public_method_on_child_class_and_leave_it_unchanged_after_test
     superklass = Class.new do
       class << self
         def my_class_method
@@ -33,7 +33,7 @@ class StubClassMethodDefinedOnSuperclassTest < Mocha::TestCase
     assert_equal :original_return_value, klass.my_class_method
   end
 
-  def test_should_stub_protected_method_and_leave_it_unchanged_after_test
+  def test_should_stub_protected_method_on_child_class_and_leave_it_unchanged_after_test
     superklass = Class.new do
       class << self
         def my_class_method
@@ -53,7 +53,7 @@ class StubClassMethodDefinedOnSuperclassTest < Mocha::TestCase
     assert_equal :original_return_value, klass.send(:my_class_method)
   end
 
-  def test_should_stub_private_method_and_leave_it_unchanged_after_test
+  def test_should_stub_private_method_on_child_class_and_leave_it_unchanged_after_test
     superklass = Class.new do
       class << self
         def my_class_method
@@ -71,5 +71,42 @@ class StubClassMethodDefinedOnSuperclassTest < Mocha::TestCase
       assert_passed(test_result)
     end
     assert_equal :original_return_value, klass.send(:my_class_method)
+  end
+
+  def test_should_stub_method_on_superclass_and_leave_it_unchanged_after_test
+    superklass = Class.new do
+      class << self
+        def my_class_method
+          :original_return_value
+        end
+        public :my_class_method
+      end
+    end
+    klass = Class.new(superklass)
+    assert_snapshot_unchanged(klass) do
+      test_result = run_as_test do
+        superklass.stubs(:my_class_method).returns(:new_return_value)
+        assert_equal :new_return_value, klass.my_class_method
+      end
+      assert_passed(test_result)
+    end
+    assert_equal :original_return_value, klass.my_class_method
+  end
+
+  def test_stub_on_earliest_receiver_should_take_priority
+    superklass = Class.new do
+      class << self
+        def my_class_method
+          :original_return_value
+        end
+      end
+    end
+    klass = Class.new(superklass)
+    test_result = run_as_test do
+      klass.stubs(:my_class_method).returns(:klass_return_value)
+      superklass.stubs(:my_class_method).returns(:superklass_return_value)
+      assert_equal :klass_return_value, klass.my_class_method
+    end
+    assert_passed(test_result)
   end
 end

--- a/test/unit/expectation_list_test.rb
+++ b/test/unit/expectation_list_test.rb
@@ -68,4 +68,15 @@ class ExpectationListTest < Mocha::TestCase
     assert_same expectation1, expectation_list.match_allowing_invocation(:my_method)
   end
 
+  def test_should_combine_two_expectation_lists_into_one
+    expectation_list1 = ExpectationList.new
+    expectation_list2 = ExpectationList.new
+    expectation1 = Expectation.new(nil, :my_method)
+    expectation2 = Expectation.new(nil, :my_method)
+    expectation_list1.add(expectation1)
+    expectation_list2.add(expectation2)
+    expectation_list = expectation_list1 + expectation_list2
+    assert_equal [expectation1, expectation2], expectation_list.to_a
+  end
+
 end

--- a/test/unit/receivers_test.rb
+++ b/test/unit/receivers_test.rb
@@ -1,0 +1,66 @@
+require File.expand_path('../../test_helper', __FILE__)
+require 'mocha/receivers'
+
+class ObjectReceiverTest < Mocha::TestCase
+  include Mocha
+
+  class FakeObject < Struct.new(:mocha)
+    def is_a?(klass)
+      false
+    end
+  end
+
+  class FakeClass < Struct.new(:superclass, :mocha)
+    def is_a?(klass)
+      klass == Class
+    end
+  end
+
+  def test_mocks_returns_mock_for_object
+    object = FakeObject.new(:mocha)
+    receiver = ObjectReceiver.new(object)
+    assert_equal [:mocha], receiver.mocks
+  end
+
+  def test_mocks_returns_mocks_for_class_and_its_superclasses
+    grandparent = FakeClass.new(nil, :grandparent_mocha)
+    parent = FakeClass.new(grandparent, :parent_mocha)
+    klass = FakeClass.new(parent, :mocha)
+    receiver = ObjectReceiver.new(klass)
+    assert_equal [:mocha, :parent_mocha, :grandparent_mocha], receiver.mocks
+  end
+end
+
+class AnyInstanceReceiverTest < Mocha::TestCase
+  include Mocha
+
+  class FakeAnyInstanceClass
+    attr_reader :superclass
+
+    def initialize(superclass, mocha)
+      @superclass, @mocha = superclass, mocha
+    end
+
+    def any_instance
+      Struct.new(:mocha).new(@mocha)
+    end
+  end
+
+  def test_mocks_returns_mocks_for_class_and_its_superclasses
+    grandparent = FakeAnyInstanceClass.new(nil, :grandparent_mocha)
+    parent = FakeAnyInstanceClass.new(grandparent, :parent_mocha)
+    klass = FakeAnyInstanceClass.new(parent, :mocha)
+    receiver = AnyInstanceReceiver.new(klass)
+    assert_equal [:mocha, :parent_mocha, :grandparent_mocha], receiver.mocks
+  end
+end
+
+class DefaultReceiverTest < Mocha::TestCase
+  include Mocha
+
+  def test_mocks_returns_mock
+    mock = :mocha
+    receiver = DefaultReceiver.new(mock)
+    assert_equal [:mocha], receiver.mocks
+  end
+end


### PR DESCRIPTION
Note: This may break existing tests which rely on the old behaviour!

Stubbing a superclass method and then invoking that method on a child
class would previously cause an unexpected invocation error. This was
because the superclass and child class delegated to different mock
objects i.e. the superclass has its own `@mocha` class instance variable
which is different from the child class' `@mocha` class instance
variable.

By searching up through the inheritance hierarchy for each of the delegate
mock objects, we can provide more intuitive behaviour. Instead of
an unexpected invocation error (see above), invoking the method on the
child class will cause the stubbed method on the superclass to be used.

```
class Parent
  def self.my_class_method
    :original_value
  end
end

class Child < Parent
end

Parent.stubs(:my_class_method).returns(:stubbed_value)

# old behaviour
Child.my_class_method # => unexpected invocation error

# new behaviour
Child.my_class_method # => :stubbed_value
```

For consistency, I have also implemented a similar change for the
corresponding `any_instance` scenario:

```
class Parent
  def my_instance_method
    :original_value
  end
end

class Child < Parent
end

Parent.any_instance.stubs(:my_instance_method).returns(:stubbed_value)

# old behaviour
Child.new.my_instance_method # => unexpected invocation error

# new behaviour
Child.new.my_instance_method # => :stubbed_value
```

These changes were largely based on changes suggested by @ccutrer in #145.
