### PR TITLE
handle cases where parameter value is blank for query string matcher

### DIFF
--- a/lib/mocha/parameter_matchers/query_string.rb
+++ b/lib/mocha/parameter_matchers/query_string.rb
@@ -49,7 +49,11 @@ module Mocha
     private
       # @private
       def explode(uri)
-        query_hash = (uri.query || '').split('&').inject({}){ |h, kv| h.merge(Hash[*kv.split('=')]) }
+        query_hash = (uri.query || '').split('&').inject({}) do |h, kv|
+          param = kv.split('=')
+          param[1] = '' if param.size < 2
+          h.merge(Hash[*param])
+        end
         URI::Generic::COMPONENT.inject({}){ |h, k| h.merge(k => uri.__send__(k)) }.merge(:query => query_hash)
       end
 

--- a/test/acceptance/parameter_matcher_test.rb
+++ b/test/acceptance/parameter_matcher_test.rb
@@ -297,6 +297,15 @@ class ParameterMatcherTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  def test_should_match_parameter_with_blank_value
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(has_equivalent_query_string('http://example.com/foo?a='))
+      mock.method('http://example.com/foo?a=')
+    end
+    assert_passed(test_result)
+  end
+
   def test_should_match_parameter_when_value_is_divisible_by_four
     test_result = run_as_test do
       mock = mock()


### PR DESCRIPTION
Currently the following will raise an exception:
```
object = mock()
object.expects(:method_1).with(has_equivalent_query_string('http://example.com/foo?a='))
object.method_1('http://example.com/foo?a=')
```
This PR adds a fix so that the above assertion will pass.