### PR TITLE
Define respond_to_missing? on Mocha::Mock

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -9,6 +9,7 @@ require 'mocha/unexpected_invocation'
 require 'mocha/argument_iterator'
 require 'mocha/expectation_error_factory'
 require 'mocha/deprecation'
+require 'mocha/ruby_version'
 
 module Mocha
 
@@ -314,7 +315,7 @@ module Mocha
     end
 
     # @private
-    def respond_to?(symbol, include_private = false)
+    def respond_to_missing?(symbol, include_private = false)
       if @responder then
         if @responder.method(:respond_to?).arity > 1
           @responder.respond_to?(symbol, include_private)
@@ -323,6 +324,13 @@ module Mocha
         end
       else
         @everything_stubbed || all_expectations.matches_method?(symbol)
+      end
+    end
+
+    # @private
+    if PRE_RUBY_V19
+      def respond_to?(symbol, include_private = false)
+        respond_to_missing?(symbol, include_private)
       end
     end
 

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -334,6 +334,14 @@ class MockTest < Mocha::TestCase
     assert_match(/unexpected invocation/, e.message)
   end
 
+  unless PRE_RUBY_V19
+    def test_expectation_is_defined_on_mock
+      mock = build_mock
+      mock.expects(:method1)
+      assert defined? mock.method1
+    end
+  end
+
   private
 
   def build_mock


### PR DESCRIPTION
Fixes #321.

As of Ruby 2.4, `Forwardable` warns when delegating to a private method.
Warnings are shown when delegating methods to a `Mocha::Mock`.

To determine whether to show a warning, Forwardable tests the delegated
method with the `defined?` operator. Mocha uses `method_missing` to respond
to mocked methods. `defined?` uses `respond_to_missing?` to determine
whether or not a missing method is defined. Defining `respond_to_missing?`
on `Mocha::Mock`, in place of `respond_to?`, prevents warnings from being
shown.

To preserve compatibility with Ruby 1.8.7, we continue to conditionally
define `respond_to?`. Prior to Ruby 1.9.3, `defined?` returns `nil` for method
calls handled via `method_missing`, so we also only test that mocked
methods are `defined?` in later Ruby versions.