### PR TITLE
Fix typo in docs for equals

### DIFF
--- a/lib/mocha/parameter_matchers/equals.rb
+++ b/lib/mocha/parameter_matchers/equals.rb
@@ -22,7 +22,7 @@ module Mocha
     #   object = mock()
     #   object.expects(:method_1).with(equals(2))
     #   object.method_1(3)
-    #   # error raised, because method_1 was not called with an +Object+ that equals 3
+    #   # error raised, because method_1 was not called with an +Object+ that equals 2
     def equals(value)
       Equals.new(value)
     end


### PR DESCRIPTION
@floehopper 

The docs say that an exception is raised because `method_1` is not called with an object that equals `3` but the expectation is that the object equals `2` (`with(equals(2))`).