### PR TITLE
Rename QueryStringMatches to QueryString

### DIFF
--- a/lib/mocha/parameter_matchers/query_string.rb
+++ b/lib/mocha/parameter_matchers/query_string.rb
@@ -7,7 +7,7 @@ module Mocha
     # Matches a URI without regard to the ordering of parameters in the query string.
     #
     # @param [String] uri URI to match.
-    # @return [QueryStringMatches] parameter matcher.
+    # @return [QueryString] parameter matcher.
     #
     # @see Expectation#with
     #
@@ -23,11 +23,11 @@ module Mocha
     #   object.method_1('http://example.com/foo?a=1&b=3')
     #   # error raised, because the query parameters were different
     def has_equivalent_query_string(uri)
-      QueryStringMatches.new(uri)
+      QueryString.new(uri)
     end
 
     # Parameter matcher which matches URIs with equivalent query strings.
-    class QueryStringMatches < Base
+    class QueryString < Base
 
       # @private
       def initialize(uri)

--- a/test/acceptance/parameter_matcher_test.rb
+++ b/test/acceptance/parameter_matcher_test.rb
@@ -243,16 +243,7 @@ class ParameterMatcherTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
-  def test_should_match_parameter_that_has_identical_query_string
-    test_result = run_as_test do
-      mock = mock()
-      mock.expects(:method).with(has_equivalent_query_string('http://example.com/foo?a=1&b=2'))
-      mock.method('http://example.com/foo?a=1&b=2')
-    end
-    assert_passed(test_result)
-  end
-
-  def test_should_match_parameter_that_has_rearranged_query_string
+  def test_should_match_parameter_that_has_equivalent_query_string
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_equivalent_query_string('http://example.com/foo?b=2&a=1'))
@@ -261,40 +252,13 @@ class ParameterMatcherTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
-  def test_should_not_match_parameter_that_does_not_have_the_same_query_parameters
+  def test_should_not_match_parameter_that_does_not_have_equivalent_query_string
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_equivalent_query_string('http://example.com/foo?a=1'))
       mock.method('http://example.com/foo?a=1&b=2')
     end
     assert_failed(test_result)
-  end
-
-  def test_should_not_match_parameter_that_has_no_query_parameters_when_they_are_expected
-    test_result = run_as_test do
-      mock = mock()
-      mock.expects(:method).with(has_equivalent_query_string('http://example.com/foo'))
-      mock.method('http://example.com/foo?a=1&b=2')
-    end
-    assert_failed(test_result)
-  end
-
-  def test_should_not_match_parameter_that_has_the_same_query_string_bit_which_differs_otherwise
-    test_result = run_as_test do
-      mock = mock()
-      mock.expects(:method).with(has_equivalent_query_string('http://a.example.com/foo?a=1&b=2'))
-      mock.method('http://b.example.com/foo?a=1&b=2')
-    end
-    assert_failed(test_result)
-  end
-
-  def test_should_match_parameter_with_no_domain_or_scheme
-    test_result = run_as_test do
-      mock = mock()
-      mock.expects(:method).with(has_equivalent_query_string('/foo?a=1&b=2'))
-      mock.method('/foo?a=1&b=2')
-    end
-    assert_passed(test_result)
   end
 
   def test_should_match_parameter_when_value_is_divisible_by_four

--- a/test/unit/parameter_matchers/query_string_test.rb
+++ b/test/unit/parameter_matchers/query_string_test.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 
 require 'mocha/parameter_matchers/query_string'
 
-class QueryStringMatchesTest < Mocha::TestCase
+class QueryStringTest < Mocha::TestCase
 
   include Mocha::ParameterMatchers
 

--- a/test/unit/parameter_matchers/query_string_test.rb
+++ b/test/unit/parameter_matchers/query_string_test.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+require 'mocha/parameter_matchers/query_string'
+
+class QueryStringMatchesTest < Mocha::TestCase
+
+  include Mocha::ParameterMatchers
+
+  def test_should_match_identical_query_string
+    matcher = has_equivalent_query_string('http://example.com/foo?a=1&b=2')
+    assert matcher.matches?(['http://example.com/foo?a=1&b=2'])
+  end
+
+  def test_should_match_rearranged_query_string
+    matcher = has_equivalent_query_string('http://example.com/foo?b=2&a=1')
+    assert matcher.matches?(['http://example.com/foo?a=1&b=2'])
+  end
+
+  def test_should_not_match_different_query_string
+    matcher = has_equivalent_query_string('http://example.com/foo?a=1')
+    assert !matcher.matches?(['http://example.com/foo?a=1&b=2'])
+  end
+
+  def test_should_not_match_query_string_when_none_expected
+    matcher = has_equivalent_query_string('http://example.com/foo')
+    assert !matcher.matches?(['http://example.com/foo?a=1&b=2'])
+  end
+
+  def test_should_not_match_equivalent_query_string_when_other_parts_of_url_differ
+    matcher = has_equivalent_query_string('http://a.example.com/foo?a=1&b=2')
+    assert !matcher.matches?(['http://b.example.com/foo?a=1&b=2'])
+  end
+
+  def test_should_match_equivalent_query_string_when_url_has_no_scheme_or_domain
+    matcher = has_equivalent_query_string('/foo?a=1&b=2')
+    assert matcher.matches?(['/foo?a=1&b=2'])
+  end
+end


### PR DESCRIPTION
This feels more consistent with the other parameter matcher class names and with the existing filenames.