### PR TITLE
Display file and line number in deprecation warning

### DIFF
--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -1,4 +1,3 @@
-require 'mocha/debug'
 require 'mocha/backtrace_filter'
 
 module Mocha
@@ -20,7 +19,7 @@ module Mocha
 
     end
 
-    self.mode = Debug::OPTIONS['debug'] ? :debug : :enabled
+    self.mode = :enabled
     self.messages = []
 
   end

--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -10,8 +10,12 @@ module Mocha
 
       def warning(message)
         @messages << message
-        $stderr.puts "\n*** Mocha deprecation warning: #{message}\n\n" unless mode == :disabled
-        $stderr.puts caller.join("\n  ") if mode == :debug
+        unless mode == :disabled
+          $stderr.puts "\n*** Mocha deprecation warning: #{message}\n\n"
+        end
+        if mode == :debug
+          $stderr.puts caller.join("\n  ")
+        end
       end
 
     end

--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -1,4 +1,5 @@
 require 'mocha/debug'
+require 'mocha/backtrace_filter'
 
 module Mocha
 
@@ -11,10 +12,9 @@ module Mocha
       def warning(message)
         @messages << message
         unless mode == :disabled
-          $stderr.puts "Mocha deprecation warning: #{message}"
-        end
-        if mode == :debug
-          $stderr.puts caller.join("\n  ")
+          filter = BacktraceFilter.new
+          location = filter.filtered(caller)[0]
+          $stderr.puts "Mocha deprecation warning at #{location}: #{message}"
         end
       end
 

--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -11,7 +11,7 @@ module Mocha
       def warning(message)
         @messages << message
         unless mode == :disabled
-          $stderr.puts "\n*** Mocha deprecation warning: #{message}\n\n"
+          $stderr.puts "Mocha deprecation warning: #{message}"
         end
         if mode == :debug
           $stderr.puts caller.join("\n  ")


### PR DESCRIPTION
This changes the output from:

```

*** Mocha deprecation warning at test.rb:7:in `test_foo': Passing a block is deprecated.


```

To:

```
Mocha deprecation warning at test.rb:7:in `test_foo': Passing a block is deprecated.
```

* Includes file and line number where deprecated method was called
* Makes deprecation warnings less prominent - fewer surrounding newlines & no leading asterisks
* Remove debug mode from `Mocha::Deprecation` - now only `:enabled` or `:disabled` are valid

Fixes #312.