### PR TITLE
Correct RSpec section of the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ require 'mocha/mini_test'
 
 ##### RSpec
 
-Assuming you are using the `rspec-rails` gem:
+RSpec includes a mocha adapter. Just tell RSpec you want to mock with `:mocha`:
 
 ```ruby
 # Gemfile in Rails app


### PR DESCRIPTION
rspec-rails knows nothing about mocha; the mocha adapter is in rspec-core.