### PR TITLE
ExpectationError should subclass StandardError

### DIFF
--- a/lib/mocha/expectation_error.rb
+++ b/lib/mocha/expectation_error.rb
@@ -4,5 +4,5 @@ module Mocha
   # Authors of test libraries may use +Mocha::ExpectationErrorFactory+ to have Mocha raise a different exception.
   #
   # @see Mocha::ExpectationErrorFactory
-  class ExpectationError < Exception; end
+  class ExpectationError < StandardError; end
 end


### PR DESCRIPTION
Directly inheriting from Exception is not considered to be a good Ruby
practice; it's almost always best to subclass from some other, more
descriptive error class, such as StandardError or RuntimeError. Errors
that directly subclass Exception are more intended for things like
signals.

I traced this inheritance to commit
fdcb1503906293745444d8bf49ee624fa7839f75 but no reason was given as to
why this inheritance pattern changed.

It causes bugs when trying to upgrade from, for instance, version 0.9.8
of Mocha to future versions that support `unstub` because all versions
of Rails 3.0.x include an ActiveSupport::TestCase patch that opens up
Mocha::ExpectationError with a base class of StandardError.
https://github.com/rails/rails/blob/3-0-stable/activesupport/lib/active_support/test_case.rb
This is what it should be anyway, so I'm submitting this patch.

Signed-off-by: David Celis me@davidcel.is
