### PR TITLE
Add Ruby 2.4 and ruby-head in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
+  - ruby-head
   - jruby
 gemfile:
   - Gemfile
@@ -18,6 +19,9 @@ env:
 matrix:
   include:
     - rvm: jruby
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: ruby-head
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.4.0
@@ -86,6 +90,9 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.4.0
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
@@ -128,3 +135,6 @@ matrix:
     - rvm: 1.8.7-p371
       gemfile: Gemfile
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.1.10
   - 2.2.6
   - 2.3.3
+  - 2.4.0
   - jruby
 gemfile:
   - Gemfile
@@ -17,6 +18,9 @@ env:
 matrix:
   include:
     - rvm: jruby
+      gemfile: gemfiles/Gemfile.minitest.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
+    - rvm: 2.4.0
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.3.3
@@ -80,6 +84,9 @@ matrix:
       gemfile: gemfiles/Gemfile.minitest.1.3.0
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: jruby
+      gemfile: gemfiles/Gemfile.test-unit.latest
+      env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
+    - rvm: 2.4.0
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ rvm:
   - 1.8.7-p371
   - 1.9.3
   - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - jruby
 gemfile:
   - Gemfile
@@ -19,13 +19,13 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
-    - rvm: 2.3
+    - rvm: 2.3.3
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
-    - rvm: 2.2
+    - rvm: 2.2.6
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
-    - rvm: 2.1
+    - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 2.0.0
@@ -82,13 +82,13 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
-    - rvm: 2.3
+    - rvm: 2.3.3
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
-    - rvm: 2.2
+    - rvm: 2.2.6
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
-    - rvm: 2.1
+    - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: 2.0.0


### PR DESCRIPTION
I want to add ruby-2.4 and ruby-head in `.travis.yml`.

## Ruby 2.4

I added "2.4.0", not "2.4".
Because last month I tried "2.4" in `.travis.yml`, it was not available.
I can not find official document for that.

## ruby-head

I want to add `ruby-head` as allow_failures in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
I think that is the reason why `rails` and `rspec` can support new version Ruby as faster.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml
https://github.com/sparklemotion/nokogiri/blob/master/.travis.yml

Is it possible to add it?

Thanks.
