### PR TITLE
Improve AnyInstanceMethod#hide_original_method

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,16 +14,10 @@ module Mocha
     end
 
     def hide_original_method
-      if method_exists?(method)
+      if @original_visibility = method_visibility(method)
         begin
           @original_method = stubbee.instance_method(method)
           if @original_method && @original_method.owner == stubbee
-            @original_visibility = :public
-            if stubbee.protected_instance_methods.include?(method)
-              @original_visibility = :protected
-            elsif stubbee.private_instance_methods.include?(method)
-              @original_visibility = :private
-            end
             stubbee.send(:remove_method, method)
           end
 
@@ -56,11 +50,10 @@ module Mocha
       end
     end
 
-    def method_exists?(method)
-      return true if stubbee.public_instance_methods(false).include?(method)
-      return true if stubbee.protected_instance_methods(false).include?(method)
-      return true if stubbee.private_instance_methods(false).include?(method)
-      return false
+    def method_visibility(method)
+      (stubbee.public_instance_methods(true).include?(method) && :public) ||
+        (stubbee.protected_instance_methods(true).include?(method) && :protected) ||
+        (stubbee.private_instance_methods(true).include?(method) && :private)
     end
 
     private

--- a/test/acceptance/stub_any_instance_method_test.rb
+++ b/test/acceptance/stub_any_instance_method_test.rb
@@ -127,22 +127,64 @@ class StubAnyInstanceMethodTest < Mocha::TestCase
     assert_equal 0, klass.any_instance.mocha.__expectations__.length
   end
 
-  def test_should_be_able_to_stub_a_superclass_method
+  def test_should_be_able_to_stub_a_public_superclass_method
     superklass = Class.new do
       def my_superclass_method
         :original_return_value
       end
+      public :my_superclass_method
     end
     klass = Class.new(superklass)
     instance = klass.new
     test_result = run_as_test do
       klass.any_instance.stubs(:my_superclass_method).returns(:new_return_value)
+      assert_method_visibility instance, :my_superclass_method, :public
       assert_equal :new_return_value, instance.my_superclass_method
     end
     assert_passed(test_result)
     assert instance.public_methods(true).any? { |m| m.to_s == 'my_superclass_method' }
     assert !klass.public_methods(false).any? { |m| m.to_s == 'my_superclass_method' }
     assert_equal :original_return_value, instance.my_superclass_method
+  end
+
+  def test_should_be_able_to_stub_a_protected_superclass_method
+    superklass = Class.new do
+      def my_superclass_method
+        :original_return_value
+      end
+      protected :my_superclass_method
+    end
+    klass = Class.new(superklass)
+    instance = klass.new
+    test_result = run_as_test do
+      klass.any_instance.stubs(:my_superclass_method).returns(:new_return_value)
+      assert_method_visibility instance, :my_superclass_method, :protected
+      assert_equal :new_return_value, instance.send(:my_superclass_method)
+    end
+    assert_passed(test_result)
+    assert instance.protected_methods(true).any? { |m| m.to_s == 'my_superclass_method' }
+    assert !klass.protected_methods(false).any? { |m| m.to_s == 'my_superclass_method' }
+    assert_equal :original_return_value, instance.send(:my_superclass_method)
+  end
+
+  def test_should_be_able_to_stub_a_private_superclass_method
+    superklass = Class.new do
+      def my_superclass_method
+        :original_return_value
+      end
+      private :my_superclass_method
+    end
+    klass = Class.new(superklass)
+    instance = klass.new
+    test_result = run_as_test do
+      klass.any_instance.stubs(:my_superclass_method).returns(:new_return_value)
+      assert_method_visibility instance, :my_superclass_method, :private
+      assert_equal :new_return_value, instance.send(:my_superclass_method)
+    end
+    assert_passed(test_result)
+    assert instance.private_methods(true).any? { |m| m.to_s == 'my_superclass_method' }
+    assert !klass.private_methods(false).any? { |m| m.to_s == 'my_superclass_method' }
+    assert_equal :original_return_value, instance.send(:my_superclass_method)
   end
 
   def test_should_be_able_to_stub_method_if_ruby18_public_instance_methods_include_method_but_method_does_not_actually_exist_like_active_record_association_proxy
@@ -185,7 +227,7 @@ class StubAnyInstanceMethodTest < Mocha::TestCase
     end
     test_result = run_as_test do
       ruby18_klass.any_instance.stubs(:my_instance_method).returns(:new_return_value)
-      assert_equal :new_return_value, ruby18_klass.new.my_instance_method
+      assert_equal :new_return_value, ruby18_klass.new.send(:my_instance_method)
     end
     assert_passed(test_result)
   end
@@ -200,7 +242,7 @@ class StubAnyInstanceMethodTest < Mocha::TestCase
     end
     test_result = run_as_test do
       ruby19_klass.any_instance.stubs(:my_instance_method).returns(:new_return_value)
-      assert_equal :new_return_value, ruby19_klass.new.my_instance_method
+      assert_equal :new_return_value, ruby19_klass.new.send(:my_instance_method)
     end
     assert_passed(test_result)
   end
@@ -215,7 +257,7 @@ class StubAnyInstanceMethodTest < Mocha::TestCase
     end
     test_result = run_as_test do
       ruby18_klass.any_instance.stubs(:my_instance_method).returns(:new_return_value)
-      assert_equal :new_return_value, ruby18_klass.new.my_instance_method
+      assert_equal :new_return_value, ruby18_klass.new.send(:my_instance_method)
     end
     assert_passed(test_result)
   end
@@ -230,7 +272,7 @@ class StubAnyInstanceMethodTest < Mocha::TestCase
     end
     test_result = run_as_test do
       ruby19_klass.any_instance.stubs(:my_instance_method).returns(:new_return_value)
-      assert_equal :new_return_value, ruby19_klass.new.my_instance_method
+      assert_equal :new_return_value, ruby19_klass.new.send(:my_instance_method)
     end
     assert_passed(test_result)
   end

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -7,6 +7,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
 
   include Mocha
 
+unless RUBY_V2_PLUS
   def test_should_hide_original_method
     klass = Class.new { def method_x; end }
     method = AnyInstanceMethod.new(klass, :method_x)
@@ -15,6 +16,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
 
     assert_equal false, klass.method_defined?(:method_x)
   end
+end
 
   def test_should_not_raise_error_hiding_method_that_isnt_defined
     klass = Class.new


### PR DESCRIPTION
We realised that we need to make similar changes to `AnyInstanceMethod#hide_original_method` as were made to `ClassMethod` in PR #248.

This PR contains those same changes.

