### PR TITLE
Refactor ClassMethod and AnyInstanceMethod

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -16,7 +16,7 @@ module Mocha
     def restore_original_method
       unless RUBY_V2_PLUS
         if original_method_defined_on_stubbee?
-          default_stub_method_owner.send(:define_method, method_name, @original_method)
+          default_stub_method_owner.send(:define_method, method_name, original_method)
           Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
         end
       end
@@ -30,12 +30,12 @@ module Mocha
 
     private
 
-    def original_method
-      default_stub_method_owner.instance_method(method_name)
+    def store_original_method
+      @original_method = default_stub_method_owner.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_stub_method_owner
+      original_method && original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -30,7 +30,7 @@ module Mocha
 
     private
 
-    def original_method(method_name)
+    def original_method
       default_stub_method_owner.instance_method(method_name)
     end
 

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,7 +14,7 @@ module Mocha
     end
 
     def restore_original_method
-      unless RUBY_V2_PLUS
+      unless use_prepended_module_for_stub_method?
         if original_method_defined_on_stubbee?
           default_stub_method_owner.send(:define_method, method_name, original_method)
           Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,7 +15,7 @@ module Mocha
 
     def restore_original_method
       unless RUBY_V2_PLUS
-        if @original_method && @original_method.owner == default_stub_method_owner
+        if original_method_defined_on_stubbee?
           default_stub_method_owner.send(:define_method, method_name, @original_method)
           Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
         end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -34,10 +34,6 @@ module Mocha
       @original_method = default_stub_method_owner.instance_method(method_name)
     end
 
-    def original_method_defined_on_stubbee?
-      original_method && original_method.owner == default_stub_method_owner
-    end
-
     def stub_method_definition
       filename, line_number_of_method_implementation = __FILE__, __LINE__ + 2
       method_implementation = <<-CODE

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,36 +15,36 @@ module Mocha
 
     def restore_original_method
       unless RUBY_V2_PLUS
-        if @original_method && @original_method.owner == default_definition_target
-          default_definition_target.send(:define_method, method_name, @original_method)
-          Module.instance_method(@original_visibility).bind(default_definition_target).call(method_name)
+        if @original_method && @original_method.owner == default_stub_method_owner
+          default_stub_method_owner.send(:define_method, method_name, @original_method)
+          Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
         end
       end
     end
 
     def method_visibility(method_name)
-      (default_definition_target.public_instance_methods(true).include?(method_name) && :public) ||
-        (default_definition_target.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (default_definition_target.private_instance_methods(true).include?(method_name) && :private)
+      (default_stub_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
+        (default_stub_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (default_stub_method_owner.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
     def original_method(method_name)
-      default_definition_target.instance_method(method_name)
+      default_stub_method_owner.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_definition_target
+      @original_method && @original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee
-      default_definition_target.send(:remove_method, method_name)
+      default_stub_method_owner.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      default_definition_target.__send__ :prepend, @definition_target
+      default_stub_method_owner.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition
@@ -57,7 +57,7 @@ module Mocha
       [method_implementation, filename, line_number_of_method_implementation]
     end
 
-    def default_definition_target
+    def default_stub_method_owner
       stubbee
     end
 

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,36 +15,36 @@ module Mocha
 
     def restore_original_method
       unless RUBY_V2_PLUS
-        if @original_method && @original_method.owner == stubbee
-          stubbee.send(:define_method, method_name, @original_method)
-          Module.instance_method(@original_visibility).bind(stubbee).call(method_name)
+        if @original_method && @original_method.owner == default_definition_target
+          default_definition_target.send(:define_method, method_name, @original_method)
+          Module.instance_method(@original_visibility).bind(default_definition_target).call(method_name)
         end
       end
     end
 
     def method_visibility(method_name)
-      (stubbee.public_instance_methods(true).include?(method_name) && :public) ||
-        (stubbee.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (stubbee.private_instance_methods(true).include?(method_name) && :private)
+      (default_definition_target.public_instance_methods(true).include?(method_name) && :public) ||
+        (default_definition_target.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (default_definition_target.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
     def original_method(method_name)
-      stubbee.instance_method(method_name)
+      default_definition_target.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == stubbee
+      @original_method && @original_method.owner == default_definition_target
     end
 
     def remove_original_method_from_stubbee
-      stubbee.send(:remove_method, method_name)
+      default_definition_target.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      stubbee.__send__ :prepend, @definition_target
+      default_definition_target.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,7 +15,7 @@ module Mocha
 
     def restore_original_method
       unless use_prepended_module_for_stub_method?
-        if original_method_defined_on_stubbee?
+        if stub_method_overwrites_original_method?
           default_stub_method_owner.send(:define_method, method_name, original_method)
           Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
         end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -16,22 +16,22 @@ module Mocha
     def restore_original_method
       unless RUBY_V2_PLUS
         if @original_method && @original_method.owner == stubbee
-          stubbee.send(:define_method, method, @original_method)
-          Module.instance_method(@original_visibility).bind(stubbee).call(method)
+          stubbee.send(:define_method, method_name, @original_method)
+          Module.instance_method(@original_visibility).bind(stubbee).call(method_name)
         end
       end
     end
 
-    def method_visibility(method)
-      (stubbee.public_instance_methods(true).include?(method) && :public) ||
-        (stubbee.protected_instance_methods(true).include?(method) && :protected) ||
-        (stubbee.private_instance_methods(true).include?(method) && :private)
+    def method_visibility(method_name)
+      (stubbee.public_instance_methods(true).include?(method_name) && :public) ||
+        (stubbee.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (stubbee.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
-    def original_method(method)
-      stubbee.instance_method(method)
+    def original_method(method_name)
+      stubbee.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
@@ -39,7 +39,7 @@ module Mocha
     end
 
     def remove_original_method_from_stubbee
-      stubbee.send(:remove_method, method)
+      stubbee.send(:remove_method, method_name)
     end
 
     def prepend_module
@@ -50,8 +50,8 @@ module Mocha
     def stub_method_definition
       filename, line_number_of_method_implementation = __FILE__, __LINE__ + 2
       method_implementation = <<-CODE
-      def #{method}(*args, &block)
-        self.class.any_instance.mocha.method_missing(:#{method}, *args, &block)
+      def #{method_name}(*args, &block)
+        self.class.any_instance.mocha.method_missing(:#{method_name}, *args, &block)
       end
       CODE
       [method_implementation, filename, line_number_of_method_implementation]

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -20,7 +20,7 @@ module Mocha
             @definition_target = PrependedModule.new
             stubbee.__send__ :prepend, @definition_target
           else
-            @original_method = stubbee.instance_method(method)
+            @original_method = original_method(method)
             if @original_method && @original_method.owner == stubbee
               stubbee.send(:remove_method, method)
             end
@@ -58,6 +58,10 @@ module Mocha
     end
 
     private
+
+    def original_method(method)
+      stubbee.instance_method(method)
+    end
 
     def definition_target
       @definition_target ||= stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -17,8 +17,7 @@ module Mocha
       if @original_visibility = method_visibility(method)
         begin
           if RUBY_V2_PLUS
-            @definition_target = PrependedModule.new
-            stubbee.__send__ :prepend, @definition_target
+            prepend_module
           else
             @original_method = original_method(method)
             if @original_method && @original_method.owner == stubbee
@@ -61,6 +60,11 @@ module Mocha
 
     def original_method(method)
       stubbee.instance_method(method)
+    end
+
+    def prepend_module
+      @definition_target = PrependedModule.new
+      stubbee.__send__ :prepend, @definition_target
     end
 
     def definition_target

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -20,7 +20,7 @@ module Mocha
             prepend_module
           else
             @original_method = original_method(method)
-            if @original_method && @original_method.owner == stubbee
+            if original_method_defined_on_stubbee?
               stubbee.send(:remove_method, method)
             end
           end
@@ -60,6 +60,10 @@ module Mocha
 
     def original_method(method)
       stubbee.instance_method(method)
+    end
+
+    def original_method_defined_on_stubbee?
+      @original_method && @original_method.owner == stubbee
     end
 
     def prepend_module

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -42,11 +42,6 @@ module Mocha
       default_stub_method_owner.send(:remove_method, method_name)
     end
 
-    def prepend_module
-      @stub_method_owner = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @stub_method_owner
-    end
-
     def stub_method_definition
       filename, line_number_of_method_implementation = __FILE__, __LINE__ + 2
       method_implementation = <<-CODE

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -57,10 +57,6 @@ module Mocha
       [method_implementation, filename, line_number_of_method_implementation]
     end
 
-    def definition_target
-      @definition_target ||= default_definition_target
-    end
-
     def default_definition_target
       stubbee
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -21,7 +21,7 @@ module Mocha
           else
             @original_method = original_method(method)
             if original_method_defined_on_stubbee?
-              stubbee.send(:remove_method, method)
+              remove_original_method_from_stubbee
             end
           end
         rescue NameError
@@ -64,6 +64,10 @@ module Mocha
 
     def original_method_defined_on_stubbee?
       @original_method && @original_method.owner == stubbee
+    end
+
+    def remove_original_method_from_stubbee
+      stubbee.send(:remove_method, method)
     end
 
     def prepend_module

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -43,8 +43,8 @@ module Mocha
     end
 
     def prepend_module
-      @definition_target = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @definition_target
+      @stub_method_owner = PrependedModule.new
+      default_stub_method_owner.__send__ :prepend, @stub_method_owner
     end
 
     def stub_method_definition

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -38,10 +38,6 @@ module Mocha
       original_method && original_method.owner == default_stub_method_owner
     end
 
-    def remove_original_method_from_stubbee
-      default_stub_method_owner.send(:remove_method, method_name)
-    end
-
     def stub_method_definition
       filename, line_number_of_method_implementation = __FILE__, __LINE__ + 2
       method_implementation = <<-CODE

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,11 +14,7 @@ module Mocha
     end
 
     def define_new_method
-      definition_target.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
-        def #{method}(*args, &block)
-          self.class.any_instance.mocha.method_missing(:#{method}, *args, &block)
-        end
-      CODE
+      definition_target.class_eval(*stub_method_definition)
       if @original_visibility
         Module.instance_method(@original_visibility).bind(definition_target).call(method)
       end
@@ -56,6 +52,16 @@ module Mocha
     def prepend_module
       @definition_target = PrependedModule.new
       stubbee.__send__ :prepend, @definition_target
+    end
+
+    def stub_method_definition
+      filename, line_number_of_method_implementation = __FILE__, __LINE__ + 2
+      method_implementation = <<-CODE
+      def #{method}(*args, &block)
+        self.class.any_instance.mocha.method_missing(:#{method}, *args, &block)
+      end
+      CODE
+      [method_implementation, filename, line_number_of_method_implementation]
     end
 
     def definition_target

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,23 +13,6 @@ module Mocha
       stubbee.any_instance.reset_mocha
     end
 
-    def hide_original_method
-      if @original_visibility = method_visibility(method)
-        begin
-          if RUBY_V2_PLUS
-            prepend_module
-          else
-            @original_method = original_method(method)
-            if original_method_defined_on_stubbee?
-              remove_original_method_from_stubbee
-            end
-          end
-        rescue NameError
-          # deal with nasties like ActiveRecord::Associations::AssociationProxy
-        end
-      end
-    end
-
     def define_new_method
       definition_target.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
         def #{method}(*args, &block)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -22,7 +22,7 @@ module Mocha
       end
     end
 
-    def method_visibility(method_name)
+    def method_visibility
       (default_stub_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
         (default_stub_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
         (default_stub_method_owner.private_instance_methods(true).include?(method_name) && :private)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,13 +13,6 @@ module Mocha
       stubbee.any_instance.reset_mocha
     end
 
-    def define_new_method
-      definition_target.class_eval(*stub_method_definition)
-      if @original_visibility
-        Module.instance_method(@original_visibility).bind(definition_target).call(method)
-      end
-    end
-
     def restore_original_method
       unless RUBY_V2_PLUS
         if @original_method && @original_method.owner == stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -58,7 +58,11 @@ module Mocha
     end
 
     def definition_target
-      @definition_target ||= stubbee
+      @definition_target ||= default_definition_target
+    end
+
+    def default_definition_target
+      stubbee
     end
 
   end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -42,10 +42,6 @@ module Mocha
       end
     end
 
-    def remove_new_method
-      definition_target.send(:remove_method, method)
-    end
-
     def restore_original_method
       unless RUBY_V2_PLUS
         if @original_method && @original_method.owner == stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -23,9 +23,9 @@ module Mocha
     end
 
     def method_visibility
-      (original_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
-        (original_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (original_method_owner.private_instance_methods(true).include?(method_name) && :private)
+      (original_method_owner.public_method_defined?(method_name) && :public) ||
+        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
+        (original_method_owner.private_method_defined?(method_name) && :private)
     end
 
     private

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -17,7 +17,7 @@ module Mocha
       unless use_prepended_module_for_stub_method?
         if stub_method_overwrites_original_method?
           original_method_owner.send(:define_method, method_name, original_method)
-          Module.instance_method(@original_visibility).bind(original_method_owner).call(method_name)
+          Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
         end
       end
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -16,22 +16,22 @@ module Mocha
     def restore_original_method
       unless use_prepended_module_for_stub_method?
         if stub_method_overwrites_original_method?
-          default_stub_method_owner.send(:define_method, method_name, original_method)
-          Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
+          original_method_owner.send(:define_method, method_name, original_method)
+          Module.instance_method(@original_visibility).bind(original_method_owner).call(method_name)
         end
       end
     end
 
     def method_visibility
-      (default_stub_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
-        (default_stub_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (default_stub_method_owner.private_instance_methods(true).include?(method_name) && :private)
+      (original_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
+        (original_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (original_method_owner.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
     def store_original_method
-      @original_method = default_stub_method_owner.instance_method(method_name)
+      @original_method = original_method_owner.instance_method(method_name)
     end
 
     def stub_method_definition
@@ -44,7 +44,7 @@ module Mocha
       [method_implementation, filename, line_number_of_method_implementation]
     end
 
-    def default_stub_method_owner
+    def original_method_owner
       stubbee
     end
 

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -22,12 +22,6 @@ module Mocha
       end
     end
 
-    def method_visibility
-      (original_method_owner.public_method_defined?(method_name) && :public) ||
-        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
-        (original_method_owner.private_method_defined?(method_name) && :private)
-    end
-
     private
 
     def store_original_method

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -41,7 +41,7 @@ module Mocha
       if @original_visibility = method_visibility(method_name)
         begin
           if RUBY_V2_PLUS
-            prepend_module
+            use_prepended_module_for_stub_method
           else
             @original_method = original_method(method_name)
             if original_method_defined_on_stubbee?
@@ -117,7 +117,7 @@ module Mocha
       default_stub_method_owner.send(:remove_method, method_name)
     end
 
-    def prepend_module
+    def use_prepended_module_for_stub_method
       @stub_method_owner = PrependedModule.new
       default_stub_method_owner.__send__ :prepend, @stub_method_owner
     end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -45,7 +45,7 @@ module Mocha
           else
             @original_method = original_method(method)
             if original_method_defined_on_stubbee?
-              stubbee.__metaclass__.send(:remove_method, method)
+              remove_original_method_from_stubbee
             end
           end
         rescue NameError
@@ -115,6 +115,10 @@ module Mocha
 
     def original_method_defined_on_stubbee?
       @original_method && @original_method.owner == stubbee.__metaclass__
+    end
+
+    def remove_original_method_from_stubbee
+      stubbee.__metaclass__.send(:remove_method, method)
     end
 
     def prepend_module

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -40,7 +40,7 @@ module Mocha
     def hide_original_method
       if @original_visibility = method_visibility(method_name)
         begin
-          if RUBY_V2_PLUS
+          if use_prepended_module_for_stub_method?
             use_prepended_module_for_stub_method
           else
             store_original_method
@@ -66,7 +66,7 @@ module Mocha
     end
 
     def restore_original_method
-      unless RUBY_V2_PLUS
+      unless use_prepended_module_for_stub_method?
         if original_method_defined_on_stubbee?
           if PRE_RUBY_V19
             original_method_in_scope = original_method
@@ -117,6 +117,10 @@ module Mocha
 
     def remove_original_method_from_stubbee
       default_stub_method_owner.send(:remove_method, method_name)
+    end
+
+    def use_prepended_module_for_stub_method?
+      RUBY_V2_PLUS
     end
 
     def use_prepended_module_for_stub_method

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -41,8 +41,7 @@ module Mocha
       if @original_visibility = method_visibility(method)
         begin
           if RUBY_V2_PLUS
-            @definition_target = PrependedModule.new
-            stubbee.__metaclass__.__send__ :prepend, @definition_target
+            prepend_module
           else
             @original_method = original_method(method)
             if @original_method && @original_method.owner == stubbee.__metaclass__
@@ -112,6 +111,11 @@ module Mocha
 
     def original_method(method)
       stubbee._method(method)
+    end
+
+    def prepend_module
+      @definition_target = PrependedModule.new
+      stubbee.__metaclass__.__send__ :prepend, @definition_target
     end
 
     def definition_target

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -47,7 +47,7 @@ module Mocha
           rescue NameError
             # deal with nasties like ActiveRecord::Associations::AssociationProxy
           end
-          if original_method_defined_on_stubbee?
+          if stub_method_overwrites_original_method?
             remove_original_method_from_stubbee
           end
         end
@@ -67,7 +67,7 @@ module Mocha
 
     def restore_original_method
       unless use_prepended_module_for_stub_method?
-        if original_method_defined_on_stubbee?
+        if stub_method_overwrites_original_method?
           if PRE_RUBY_V19
             original_method_in_scope = original_method
             default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
@@ -111,7 +111,7 @@ module Mocha
       @original_method = stubbee._method(method_name)
     end
 
-    def original_method_defined_on_stubbee?
+    def stub_method_overwrites_original_method?
       original_method && original_method.owner == default_stub_method_owner
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -67,18 +67,18 @@ module Mocha
 
     def restore_original_method
       unless RUBY_V2_PLUS
-        if @original_method && @original_method.owner == default_definition_target
+        if @original_method && @original_method.owner == default_stub_method_owner
           if PRE_RUBY_V19
             original_method = @original_method
-            default_definition_target.send(:define_method, method_name) do |*args, &block|
+            default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
               original_method.call(*args, &block)
             end
           else
-            default_definition_target.send(:define_method, method_name, @original_method)
+            default_stub_method_owner.send(:define_method, method_name, @original_method)
           end
         end
         if @original_visibility
-          Module.instance_method(@original_visibility).bind(default_definition_target).call(method_name)
+          Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
         end
       end
     end
@@ -96,7 +96,7 @@ module Mocha
 
     def method_visibility(method_name)
       symbol = method_name.to_sym
-      metaclass = default_definition_target
+      metaclass = default_stub_method_owner
 
       (metaclass.public_method_defined?(symbol) && :public) ||
         (metaclass.protected_method_defined?(symbol) && :protected) ||
@@ -110,16 +110,16 @@ module Mocha
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_definition_target
+      @original_method && @original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee
-      default_definition_target.send(:remove_method, method_name)
+      default_stub_method_owner.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      default_definition_target.__send__ :prepend, @definition_target
+      default_stub_method_owner.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition
@@ -133,10 +133,10 @@ module Mocha
     end
 
     def definition_target
-      @definition_target ||= default_definition_target
+      @definition_target ||= default_stub_method_owner
     end
 
-    def default_definition_target
+    def default_stub_method_owner
       stubbee.__metaclass__
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -44,7 +44,7 @@ module Mocha
             prepend_module
           else
             @original_method = original_method(method)
-            if @original_method && @original_method.owner == stubbee.__metaclass__
+            if original_method_defined_on_stubbee?
               stubbee.__metaclass__.send(:remove_method, method)
             end
           end
@@ -111,6 +111,10 @@ module Mocha
 
     def original_method(method)
       stubbee._method(method)
+    end
+
+    def original_method_defined_on_stubbee?
+      @original_method && @original_method.owner == stubbee.__metaclass__
     end
 
     def prepend_module

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -43,7 +43,7 @@ module Mocha
           if RUBY_V2_PLUS
             use_prepended_module_for_stub_method
           else
-            @original_method = original_method(method_name)
+            @original_method = original_method
             if original_method_defined_on_stubbee?
               remove_original_method_from_stubbee
             end
@@ -105,7 +105,7 @@ module Mocha
 
     private
 
-    def original_method(method_name)
+    def original_method
       stubbee._method(method_name)
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -38,7 +38,8 @@ module Mocha
     end
 
     def hide_original_method
-      if @original_visibility = method_visibility
+      if method_defined_in_stubbee_or_in_ancestor_chain?
+        @original_visibility = method_visibility
         if use_prepended_module_for_stub_method?
           use_prepended_module_for_stub_method
         else
@@ -102,6 +103,7 @@ module Mocha
         (metaclass.protected_method_defined?(symbol) && :protected) ||
         (metaclass.private_method_defined?(symbol) && :private)
     end
+    alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -44,7 +44,7 @@ module Mocha
             @definition_target = PrependedModule.new
             stubbee.__metaclass__.__send__ :prepend, @definition_target
           else
-            @original_method = stubbee._method(method)
+            @original_method = original_method(method)
             if @original_method && @original_method.owner == stubbee.__metaclass__
               stubbee.__metaclass__.send(:remove_method, method)
             end
@@ -109,6 +109,10 @@ module Mocha
     end
 
     private
+
+    def original_method(method)
+      stubbee._method(method)
+    end
 
     def definition_target
       @definition_target ||= stubbee.__metaclass__

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -133,7 +133,11 @@ module Mocha
     end
 
     def definition_target
-      @definition_target ||= stubbee.__metaclass__
+      @definition_target ||= default_definition_target
+    end
+
+    def default_definition_target
+      stubbee.__metaclass__
     end
 
   end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -38,7 +38,7 @@ module Mocha
     end
 
     def hide_original_method
-      if @original_visibility = method_visibility(method_name)
+      if @original_visibility = method_visibility
         if use_prepended_module_for_stub_method?
           use_prepended_module_for_stub_method
         else
@@ -94,7 +94,7 @@ module Mocha
       "#{stubbee}.#{method_name}"
     end
 
-    def method_visibility(method_name)
+    def method_visibility
       symbol = method_name.to_sym
       metaclass = default_stub_method_owner
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -55,14 +55,14 @@ module Mocha
     end
 
     def define_new_method
-      definition_target.class_eval(*stub_method_definition)
+      stub_method_owner.class_eval(*stub_method_definition)
       if @original_visibility
-        Module.instance_method(@original_visibility).bind(definition_target).call(method_name)
+        Module.instance_method(@original_visibility).bind(stub_method_owner).call(method_name)
       end
     end
 
     def remove_new_method
-      definition_target.send(:remove_method, method_name)
+      stub_method_owner.send(:remove_method, method_name)
     end
 
     def restore_original_method
@@ -118,8 +118,8 @@ module Mocha
     end
 
     def prepend_module
-      @definition_target = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @definition_target
+      @stub_method_owner = PrependedModule.new
+      default_stub_method_owner.__send__ :prepend, @stub_method_owner
     end
 
     def stub_method_definition
@@ -132,8 +132,8 @@ module Mocha
       [method_implementation, filename, line_number_of_method_implementation]
     end
 
-    def definition_target
-      @definition_target ||= default_stub_method_owner
+    def stub_method_owner
+      @stub_method_owner ||= default_stub_method_owner
     end
 
     def default_stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -39,17 +39,17 @@ module Mocha
 
     def hide_original_method
       if @original_visibility = method_visibility(method_name)
-        begin
-          if use_prepended_module_for_stub_method?
-            use_prepended_module_for_stub_method
-          else
+        if use_prepended_module_for_stub_method?
+          use_prepended_module_for_stub_method
+        else
+          begin
             store_original_method
-            if original_method_defined_on_stubbee?
-              remove_original_method_from_stubbee
-            end
+          rescue NameError
+            # deal with nasties like ActiveRecord::Associations::AssociationProxy
           end
-        rescue NameError
-          # deal with nasties like ActiveRecord::Associations::AssociationProxy
+          if original_method_defined_on_stubbee?
+            remove_original_method_from_stubbee
+          end
         end
       end
     end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -67,18 +67,18 @@ module Mocha
 
     def restore_original_method
       unless RUBY_V2_PLUS
-        if @original_method && @original_method.owner == stubbee.__metaclass__
+        if @original_method && @original_method.owner == default_definition_target
           if PRE_RUBY_V19
             original_method = @original_method
-            stubbee.__metaclass__.send(:define_method, method_name) do |*args, &block|
+            default_definition_target.send(:define_method, method_name) do |*args, &block|
               original_method.call(*args, &block)
             end
           else
-            stubbee.__metaclass__.send(:define_method, method_name, @original_method)
+            default_definition_target.send(:define_method, method_name, @original_method)
           end
         end
         if @original_visibility
-          Module.instance_method(@original_visibility).bind(stubbee.__metaclass__).call(method_name)
+          Module.instance_method(@original_visibility).bind(default_definition_target).call(method_name)
         end
       end
     end
@@ -96,7 +96,7 @@ module Mocha
 
     def method_visibility(method_name)
       symbol = method_name.to_sym
-      metaclass = stubbee.__metaclass__
+      metaclass = default_definition_target
 
       (metaclass.public_method_defined?(symbol) && :public) ||
         (metaclass.protected_method_defined?(symbol) && :protected) ||
@@ -110,16 +110,16 @@ module Mocha
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == stubbee.__metaclass__
+      @original_method && @original_method.owner == default_definition_target
     end
 
     def remove_original_method_from_stubbee
-      stubbee.__metaclass__.send(:remove_method, method_name)
+      default_definition_target.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      stubbee.__metaclass__.__send__ :prepend, @definition_target
+      default_definition_target.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -67,7 +67,7 @@ module Mocha
 
     def restore_original_method
       unless RUBY_V2_PLUS
-        if @original_method && @original_method.owner == default_stub_method_owner
+        if original_method_defined_on_stubbee?
           if PRE_RUBY_V19
             original_method = @original_method
             default_stub_method_owner.send(:define_method, method_name) do |*args, &block|

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -39,7 +39,7 @@ module Mocha
 
     def hide_original_method
       if method_defined_in_stubbee_or_in_ancestor_chain?
-        @original_visibility = method_visibility
+        store_original_method_visibility
         if use_prepended_module_for_stub_method?
           use_prepended_module_for_stub_method
         else
@@ -57,8 +57,8 @@ module Mocha
 
     def define_new_method
       stub_method_owner.class_eval(*stub_method_definition)
-      if @original_visibility
-        Module.instance_method(@original_visibility).bind(stub_method_owner).call(method_name)
+      if original_visibility
+        Module.instance_method(original_visibility).bind(stub_method_owner).call(method_name)
       end
     end
 
@@ -78,8 +78,8 @@ module Mocha
             original_method_owner.send(:define_method, method_name, original_method)
           end
         end
-        if @original_visibility
-          Module.instance_method(@original_visibility).bind(original_method_owner).call(method_name)
+        if original_visibility
+          Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
         end
       end
     end
@@ -107,10 +107,14 @@ module Mocha
 
     private
 
-    attr_reader :original_method
+    attr_reader :original_method, :original_visibility
 
     def store_original_method
       @original_method = stubbee._method(method_name)
+    end
+
+    def store_original_method_visibility
+      @original_visibility = method_visibility
     end
 
     def stub_method_overwrites_original_method?

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -71,15 +71,15 @@ module Mocha
         if stub_method_overwrites_original_method?
           if PRE_RUBY_V19
             original_method_in_scope = original_method
-            default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
+            original_method_owner.send(:define_method, method_name) do |*args, &block|
               original_method_in_scope.call(*args, &block)
             end
           else
-            default_stub_method_owner.send(:define_method, method_name, original_method)
+            original_method_owner.send(:define_method, method_name, original_method)
           end
         end
         if @original_visibility
-          Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
+          Module.instance_method(@original_visibility).bind(original_method_owner).call(method_name)
         end
       end
     end
@@ -97,7 +97,7 @@ module Mocha
 
     def method_visibility
       symbol = method_name.to_sym
-      metaclass = default_stub_method_owner
+      metaclass = original_method_owner
 
       (metaclass.public_method_defined?(symbol) && :public) ||
         (metaclass.protected_method_defined?(symbol) && :protected) ||
@@ -114,11 +114,11 @@ module Mocha
     end
 
     def stub_method_overwrites_original_method?
-      original_method && original_method.owner == default_stub_method_owner
+      original_method && original_method.owner == original_method_owner
     end
 
     def remove_original_method_from_stubbee
-      default_stub_method_owner.send(:remove_method, method_name)
+      original_method_owner.send(:remove_method, method_name)
     end
 
     def use_prepended_module_for_stub_method?
@@ -127,7 +127,7 @@ module Mocha
 
     def use_prepended_module_for_stub_method
       @stub_method_owner = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @stub_method_owner
+      original_method_owner.__send__ :prepend, @stub_method_owner
     end
 
     def stub_method_definition
@@ -141,10 +141,10 @@ module Mocha
     end
 
     def stub_method_owner
-      @stub_method_owner ||= default_stub_method_owner
+      @stub_method_owner ||= original_method_owner
     end
 
-    def default_stub_method_owner
+    def original_method_owner
       stubbee.__metaclass__
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -96,11 +96,9 @@ module Mocha
     end
 
     def method_visibility
-      metaclass = original_method_owner
-
-      (metaclass.public_method_defined?(method_name) && :public) ||
-        (metaclass.protected_method_defined?(method_name) && :protected) ||
-        (metaclass.private_method_defined?(method_name) && :private)
+      (original_method_owner.public_method_defined?(method_name) && :public) ||
+        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
+        (original_method_owner.private_method_defined?(method_name) && :private)
     end
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -96,12 +96,11 @@ module Mocha
     end
 
     def method_visibility
-      symbol = method_name.to_sym
       metaclass = original_method_owner
 
-      (metaclass.public_method_defined?(symbol) && :public) ||
-        (metaclass.protected_method_defined?(symbol) && :protected) ||
-        (metaclass.private_method_defined?(symbol) && :private)
+      (metaclass.public_method_defined?(method_name) && :public) ||
+        (metaclass.protected_method_defined?(method_name) && :protected) ||
+        (metaclass.private_method_defined?(method_name) && :private)
     end
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -57,7 +57,7 @@ end
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 37
+    expected_line_number = 61
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -57,7 +57,7 @@ end
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 61
+    expected_line_number = 54
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -57,7 +57,7 @@ end
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 41
+    expected_line_number = 35
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -57,7 +57,7 @@ end
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 45
+    expected_line_number = 41
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -57,7 +57,7 @@ end
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 54
+    expected_line_number = 49
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -57,7 +57,7 @@ end
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 49
+    expected_line_number = 45
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 135
+    expected_line_number = 137
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 129
+    expected_line_number = 131
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 61
+    expected_line_number = 129
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 131
+    expected_line_number = 135
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 140
+    expected_line_number = 138
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 137
+    expected_line_number = 141
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ end
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 141
+    expected_line_number = 140
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|


### PR DESCRIPTION
This branch reduces some duplication between `ClassMethod` and `AnyInstanceMethod`, and aims to make the code clearer through the use of intention revealing method names.

Removing the duplication should hopefully help us avoid the sort of situation we encountered when we made a change to `ClassMethod#hide_original_method` without also updating the implementation in `AnyInstanceMethod`. See "ClassMethod and AnyInstanceMethod divergence" below for more information about this.

There are still some overridden methods in `AnyInstanceMethod` (notably `restore_original_method` and `stub_method_definition`) that it'd be good to investigate in future to see whether we can remove more duplication.

## ClassMethod and AnyInstanceMethod divergence

* [PR 248](https://github.com/freerange/mocha/pull/248) changed `ClassMethod#hide_original_method` to use the new `#method_visibility` method instead of `method_exists?`.
  * NOTE. The changes in PR 248 were actually added to master manually. The main change being in https://github.com/freerange/mocha/commit/e87c03b068efc48267fbcd5a295514077c52b901.
* We added tests around this subtle change in behaviour (introduced in PR 248), in https://github.com/freerange/mocha/commit/5f768de62a6b6fb2c1c275b5830bc6471722cce4.
* At the point we merged PR 248, `AnyInstanceMethod#hide_original_method` was still using its own version of `method_exists?`
  * We updated this to mirror the changes in `ClassMethod` in [PR 262](https://github.com/freerange/mocha/pull/262).
* PR 248 made `InstanceMethod#method_exists?` redundant.
  * This redundant method was removed in https://github.com/freerange/mocha/commit/8f58eddf0ff658ad255cf60cedab3c767bbb15c7.
* PR 248 made `ModuleMethod#method_exists?` redundant.
  * This redundant method was removed in https://github.com/freerange/mocha/commit/fe1d49d124ac4af15e5f4fa0670f0f43be1fed4d and some tests were added to check the behaviour added in the original commit from Grosser.

## TODO

- [x] Explain the motivation in PR description/branch
  * We're mostly interested in reducing the chance of changes being made to ClassMethod and not to AnyInstanceMethod.
- [x] Do we need different implementations of `stubbed_method_implementation` (in `ClassMethod` and `AnyInstanceMethod`)?
- [x] Can you check that the documentation generated after these changes makes sense? I'm pretty sure the affected files are all excluded from the documentation, but it'd be worth double-checking.
- [x] Commit: "Extract ClassMethod#stubbed_method_implementation"
  * Explain in the commit note why I'm happy to accept the LINE+1 still.
    * Ensure the tests still make sense
  * Rename method to `stub_method_definition`
- [x] Commit: "Reduce scope of `rescue` in #hide_original_method"
  * Is my commit note correct? It says that we only have tests for AnyInstanceMethod and not for ClassMethod but it looks as though it might be the other way round.
- [x] Rename `#original_method_defined_on_stubbee?`.
  * We're actually interested in whether the method was originally defined on the stubbee or the stubbee's metaclass in the case of AnyInstanceMethod.
  * Consider something like `#stub_method_overwrites_original_method?`.
- [x] Commit "Use default_definition_target to DRY up code" appears to mean that `AnyInstanceMethod#method_visibility` isn't required (i.e. I can delete that method without any of the tests failing). This is unexpected!
- [x] Rename `#default_stub_method_owner`.
  * Something like `#original_method_owner` or `#default_owner_of_stub_method` would probably be clearer.
  * In further discussion we realised that this name is probably OK but it might be that we're overloading its use. Introducing an alias based on how we're using it might make things clearer.
