### PR TITLE
Handle blank parameter value for query string matcher

### DIFF
--- a/lib/mocha/parameter_matchers/query_string.rb
+++ b/lib/mocha/parameter_matchers/query_string.rb
@@ -49,7 +49,10 @@ module Mocha
     private
       # @private
       def explode(uri)
-        query_hash = (uri.query || '').split('&').inject({}){ |h, kv| h.merge(Hash[*kv.split('=')]) }
+        query_hash = (uri.query || '').split('&').inject({}) do |h, pair|
+          key, value = pair.split('=')
+          h.merge(key => value || '')
+        end
         URI::Generic::COMPONENT.inject({}){ |h, k| h.merge(k => uri.__send__(k)) }.merge(:query => query_hash)
       end
 

--- a/test/unit/parameter_matchers/query_string_test.rb
+++ b/test/unit/parameter_matchers/query_string_test.rb
@@ -35,4 +35,9 @@ class QueryStringTest < Mocha::TestCase
     matcher = has_equivalent_query_string('/foo?a=1&b=2')
     assert matcher.matches?(['/foo?a=1&b=2'])
   end
+
+  def test_should_match_query_string_containing_blank_value
+    matcher = has_equivalent_query_string('http://example.com/foo?a=&b=2')
+    assert matcher.matches?(['http://example.com/foo?a=&b=2'])
+  end
 end


### PR DESCRIPTION
Currently the following will raise an exception:
```
object = mock()
object.expects(:method_1).with(has_equivalent_query_string('http://example.com/foo?a='))
object.method_1('http://example.com/foo?a=')
```
This PR adds a fix so that the above assertion will pass.

Based on #303 by @weynsee.