### PR TITLE
Add jruby-head to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - jruby-head
 gemfile:
   - Gemfile
 env:
@@ -66,6 +67,9 @@ matrix:
       gemfile: gemfiles/Gemfile.minitest.1.3.0
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit JRUBY_OPTS=-Xbacktrace.mask=true
+    - rvm: jruby-head
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: jruby-head
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ gemfile:
   - Gemfile
 env:
   - MOCHA_OPTIONS=debug
+  - JRUBY_OPTS=-Xbacktrace.mask=true
 matrix:
   include:
     - rvm: 2.0.0
@@ -68,10 +69,10 @@ matrix:
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.test-unit.latest
-      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit JRUBY_OPTS=-Xbacktrace.mask=true
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: jruby-head
       gemfile: gemfiles/Gemfile.test-unit.latest
-      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit JRUBY_OPTS=-Xbacktrace.mask=true
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: jruby-head
       gemfile: gemfiles/Gemfile.minitest.latest
-      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest JRUBY_OPTS=-Xbacktrace.mask=true
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest


### PR DESCRIPTION
As part of getting JRuby 9k.pre2 finished up, we made sure mocha was green. Seemed fair to send a PR to get JRuby into your Travis runs too.