### PR TITLE
Fix minitest result errors

### DIFF
--- a/test/minitest_result.rb
+++ b/test/minitest_result.rb
@@ -20,7 +20,7 @@ class MinitestResult
   end
 
   def failures
-    @tests.map(&:failures).flatten.select { |r| Minitest::Assertion === r }.map { |f| Failure.new(f) }
+    @tests.map(&:failures).flatten.select { |r| r.instance_of?(Minitest::Assertion) }.map { |f| Failure.new(f) }
   end
 
   def failure_count
@@ -32,7 +32,7 @@ class MinitestResult
   end
 
   def errors
-    @tests.map(&:failures).flatten.select { |r| Minitest::UnexpectedError === r }
+    @tests.map(&:failures).flatten.select { |r| r.instance_of?(Minitest::UnexpectedError) }
   end
 
   def error_count

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -49,7 +49,7 @@ module TestRunner
 
   def assert_passed(test_result)
     flunk "Test failed unexpectedly with message: #{test_result.failures}" if test_result.failure_count > 0
-    flunk "Test failed unexpectedly with message: #{test_result.errors}" if test_result.error_count > 0
+    flunk "Test failed unexpectedly with message: #{test_result.errors.map(&:exception)}" if test_result.error_count > 0
   end
 
   def assert_failed(test_result)


### PR DESCRIPTION
I was able to reproduce this problem in `master` by adding `UNKNOWN_CONSTANT` inside the `run_as_test` block in the `test_should_stub_protected_method_within_test` method in `StubAnyInstanceMethodTest` and running the following command:

```
bundle exec ruby -Itest test/acceptance/stub_any_instance_method_test.rb -n /test_should_stub_protected_method_within_test/
```

### Before fix

```
  1) Failure:
StubAnyInstanceMethodTest#test_should_stub_protected_method_within_test [test/acceptance/stub_any_instance_method_test.rb:83]:
Test failed unexpectedly with message: [#<MinitestResult::Failure:0x007f876428eef0 @failure=#<Minitest::UnexpectedError: Unexpected exception>>]
```

### After fix

```
  1) Failure:
StubAnyInstanceMethodTest#test_should_stub_protected_method_within_test [test/acceptance/stub_any_instance_method_test.rb:83]:
Test failed unexpectedly with message: [#<NameError: uninitialized constant StubAnyInstanceMethodTest::UNKNOWN_CONSTANT>]
```

Hopefully you can see that the latter displays the underlying exception, i.e. `NameError: uninitialized constant StubAnyInstanceMethodTest::UNKNOWN_CONSTANT`.