### PR TITLE
Allow `includes` matcher to take matcher arguments.

### DIFF
--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -38,9 +38,8 @@ module Mocha
       def matches?(available_parameters)
         parameter = available_parameters.shift
         return false unless parameter.respond_to?(:include?)
-
         if @items.size == 1
-          return parameter.include?(@items.first)
+          return parameter.any? { |p| @items.first.to_matcher.matches?([p]) }
         else
           includes_matchers = @items.map { |item| Includes.new(item) }
           AllOf.new(*includes_matchers).matches?([parameter])

--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -23,13 +23,13 @@ module Mocha
     #   object.method_1(['foo', 'baz'])
     #   # error raised, because ['foo', 'baz'] does not include 'bar'.
     #
-    # @example Actual parameter includes item which matches nested matcher
+    # @example Actual parameter includes item which matches nested matcher.
     #   object = mock()
     #   object.expects(:method_1).with(includes(has_key(:key)))
     #   object.method_1(['foo', 'bar', {:key => 'baz'}])
     #   # no error raised
     #
-    # @example Actual parameter does not include item matching nested matcher
+    # @example Actual parameter does not include item matching nested matcher.
     #   object.method_1(['foo', 'bar', {:other_key => 'baz'}])
     #   # error raised, because no element matches `has_key(:key)` matcher
     def includes(*items)

--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -22,6 +22,16 @@ module Mocha
     # @example Actual parameter does not include all items.
     #   object.method_1(['foo', 'baz'])
     #   # error raised, because ['foo', 'baz'] does not include 'bar'.
+    #
+    # @example Actual parameter includes item which matches nested matcher
+    #   object = mock()
+    #   object.expects(:method_1).with(includes(has_key(:key)))
+    #   object.method_1(['foo', 'bar', {:key => 'baz'}])
+    #   # no error raised
+    #
+    # @example Actual parameter does not include item matching nested matcher
+    #   object.method_1(['foo', 'bar', {:other_key => 'baz'}])
+    #   # error raised, because no element matches `has_key(:key)` matcher
     def includes(*items)
       Includes.new(*items)
     end

--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -42,6 +42,26 @@ module Mocha
     # @example Actual parameter is a String not including substring.
     #   object.method_1('foobaz')
     #   # error raised, because 'foobaz' does not include 'bar'
+    #
+    # @example Actual parameter is a Hash including the given key.
+    #   object = mock()
+    #   object.expects(:method_1).with(includes(:bar))
+    #   object.method_1({:foo => 1, :bar => 2})
+    #   # no error raised
+    #
+    # @example Actual parameter is a Hash without the given key.
+    #   object.method_1({:foo => 1, :baz => 2})
+    #   # error raised, because hash does not include key 'bar'
+    #
+    # @example Actual parameter is a Hash with a key matching the given matcher.
+    #   object = mock()
+    #   object.expects(:method_1).with(includes(regexp_matches(/ar/)))
+    #   object.method_1({'foo' => 1, 'bar' => 2})
+    #   # no error raised
+    #
+    # @example Actual parameter is a Hash no key matching the given matcher.
+    #   object.method_1({'foo' => 1, 'baz' => 3})
+    #   # error raised, because hash does not include a key matching /ar/
     def includes(*items)
       Includes.new(*items)
     end
@@ -60,7 +80,7 @@ module Mocha
         return false unless parameter.respond_to?(:include?)
         if @items.size == 1
           if parameter.respond_to?(:any?)
-            return parameter.any? { |p| @items.first.to_matcher.matches?([p]) }
+            return parameter.any? { |(p,_)| @items.first.to_matcher.matches?([p]) }
           else
             return parameter.include?(@items.first)
           end

--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -79,7 +79,7 @@ module Mocha
         parameter = available_parameters.shift
         return false unless parameter.respond_to?(:include?)
         if @items.size == 1
-          if parameter.respond_to?(:any?)
+          if parameter.respond_to?(:any?) && !parameter.is_a?(String)
             return parameter.any? { |(p,_)| @items.first.to_matcher.matches?([p]) }
           else
             return parameter.include?(@items.first)

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -61,6 +61,11 @@ class IncludesTest < Mocha::TestCase
 
   def test_should_match_object_including_value_which_matches_nested_matcher
     matcher = includes(has_key(:key))
-    assert matcher.matches?([[{:key => 'value'}]])
+    assert matcher.matches?([[{:key => 'value'}, :non_matching_element]])
+  end
+
+  def test_should_not_match_object_which_doesnt_include_value_that_matches_nested_matcher
+    matcher = includes(has_key(:key))
+    assert !matcher.matches?([[{:other_key => 'other-value'}, :non_matching_element]])
   end
 end

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -68,4 +68,14 @@ class IncludesTest < Mocha::TestCase
     matcher = includes(has_key(:key))
     assert !matcher.matches?([[:non_matching_element, {:other_key => 'other-value'}]])
   end
+
+  def test_should_match_string_argument_containing_substring
+    matcher = includes('bar')
+    assert matcher.matches?(['foobarbaz'])
+  end
+
+  def test_should_not_match_string_argument_without_substring
+    matcher = includes('bar')
+    assert !matcher.matches?(['foobaz'])
+  end
 end

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 require 'mocha/parameter_matchers/includes'
 require 'mocha/parameter_matchers/object'
 require 'mocha/parameter_matchers/has_key'
+require 'mocha/parameter_matchers/regexp_matches'
 require 'mocha/inspect'
 
 class IncludesTest < Mocha::TestCase
@@ -77,5 +78,25 @@ class IncludesTest < Mocha::TestCase
   def test_should_not_match_string_argument_without_substring
     matcher = includes('bar')
     assert !matcher.matches?(['foobaz'])
+  end
+
+  def test_should_match_hash_argument_containing_given_key
+    matcher = includes(:key)
+    assert matcher.matches?([{:thing => 1, :key => 2}])
+  end
+
+  def test_should_not_match_hash_argument_missing_given_key
+    matcher = includes(:key)
+    assert !matcher.matches?([{:thing => 1, :other => :key}])
+  end
+
+  def test_should_match_hash_when_nested_matcher_matches_key
+    matcher = includes(regexp_matches(/ar/))
+    assert matcher.matches?([{'foo' => 1, 'bar' => 2}])
+  end
+
+  def test_should_not_match_hash_when_nested_matcher_doesn_not_match_key
+    matcher = includes(regexp_matches(/az/))
+    assert !matcher.matches?([{'foo' => 1, 'bar' => 2}])
   end
 end

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../../test_helper', __FILE__)
 
 require 'mocha/parameter_matchers/includes'
+require 'mocha/parameter_matchers/object'
+require 'mocha/parameter_matchers/has_key'
 require 'mocha/inspect'
 
 class IncludesTest < Mocha::TestCase
@@ -55,5 +57,10 @@ class IncludesTest < Mocha::TestCase
   def test_should_not_match_on_argument_that_does_not_respond_to_include
     matcher = includes(:x)
     assert !matcher.matches?([:x])
+  end
+
+  def test_should_match_object_including_value_which_matches_nested_matcher
+    matcher = includes(has_key(:key))
+    assert matcher.matches?([[{:key => 'value'}]])
   end
 end

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -61,11 +61,11 @@ class IncludesTest < Mocha::TestCase
 
   def test_should_match_object_including_value_which_matches_nested_matcher
     matcher = includes(has_key(:key))
-    assert matcher.matches?([[{:key => 'value'}, :non_matching_element]])
+    assert matcher.matches?([[:non_matching_element, {:key => 'value'}]])
   end
 
   def test_should_not_match_object_which_doesnt_include_value_that_matches_nested_matcher
     matcher = includes(has_key(:key))
-    assert !matcher.matches?([[{:other_key => 'other-value'}, :non_matching_element]])
+    assert !matcher.matches?([[:non_matching_element, {:other_key => 'other-value'}]])
   end
 end


### PR DESCRIPTION
We should be able to created a matcher of the form:

    object.expects(:foo).with(includes(has_entry(:key, 'value')))

and successfully match this against a method call like:

    object.foo([:a, :b, {:key => value}, :c])

Hopefully this makes sense; let me know if you've already considered functionality like this but decided against it.