### PR TITLE
Simplify implementation of String#mocha_inspect.

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -10,12 +10,6 @@ module Mocha
     end
   end
 
-  module StringMethods
-    def mocha_inspect
-      inspect.gsub(/\"/, "'")
-    end
-  end
-
   module ArrayMethods
     def mocha_inspect
       "[#{collect { |member| member.mocha_inspect }.join(', ')}]"
@@ -44,10 +38,6 @@ end
 
 class Object
   include Mocha::ObjectMethods
-end
-
-class String
-  include Mocha::StringMethods
 end
 
 class Array

--- a/test/acceptance/failure_messages_test.rb
+++ b/test/acceptance/failure_messages_test.rb
@@ -58,7 +58,7 @@ class FailureMessagesTest < Mocha::TestCase
     test_result = run_as_test do
       'Foo'.expects(:bar)
     end
-    assert_match Regexp.new("'Foo'"), test_result.failures[0].message
+    assert_match Regexp.new(%{"Foo"}), test_result.failures[0].message
   end
 
 end

--- a/test/acceptance/sequence_test.rb
+++ b/test/acceptance/sequence_test.rb
@@ -148,7 +148,7 @@ class SequenceTest < Mocha::TestCase
       mock.first
     end
     assert_failed(test_result)
-    assert_match Regexp.new("in sequence 'one'"), test_result.failures.first.message
+    assert_match Regexp.new(%{in sequence "one"}), test_result.failures.first.message
   end
 
   def test_should_allow_expectations_to_be_in_more_than_one_sequence
@@ -166,8 +166,8 @@ class SequenceTest < Mocha::TestCase
       mock.second
     end
     assert_failed(test_result)
-    assert_match Regexp.new("in sequence 'one'"), test_result.failures.first.message
-    assert_match Regexp.new("in sequence 'two'"), test_result.failures.first.message
+    assert_match Regexp.new(%{in sequence "one"}), test_result.failures.first.message
+    assert_match Regexp.new(%{in sequence "two"}), test_result.failures.first.message
   end
 
   def test_should_have_shortcut_for_expectations_to_be_in_more_than_one_sequence
@@ -185,8 +185,8 @@ class SequenceTest < Mocha::TestCase
       mock.second
     end
     assert_failed(test_result)
-    assert_match Regexp.new("in sequence 'one'"), test_result.failures.first.message
-    assert_match Regexp.new("in sequence 'two'"), test_result.failures.first.message
+    assert_match Regexp.new(%{in sequence "one"}), test_result.failures.first.message
+    assert_match Regexp.new(%{in sequence "two"}), test_result.failures.first.message
   end
 
 end

--- a/test/unit/array_inspect_test.rb
+++ b/test/unit/array_inspect_test.rb
@@ -10,7 +10,7 @@ class ArrayInspectTest < Mocha::TestCase
 
   def test_should_use_mocha_inspect_on_each_item
     array = [1, 2, "chris"]
-    assert_equal "[1, 2, 'chris']", array.mocha_inspect
+    assert_equal %{[1, 2, "chris"]}, array.mocha_inspect
   end
 
 end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -343,7 +343,7 @@ class ExpectationTest < Mocha::TestCase
     sequence_two = Sequence.new('two')
     expectation = Expectation.new(mock, :expected_method).with(1, 2, {'a' => true}, {:b => false}, [1, 2, 3]).in_sequence(sequence_one, sequence_two)
     assert !expectation.verified?
-    assert_match "mock.expected_method(1, 2, {'a' => true}, {:b => false}, [1, 2, 3]); in sequence 'one'; in sequence 'two'", expectation.mocha_inspect
+    assert_match %{mock.expected_method(1, 2, {"a" => true}, {:b => false}, [1, 2, 3]); in sequence "one"; in sequence "two"}, expectation.mocha_inspect
   end
 
   class FakeConstraint

--- a/test/unit/hash_inspect_test.rb
+++ b/test/unit/hash_inspect_test.rb
@@ -10,7 +10,7 @@ class HashInspectTest < Mocha::TestCase
 
   def test_should_use_mocha_inspect_on_each_item
     hash = {:a => 'mocha'}
-    assert_equal "{:a => 'mocha'}", hash.mocha_inspect
+    assert_equal %{{:a => "mocha"}}, hash.mocha_inspect
   end
 
 end

--- a/test/unit/parameter_matchers/equals_test.rb
+++ b/test/unit/parameter_matchers/equals_test.rb
@@ -19,7 +19,7 @@ class EqualsTest < Mocha::TestCase
 
   def test_should_describe_matcher
     matcher = equals('x')
-    assert_equal "'x'", matcher.mocha_inspect
+    assert_equal %{"x"}, matcher.mocha_inspect
   end
 
 end

--- a/test/unit/parameter_matchers/has_entry_test.rb
+++ b/test/unit/parameter_matchers/has_entry_test.rb
@@ -31,12 +31,12 @@ class HasEntryTest < Mocha::TestCase
 
   def test_should_describe_matcher_with_key_value_pair
     matcher = has_entry(:key_1, 'value_1')
-    assert_equal "has_entry(:key_1 => 'value_1')", matcher.mocha_inspect
+    assert_equal %{has_entry(:key_1 => "value_1")}, matcher.mocha_inspect
   end
 
   def test_should_describe_matcher_with_entry
     matcher = has_entry(:key_1 => 'value_1')
-    assert_equal "has_entry(:key_1 => 'value_1')", matcher.mocha_inspect
+    assert_equal %{has_entry(:key_1 => "value_1")}, matcher.mocha_inspect
   end
 
   def test_should_match_hash_including_specified_entry_with_nested_key_matcher

--- a/test/unit/parameter_matchers/has_value_test.rb
+++ b/test/unit/parameter_matchers/has_value_test.rb
@@ -21,7 +21,7 @@ class HasValueTest < Mocha::TestCase
 
   def test_should_describe_matcher
     matcher = has_value('value_1')
-    assert_equal "has_value('value_1')", matcher.mocha_inspect
+    assert_equal %{has_value("value_1")}, matcher.mocha_inspect
   end
 
   def test_should_match_hash_including_specified_value_with_nested_value_matcher

--- a/test/unit/sequence_test.rb
+++ b/test/unit/sequence_test.rb
@@ -98,7 +98,7 @@ class SequenceTest < Mocha::TestCase
     sequence = Sequence.new('wibble')
     expectation = FakeExpectation.new
     sequence.constrain_as_next_in_sequence(expectation)
-    assert_equal "in sequence 'wibble'", expectation.ordering_constraints[0].mocha_inspect
+    assert_equal %{in sequence "wibble"}, expectation.ordering_constraints[0].mocha_inspect
   end
 
 end

--- a/test/unit/string_inspect_test.rb
+++ b/test/unit/string_inspect_test.rb
@@ -3,9 +3,9 @@ require 'mocha/inspect'
 
 class StringInspectTest < Mocha::TestCase
 
-  def test_should_replace_escaped_quotes_with_single_quote
+  def test_should_use_default_inspect_method
     string = "my_string"
-    assert_equal "'my_string'", string.mocha_inspect
+    assert_equal %{"my_string"}, string.mocha_inspect
   end
 
 end


### PR DESCRIPTION
This is an alternative attempt at fixing the problem identified
and addressed in #215 regarding the "pretty printing" of single- and
double-quotes.

In this attempt, I asked myself why we *ever* needed to do the `gsub`
replacement of escaped double-quote characters with single-quote characters.
I couldn't come up with a reason other than to make the tests more readable.

Thus in this commit I've removed the custom implementation of
`String#mocha_inspect` so it falls back to the default `String#inspect`
implementation. As far as I can see the error messages are still sensibly
formatted and by using the `%{}` string literal construction, I think the
tests are still perfectly readable.

I hope that this is a simpler and more robust way to solve the problems
that @neonichu was seeing.