### PR TITLE
Pass result of yield to caller

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -562,9 +562,10 @@ module Mocha
       @invocation_count += 1
       perform_side_effects()
       if block_given? then
-        @yield_parameters.next_invocation.each do |yield_parameters|
+        yield_result = @yield_parameters.next_invocation.each do |yield_parameters|
           yield(*yield_parameters)
         end
+        return yield_result if @return_values.values.empty?
       end
       @return_values.next
     end

--- a/lib/mocha/multiple_yields.rb
+++ b/lib/mocha/multiple_yields.rb
@@ -9,9 +9,9 @@ module Mocha
     end
 
     def each
-      @parameter_groups.each do |parameter_group|
+      @parameter_groups.map do |parameter_group|
         yield(parameter_group)
-      end
+      end.last
     end
 
   end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -147,6 +147,24 @@ class ExpectationTest < Mocha::TestCase
     assert_equal [[1, 2, 3], [4, 5], [6, 7]], yielded_parameters
   end
 
+  def test_should_return_yielded_value
+    expectation = new_expectation.yields
+    result = expectation.invoke { 'foobar' }
+    assert_equal 'foobar', result
+  end
+
+  def test_should_return_last_yielded_value
+    expectation = new_expectation.multiple_yields('a', 'b', 'c')
+    result = expectation.invoke { |param| param }
+    assert_equal 'c', result
+  end
+
+  def test_should_return_specified_value_when_yielding
+    expectation = new_expectation.yields.returns('bazqux')
+    result = expectation.invoke { 'foobar' }
+    assert_equal 'bazqux', result
+  end
+
   def test_should_return_specified_value
     expectation = new_expectation.returns(99)
     assert_equal 99, expectation.invoke


### PR DESCRIPTION
When using `#yields` or `#multiple_yields`, the expectation will only return a value if it is explicitly specified with a `#returns` call.
The default behavior of Ruby blocks is to pass the result of the block back to the caller.

This mimics that behavior with expectations that yield. The result of the yielded block is the return value of the expectation unless a return value was explicitly specified. This allows stubbing out the logic of a method that ultimately yields to a given block without breaking its caller's expectation of the return value it receives, vs. a `#yield` stub implicitly stubbing out the behavior of everything it yields to as well.

In the case of `#multiple_yields`, the result from the final yield is returned, as if the stubbed method was executing:
```ruby
yield(first_parameter_group)
yield(second_parameter_group)
…
yield(final_parameter_group)
```

Fixes https://floehopper.lighthouseapp.com/projects/22289/tickets/14-8687-blocks-return-value-is-dropped-on-stubbed-yielding-methods

In the referenced ticket, it was indicated that this behavior was not in line with the Mocha philosophy and this behavior is not desired. In any case, this PR serves as a proof of concept of how it could be done.