### PR TITLE
Add Ruby 2.3 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
   - MOCHA_OPTIONS=debug
 matrix:
   include:
+    - rvm: 2.3
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.2
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
@@ -72,6 +75,9 @@ matrix:
     - rvm: 1.8.7
       gemfile: gemfiles/Gemfile.minitest.1.3.0
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: 2.3
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.2
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
 gemfile:
   - Gemfile
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
   - MOCHA_OPTIONS=debug
 matrix:
   include:
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
@@ -66,6 +69,9 @@ matrix:
     - rvm: 1.8.7
       gemfile: gemfiles/Gemfile.minitest.1.3.0
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
   - MOCHA_OPTIONS=debug
 matrix:
   include:
+    - rvm: 2.2
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.1
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
@@ -69,6 +72,9 @@ matrix:
     - rvm: 1.8.7
       gemfile: gemfiles/Gemfile.minitest.1.3.0
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: 2.2
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.1
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit


### PR DESCRIPTION
It makes sense to test against Ruby 2.3 given that it's the current
stable version.
