### PR TITLE
Rename mocha/mini_test.rb to mocha/minitest.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require 'mocha/test_unit'
 require 'rubygems'
 gem 'mocha'
 require 'minitest/unit'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 ```
 
 #### Bundler
@@ -59,7 +59,7 @@ gem "mocha"
 
 # Elsewhere after Bundler has loaded gems e.g. after `require 'bundler/setup'`
 require "minitest/unit"
-require "mocha/mini_test"
+require "mocha/minitest"
 ```
 
 #### Rails
@@ -73,7 +73,7 @@ If you're loading Mocha using Bundler within a Rails application, you should set
 gem 'mocha'
 
 # At bottom of test_helper.rb (or at least after `require 'rails/test_help'`)
-require 'mocha/mini_test'
+require 'mocha/minitest'
 ```
 
 ##### RSpec
@@ -104,7 +104,7 @@ Note: As of version 0.9.8, the Mocha plugin is not automatically setup at plugin
 
 ```ruby
 # At bottom of test_helper.rb (or at least after `require 'rails/test_help'`)
-require 'mocha/mini_test'
+require 'mocha/minitest'
 ```
 
 #### Known Issues

--- a/lib/mocha/mini_test.rb
+++ b/lib/mocha/mini_test.rb
@@ -1,3 +1,5 @@
-require "mocha/integration/mini_test"
+require 'mocha/deprecation'
 
-Mocha::Integration::MiniTest.activate
+Mocha::Deprecation.warning("`require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.")
+
+require 'mocha/minitest'

--- a/lib/mocha/minitest.rb
+++ b/lib/mocha/minitest.rb
@@ -1,0 +1,3 @@
+require "mocha/integration/mini_test"
+
+Mocha::Integration::MiniTest.activate

--- a/test/integration/mini_test_test.rb
+++ b/test/integration/mini_test_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../../test_helper', __FILE__)
 
-require "mocha/mini_test"
+require "mocha/minitest"
 require "integration/shared_tests"
 
 class MiniTestTest < Mocha::TestCase


### PR DESCRIPTION
* Deprecate requiring 'mocha/mini_test'
* Update documentation in `README.md`