### PR TITLE
Use faster container-based virtual environments for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 before_install:
   - gem install bundler
 bundler_args: "--verbose"


### PR DESCRIPTION
`sudo: required` is [the default for repositories before 2015][1].

Builds for repositories with `sudo: false` will be run in container-based virtual environments which have a much faster boot time.

[1]: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments