### PR TITLE
Use do/end instead of { } in stub_module_method_test

### DIFF
--- a/test/acceptance/stub_module_method_test.rb
+++ b/test/acceptance/stub_module_method_test.rb
@@ -14,7 +14,11 @@ class StubModuleMethodTest < Mocha::TestCase
   end
 
   def test_should_stub_method_within_test
-    mod = Module.new { def self.my_module_method; :original_return_value; end }
+    mod = Module.new do
+      def self.my_module_method
+        :original_return_value
+      end
+    end
     test_result = run_as_test do
       mod.stubs(:my_module_method).returns(:new_return_value)
       assert_equal :new_return_value, mod.my_module_method
@@ -23,7 +27,14 @@ class StubModuleMethodTest < Mocha::TestCase
   end
 
   def test_should_leave_stubbed_public_method_unchanged_after_test
-    mod = Module.new { class << self; def my_module_method; :original_return_value; end; public :my_module_method; end }
+    mod = Module.new do
+      class << self
+        def my_module_method
+          :original_return_value
+        end
+        public :my_module_method
+      end
+    end
     run_as_test do
       mod.stubs(:my_module_method).returns(:new_return_value)
     end
@@ -32,7 +43,17 @@ class StubModuleMethodTest < Mocha::TestCase
   end
 
   def test_should_leave_stubbed_protected_method_unchanged_after_test
-    mod = Module.new { class << self; def my_module_method; :original_return_value; end; protected :my_module_method; def my_unprotected_module_method; my_module_method; end; end }
+    mod = Module.new do
+      class << self
+        def my_module_method
+          :original_return_value
+        end
+        protected :my_module_method
+        def my_unprotected_module_method
+          my_module_method
+        end
+      end
+    end
     run_as_test do
       mod.stubs(:my_module_method).returns(:new_return_value)
     end
@@ -41,7 +62,14 @@ class StubModuleMethodTest < Mocha::TestCase
   end
 
   def test_should_leave_stubbed_private_method_unchanged_after_test
-    mod = Module.new { class << self; def my_module_method; :original_return_value; end; private :my_module_method; end }
+    mod = Module.new do
+      class << self
+        def my_module_method
+          :original_return_value
+        end
+        private :my_module_method
+      end
+    end
     run_as_test do
       mod.stubs(:my_module_method).returns(:new_return_value)
     end
@@ -50,7 +78,11 @@ class StubModuleMethodTest < Mocha::TestCase
   end
 
   def test_should_reset_expectations_after_test
-    mod = Module.new { def self.my_module_method; :original_return_value; end }
+    mod = Module.new do
+      def self.my_module_method
+        :original_return_value
+      end
+    end
     run_as_test do
       mod.stubs(:my_module_method)
     end
@@ -58,8 +90,14 @@ class StubModuleMethodTest < Mocha::TestCase
   end
 
   def test_should_be_able_to_stub_a_superclass_method
-    supermod = Module.new { def self.my_superclass_method; :original_return_value; end }
-    mod = Module.new { include supermod }
+    supermod = Module.new do
+      def self.my_superclass_method
+        :original_return_value
+      end
+    end
+    mod = Module.new do
+      include supermod
+    end
     test_result = run_as_test do
       mod.stubs(:my_superclass_method).returns(:new_return_value)
       assert_equal :new_return_value, mod.my_superclass_method

--- a/test/acceptance/stubba_test_result_test.rb
+++ b/test/acceptance/stubba_test_result_test.rb
@@ -16,7 +16,10 @@ class StubbaTestResultTest < Mocha::TestCase
 
   def test_should_include_expectation_verification_in_assertion_count
     test_result = run_as_test do
-      object = Class.new { def message; end }.new
+      object = Class.new do
+        def message
+        end
+      end.new
       object.expects(:message)
       object.message
     end
@@ -32,7 +35,10 @@ class StubbaTestResultTest < Mocha::TestCase
 
   def test_should_not_include_stubbing_expectation_verification_in_assertion_count
     test_result = run_as_test do
-      object = Class.new { def message; end }.new
+      object = Class.new do
+        def message
+        end
+      end.new
       object.stubs(:message)
       object.message
     end
@@ -41,7 +47,10 @@ class StubbaTestResultTest < Mocha::TestCase
 
   def test_should_include_expectation_verification_failure_in_failure_count
     test_result = run_as_test do
-      object = Class.new { def message; end }.new
+      object = Class.new do
+        def message
+        end
+      end.new
       object.expects(:message)
     end
     assert_equal 1, test_result.failure_count

--- a/test/acceptance/stubbing_on_non_mock_object_test.rb
+++ b/test/acceptance/stubbing_on_non_mock_object_test.rb
@@ -15,7 +15,10 @@ class StubbingOnNonMockObjectTest < Mocha::TestCase
 
   def test_should_allow_stubbing_method_on_non_mock_object
     Mocha::Configuration.allow(:stubbing_method_on_non_mock_object)
-    non_mock_object = Class.new { def existing_method; end }
+    non_mock_object = Class.new do
+      def existing_method
+      end
+    end
     test_result = run_as_test do
       non_mock_object.stubs(:existing_method)
     end
@@ -25,7 +28,10 @@ class StubbingOnNonMockObjectTest < Mocha::TestCase
 
   def test_should_warn_on_stubbing_method_on_non_mock_object
     Mocha::Configuration.warn_when(:stubbing_method_on_non_mock_object)
-    non_mock_object = Class.new { def existing_method; end }
+    non_mock_object = Class.new do
+      def existing_method
+      end
+    end
     test_result = run_as_test do
       non_mock_object.stubs(:existing_method)
     end
@@ -35,7 +41,10 @@ class StubbingOnNonMockObjectTest < Mocha::TestCase
 
   def test_should_prevent_stubbing_method_on_non_mock_object
     Mocha::Configuration.prevent(:stubbing_method_on_non_mock_object)
-    non_mock_object = Class.new { def existing_method; end }
+    non_mock_object = Class.new do
+      def existing_method
+      end
+    end
     test_result = run_as_test do
       non_mock_object.stubs(:existing_method)
     end
@@ -44,7 +53,10 @@ class StubbingOnNonMockObjectTest < Mocha::TestCase
   end
 
   def test_should_default_to_allow_stubbing_method_on_non_mock_object
-    non_mock_object = Class.new { def existing_method; end }
+    non_mock_object = Class.new do
+      def existing_method
+      end
+    end
     test_result = run_as_test do
       non_mock_object.stubs(:existing_method)
     end


### PR DESCRIPTION
This is consistent with the way we're defining modules and classes in
other similar tests. I also find it easier to read.