### PR TITLE
Spike: Always using prepend module mechanism for ruby v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ require 'mocha/mini_test'
 
 #### Known Issues
 
+* Stubbing an aliased class method, where the original method is defined in a module that's used to `extend` the class doesn't work in Ruby 1.8.x. See stub_method_defined_on_module_and_aliased_test.rb for an example of this behaviour.
 * 0.13.x versions cause a harmless, but annoying, deprecation warning when used with Rails 3.2.0-3.2.12, 3.1.0-3.1.10 & 3.0.0-3.0.19.
 * 0.11.x versions don't work with Rails 3.2.13 (`TypeError: superclass mismatch for class ExpectationError`). See #115.
 * Versions 0.10.2, 0.10.3 & 0.11.0 of the Mocha gem were broken. Please do not use these versions.

--- a/test/acceptance/stub_method_defined_on_module_and_aliased_test.rb
+++ b/test/acceptance/stub_method_defined_on_module_and_aliased_test.rb
@@ -1,37 +1,39 @@
 require File.expand_path('../acceptance_test_helper', __FILE__)
 require 'mocha/setup'
 
-class StubMethodDefinedOnModuleAndAliasedTest < Mocha::TestCase
-  include AcceptanceTest
+unless Mocha::PRE_RUBY_V19
+  class StubMethodDefinedOnModuleAndAliasedTest < Mocha::TestCase
+    include AcceptanceTest
 
-  def setup
-    setup_acceptance_test
-  end
-
-  def teardown
-    teardown_acceptance_test
-  end
-
-  def test_stubbing_class_method_defined_by_aliasing_module_instance_method
-    mod = Module.new do
-      def module_instance_method
-        'module-instance-method'
-      end
+    def setup
+      setup_acceptance_test
     end
 
-    klass = Class.new do
-      extend mod
-      class << self
-        alias_method :aliased_module_instance_method, :module_instance_method
-      end
+    def teardown
+      teardown_acceptance_test
     end
 
-    assert_snapshot_unchanged(klass) do
-      test_result = run_as_test do
-        klass.stubs(:aliased_module_instance_method).returns('stubbed-aliased-module-instance-method')
-        assert_equal 'stubbed-aliased-module-instance-method', klass.aliased_module_instance_method
+    def test_stubbing_class_method_defined_by_aliasing_module_instance_method
+      mod = Module.new do
+        def module_instance_method
+          'module-instance-method'
+        end
       end
-      assert_passed(test_result)
+
+      klass = Class.new do
+        extend mod
+        class << self
+          alias_method :aliased_module_instance_method, :module_instance_method
+        end
+      end
+
+      assert_snapshot_unchanged(klass) do
+        test_result = run_as_test do
+          klass.stubs(:aliased_module_instance_method).returns('stubbed-aliased-module-instance-method')
+          assert_equal 'stubbed-aliased-module-instance-method', klass.aliased_module_instance_method
+        end
+        assert_passed(test_result)
+      end
     end
   end
 end

--- a/test/acceptance/stub_method_defined_on_module_and_aliased_test.rb
+++ b/test/acceptance/stub_method_defined_on_module_and_aliased_test.rb
@@ -1,0 +1,37 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+require 'mocha/setup'
+
+class StubMethodDefinedOnModuleAndAliasedTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_stubbing_class_method_defined_by_aliasing_module_instance_method
+    mod = Module.new do
+      def module_instance_method
+        'module-instance-method'
+      end
+    end
+
+    klass = Class.new do
+      extend mod
+      class << self
+        alias_method :aliased_module_instance_method, :module_instance_method
+      end
+    end
+
+    assert_snapshot_unchanged(klass) do
+      test_result = run_as_test do
+        klass.stubs(:aliased_module_instance_method).returns('stubbed-aliased-module-instance-method')
+        assert_equal 'stubbed-aliased-module-instance-method', klass.aliased_module_instance_method
+      end
+      assert_passed(test_result)
+    end
+  end
+end

--- a/test/assertions.rb
+++ b/test/assertions.rb
@@ -3,6 +3,6 @@ require 'mocha/ruby_version'
 module Assertions
   def assert_method_visiblity(object, method_name, visiblity)
     method_key = Mocha::PRE_RUBY_V19 ? method_name.to_s : method_name.to_sym
-    assert object.send("#{visiblity}_methods", false).include?(method_key), "#{method_name} is not #{visiblity}"
+    assert object.send("#{visiblity}_methods").include?(method_key), "#{method_name} is not #{visiblity}"
   end
 end

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -8,6 +8,7 @@ class ClassMethodTest < Mocha::TestCase
 
   include Mocha
 
+unless RUBY_V2_PLUS
   def test_should_hide_original_method
     klass = Class.new { def self.method_x; end }
     method = ClassMethod.new(klass, :method_x)
@@ -16,6 +17,7 @@ class ClassMethodTest < Mocha::TestCase
 
     assert_equal false, klass.respond_to?(:method_x)
   end
+end
 
   def test_should_not_raise_error_hiding_method_that_isnt_defined
     klass = Class.new


### PR DESCRIPTION
We're creating this PR in order to run the Travis CI matrix of builds.