### PR TITLE
Fix pretty printing of quotes in `mocha_inspect`

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -12,7 +12,7 @@ module Mocha
 
   module StringMethods
     def mocha_inspect
-      inspect.gsub(/\"/, "'")
+      inspect.gsub(/\\\"/, '"').gsub(/'/, "\\\\'").gsub(/(^")|("$)/, "'")
     end
   end
 

--- a/test/unit/string_inspect_test.rb
+++ b/test/unit/string_inspect_test.rb
@@ -8,4 +8,14 @@ class StringInspectTest < Mocha::TestCase
     assert_equal "'my_string'", string.mocha_inspect
   end
 
+  def test_should_not_replace_quotes_in_the_actual_string
+	string = '"'
+	assert_equal "'\"'", string.mocha_inspect
+  end
+
+  def test_should_escape_single_quotes
+	string = "'"
+	assert_equal "'\\''", string.mocha_inspect
+  end
+
 end


### PR DESCRIPTION
The pretty-printing of quotes from `inspect` was messing up actual quotes a bit, consider this example:

```ruby
#!/usr/bin/env ruby

require 'bacon'
require 'mocha-on-bacon'
require 'open4'

Open4.expects(:spawn).with('"').once
Open4.spawn('\'')
```

before this PR:

```
./quotes.rb:8:in `<main>': unexpected invocation: Open4.spawn(''') (Mocha::ExpectationError)
unsatisfied expectations:
- expected exactly once, not yet invoked: Open4.spawn('\'')
```

after this PR:

```
./quotes.rb:8:in `<main>': unexpected invocation: Open4.spawn('\'') (Mocha::ExpectationError)
unsatisfied expectations:
- expected exactly once, not yet invoked: Open4.spawn('"')
```

So one now no longer gets confused by replaced double-quotes or incorrectly escaped single-quotes in the messages.
