### PR TITLE
Ensure all tests run individually

### DIFF
--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -76,6 +76,7 @@ end
     klass.define_instance_method(:any_instance) { any_instance }
     method = AnyInstanceMethod.new(klass, :method_x)
     method.replace_instance_method(:restore_original_method) { }
+    method.replace_instance_method(:reset_mocha) { }
     method.define_instance_accessor(:remove_called)
     method.replace_instance_method(:remove_new_method) { self.remove_called = true }
 
@@ -92,6 +93,7 @@ end
     klass.define_instance_method(:any_instance) { any_instance }
     method = AnyInstanceMethod.new(klass, :method_x)
     method.replace_instance_method(:remove_new_method) { }
+    method.replace_instance_method(:reset_mocha) { }
     method.define_instance_accessor(:restore_called)
     method.replace_instance_method(:restore_original_method) { self.restore_called = true }
 

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -121,6 +121,7 @@ end
     method = ClassMethod.new(klass, :method_x)
     mocha = build_mock
     klass.define_instance_method(:mocha) { mocha }
+    method.replace_instance_method(:reset_mocha) { }
     method.define_instance_accessor(:remove_called)
     method.replace_instance_method(:remove_new_method) { self.remove_called = true }
 
@@ -134,6 +135,7 @@ end
     mocha = build_mock
     klass.define_instance_method(:mocha) { mocha }
     method = ClassMethod.new(klass, :method_x)
+    method.replace_instance_method(:reset_mocha) { }
     method.define_instance_accessor(:restore_called)
     method.replace_instance_method(:restore_original_method) { self.restore_called = true }
 

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -11,6 +11,7 @@ class ClassMethodTest < Mocha::TestCase
 unless RUBY_V2_PLUS
   def test_should_hide_original_method
     klass = Class.new { def self.method_x; end }
+    klass.__metaclass__.send(:alias_method, :_method, :method)
     method = ClassMethod.new(klass, :method_x)
 
     method.hide_original_method
@@ -59,6 +60,7 @@ end
 
   def test_should_restore_original_method
     klass = Class.new { def self.method_x; :original_result; end }
+    klass.__metaclass__.send(:alias_method, :_method, :method)
     method = ClassMethod.new(klass, :method_x)
 
     method.hide_original_method
@@ -72,6 +74,7 @@ end
 
   def test_should_restore_original_method_accepting_a_block_parameter
     klass = Class.new { def self.method_x(&block); block.call if block_given? ; end }
+    klass.__metaclass__.send(:alias_method, :_method, :method)
     method = ClassMethod.new(klass, :method_x)
 
     method.hide_original_method


### PR DESCRIPTION
I'd noticed that running some tests individually (i.e. outside of `rake test`) would result in failures.

I created a script to run each test file individually which allowed me to find and fix problems in the following two tests:

* test/unit/any_instance_test.rb
* test/unit/class_method_test.rb

I believe this fixes #251.