### PR TITLE
move minitest to the correct namespace

### DIFF
--- a/lib/mocha/mini_test.rb
+++ b/lib/mocha/mini_test.rb
@@ -1,3 +1,2 @@
-require "mocha/integration/mini_test"
-
-Mocha::Integration::MiniTest.activate
+warn "Require mocha/minitest instead of mocha/mini_test"
+require 'mocha/mini_test'

--- a/lib/mocha/minitest.rb
+++ b/lib/mocha/minitest.rb
@@ -1,0 +1,3 @@
+require "mocha/integration/mini_test"
+
+Mocha::Integration::MiniTest.activate


### PR DESCRIPTION
had to open the gem to figure out why `require 'mocha/minitest'` did not work :(
... just a quickfix, proper move should happen in the next major release ...

@floehopper 