### PR TITLE
Ruby 2.5 Warnings

### DIFF
--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -33,11 +33,11 @@ module Mocha
 
       def method_exists?(method, include_public_methods = true)
         if include_public_methods
-          return true if @stubba_object.public_instance_methods(include_superclass_methods = true).include?(method)
+          return true if @stubba_object.public_instance_methods(_include_superclass_methods = true).include?(method)
           return true if @stubba_object.allocate.respond_to?(method.to_sym)
         end
-        return true if @stubba_object.protected_instance_methods(include_superclass_methods = true).include?(method)
-        return true if @stubba_object.private_instance_methods(include_superclass_methods = true).include?(method)
+        return true if @stubba_object.protected_instance_methods(_include_superclass_methods = true).include?(method)
+        return true if @stubba_object.private_instance_methods(_include_superclass_methods = true).include?(method)
         return false
       end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -100,12 +100,12 @@ module Mocha
     def on_stubbing(object, method)
       method = PRE_RUBY_V19 ? method.to_s : method.to_sym
       unless Mocha::Configuration.allow?(:stubbing_non_existent_method)
-        unless object.method_exists?(method, include_public_methods = true)
+        unless object.method_exists?(method, _include_public_methods = true)
           on_stubbing_non_existent_method(object, method)
         end
       end
       unless Mocha::Configuration.allow?(:stubbing_non_public_method)
-        if object.method_exists?(method, include_public_methods = false)
+        if object.method_exists?(method, _include_public_methods = false)
           on_stubbing_non_public_method(object, method)
         end
       end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -162,11 +162,11 @@ module Mocha
     # @private
     def method_exists?(method, include_public_methods = true)
       if include_public_methods
-        return true if public_methods(include_superclass_methods = true).include?(method)
+        return true if public_methods(_include_superclass_methods = true).include?(method)
         return true if respond_to?(method.to_sym)
       end
-      return true if protected_methods(include_superclass_methods = true).include?(method)
-      return true if private_methods(include_superclass_methods = true).include?(method)
+      return true if protected_methods(_include_superclass_methods = true).include?(method)
+      return true if private_methods(_include_superclass_methods = true).include?(method)
       return false
     end
 

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -359,8 +359,8 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_be_in_correct_order_if_all_ordering_constraints_allow_invocation_now
-    constraint_one = FakeConstraint.new(allows_invocation_now = true)
-    constraint_two = FakeConstraint.new(allows_invocation_now = true)
+    constraint_one = FakeConstraint.new(_allows_invocation_now = true)
+    constraint_two = FakeConstraint.new(_allows_invocation_now = true)
     expectation = Expectation.new(nil, :method_one)
     expectation.add_ordering_constraint(constraint_one)
     expectation.add_ordering_constraint(constraint_two)
@@ -368,8 +368,8 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_not_be_in_correct_order_if_one_ordering_constraint_does_not_allow_invocation_now
-    constraint_one = FakeConstraint.new(allows_invocation_now = true)
-    constraint_two = FakeConstraint.new(allows_invocation_now = false)
+    constraint_one = FakeConstraint.new(_allows_invocation_now = true)
+    constraint_two = FakeConstraint.new(_allows_invocation_now = false)
     expectation = Expectation.new(nil, :method_one)
     expectation.add_ordering_constraint(constraint_one)
     expectation.add_ordering_constraint(constraint_two)
@@ -377,8 +377,8 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_match_if_all_ordering_constraints_allow_invocation_now
-    constraint_one = FakeConstraint.new(allows_invocation_now = true)
-    constraint_two = FakeConstraint.new(allows_invocation_now = true)
+    constraint_one = FakeConstraint.new(_allows_invocation_now = true)
+    constraint_two = FakeConstraint.new(_allows_invocation_now = true)
     expectation = Expectation.new(nil, :method_one)
     expectation.add_ordering_constraint(constraint_one)
     expectation.add_ordering_constraint(constraint_two)
@@ -386,8 +386,8 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_not_match_if_one_ordering_constraints_does_not_allow_invocation_now
-    constraint_one = FakeConstraint.new(allows_invocation_now = true)
-    constraint_two = FakeConstraint.new(allows_invocation_now = false)
+    constraint_one = FakeConstraint.new(_allows_invocation_now = true)
+    constraint_two = FakeConstraint.new(_allows_invocation_now = false)
     expectation = Expectation.new(nil, :method_one)
     expectation.add_ordering_constraint(constraint_one)
     expectation.add_ordering_constraint(constraint_two)


### PR DESCRIPTION
Ruby 2.5 warns stricter about unused variables (since r59585).
So here's a fix.