### PR TITLE
Fix `includes` matcher for `Array` values

### DIFF
--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -80,7 +80,8 @@ module Mocha
         return false unless parameter.respond_to?(:include?)
         if @items.size == 1
           if parameter.respond_to?(:any?) && !parameter.is_a?(String)
-            return parameter.any? { |(p,_)| @items.first.to_matcher.matches?([p]) }
+            parameter = parameter.keys if parameter.is_a?(Hash)
+            return parameter.any? { |p| @items.first.to_matcher.matches?([p]) }
           else
             return parameter.include?(@items.first)
           end

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -15,6 +15,11 @@ class IncludesTest < Mocha::TestCase
     assert matcher.matches?([[:x, :y, :z]])
   end
 
+  def test_should_match_object_including_array_value
+    matcher = includes([:x])
+    assert matcher.matches?([[[:x], [:y], [:z]]])
+  end
+
   def test_should_match_object_including_all_values
     matcher = includes(:x, :y, :z)
     assert matcher.matches?([[:x, :y, :z]])


### PR DESCRIPTION
The following code works with mocha v1.1.0:

    MyClass.any_instance.expects(:my_method).with(includes([1, 2]))

    MyClass.new.some_method([[1, 2], [3, 4]])

It doesn't work in v1.2.0 due to commit ff8ce3817ee1ee8181a586ac4c7f56a28b0e4c46,
which changes the existing behaviour for `Array` values.

This commit reverts to the previous behaviour (only one block argument),
and adds a special case for `Hash` to match against keys.