### PR TITLE
Add latest stable version of JRuby to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
+  - jruby
 gemfile:
   - Gemfile
 env:
   - MOCHA_OPTIONS=debug
 matrix:
   include:
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.3
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
@@ -75,6 +79,9 @@ matrix:
     - rvm: 1.8.7
       gemfile: gemfiles/Gemfile.minitest.1.3.0
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.3
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit

--- a/test/execution_point.rb
+++ b/test/execution_point.rb
@@ -10,14 +10,16 @@ class ExecutionPoint
     @backtrace = backtrace
   end
 
+  def first_line_of_backtrace
+    @backtrace && (@backtrace.first || 'unknown:0')
+  end
+
   def file_name
-    return "unknown" unless @backtrace && @backtrace.first
-    /\A(.*?):\d+/.match(@backtrace.first)[1]
+    /\A(.*?):\d+/.match(first_line_of_backtrace)[1]
   end
 
   def line_number
-    return "unknown" unless @backtrace && @backtrace.first
-    Integer(/\A.*?:(\d+)/.match(@backtrace.first)[1])
+    Integer(/\A.*?:(\d+)/.match(first_line_of_backtrace)[1])
   end
 
   def ==(other)

--- a/test/execution_point.rb
+++ b/test/execution_point.rb
@@ -10,16 +10,16 @@ class ExecutionPoint
     @backtrace = backtrace
   end
 
-  def first_line_of_backtrace
-    @backtrace && (@backtrace.first || 'unknown:0')
+  def first_relevant_line_of_backtrace
+    @backtrace && (@backtrace.reject { |l| /\Aorg\/jruby\//.match(l) }.first || 'unknown:0')
   end
 
   def file_name
-    /\A(.*?):\d+/.match(first_line_of_backtrace)[1]
+    /\A(.*?):\d+/.match(first_relevant_line_of_backtrace)[1]
   end
 
   def line_number
-    Integer(/\A.*?:(\d+)/.match(first_line_of_backtrace)[1])
+    Integer(/\A.*?:(\d+)/.match(first_relevant_line_of_backtrace)[1])
   end
 
   def ==(other)


### PR DESCRIPTION
Since @headius fixed jruby/jruby#4250 and it was released in JRuby v9.1.6.0, the Mocha unit & acceptance tests have all been passing under this latest version of JRuby.

However, an assertion related to the stack-trace from a Mocha exception was failing under JRuby for both Minitest & Test::Unit (see [this comment](https://github.com/freerange/mocha/issues/274#issuecomment-264168406) for details). This PR filters out JRuby-related lines of the stack-trace thus fixing the assertions.

Finally this PR also adds JRuby to the Travis CI build matrix in the hope that we can prevent regressions in the future.
