### PR TITLE
Prevent use of Mocha outside the context of a test/example

### DIFF
--- a/lib/mocha/central.rb
+++ b/lib/mocha/central.rb
@@ -2,6 +2,23 @@ module Mocha
 
   class Central
 
+    class Null < self
+
+      def initialize(&block)
+        super
+        @raise_not_initialized_error = block
+      end
+
+      def stub(*)
+        @raise_not_initialized_error.call
+      end
+
+      def unstub(*)
+        @raise_not_initialized_error.call
+      end
+
+    end
+
     attr_accessor :stubba_methods
 
     def initialize

--- a/lib/mocha/error_with_filtered_backtrace.rb
+++ b/lib/mocha/error_with_filtered_backtrace.rb
@@ -1,0 +1,17 @@
+require 'mocha/backtrace_filter'
+
+module Mocha
+
+  # @private
+  class ErrorWithFilteredBacktrace < StandardError
+
+    # @private
+    def initialize(message = nil, backtrace = [])
+      super(message)
+      filter = BacktraceFilter.new
+      set_backtrace(filter.filtered(backtrace))
+    end
+
+  end
+
+end

--- a/lib/mocha/hooks.rb
+++ b/lib/mocha/hooks.rb
@@ -21,6 +21,7 @@ module Mocha
     #
     # This method should be called before each individual test starts (including before any "setup" code).
     def mocha_setup
+      Mockery.setup
     end
 
     # Verifies that all mock expectations have been met (only for use by authors of test libraries).

--- a/lib/mocha/hooks.rb
+++ b/lib/mocha/hooks.rb
@@ -38,8 +38,6 @@ module Mocha
     # This method should be called after each individual test has finished (including after any "teardown" code).
     def mocha_teardown
       Mockery.teardown
-    ensure
-      Mockery.reset_instance
     end
   end
 end

--- a/lib/mocha/integration/mini_test/version_13.rb
+++ b/lib/mocha/integration/mini_test/version_13.rb
@@ -25,6 +25,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.__send__ self.name
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/mini_test/version_140.rb
+++ b/lib/mocha/integration/mini_test/version_140.rb
@@ -25,6 +25,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.__send__ self.__name__
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/mini_test/version_141.rb
+++ b/lib/mocha/integration/mini_test/version_141.rb
@@ -31,6 +31,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.__send__ self.__name__
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/mini_test/version_142_to_172.rb
+++ b/lib/mocha/integration/mini_test/version_142_to_172.rb
@@ -31,6 +31,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.__send__ self.__name__
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/mini_test/version_200.rb
+++ b/lib/mocha/integration/mini_test/version_200.rb
@@ -31,6 +31,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.__send__ self.__name__
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/mini_test/version_201_to_222.rb
+++ b/lib/mocha/integration/mini_test/version_201_to_222.rb
@@ -31,6 +31,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.__send__ self.__name__
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/mini_test/version_2110_to_2111.rb
+++ b/lib/mocha/integration/mini_test/version_2110_to_2111.rb
@@ -32,6 +32,7 @@ module Mocha
               begin
                 @passed = nil
                 self.before_setup
+                mocha_setup
                 self.setup
                 self.after_setup
                 self.run_test self.__name__

--- a/lib/mocha/integration/mini_test/version_2112_to_320.rb
+++ b/lib/mocha/integration/mini_test/version_2112_to_320.rb
@@ -35,6 +35,7 @@ module Mocha
               begin
                 @passed = nil
                 self.before_setup
+                mocha_setup
                 self.setup
                 self.after_setup
                 self.run_test self.__name__

--- a/lib/mocha/integration/mini_test/version_230_to_2101.rb
+++ b/lib/mocha/integration/mini_test/version_230_to_2101.rb
@@ -31,6 +31,7 @@ module Mocha
             begin
               begin
                 @passed = nil
+                mocha_setup
                 self.setup
                 self.run_setup_hooks
                 self.__send__ self.__name__

--- a/lib/mocha/integration/test_unit/gem_version_200.rb
+++ b/lib/mocha/integration/test_unit/gem_version_200.rb
@@ -26,6 +26,7 @@ module Mocha
               yield(Test::Unit::TestCase::STARTED, name)
               begin
                 begin
+                  mocha_setup
                   run_setup
                   __send__(@method_name)
                   mocha_verify(assertion_counter)

--- a/lib/mocha/integration/test_unit/gem_version_201_to_202.rb
+++ b/lib/mocha/integration/test_unit/gem_version_201_to_202.rb
@@ -26,6 +26,7 @@ module Mocha
               yield(Test::Unit::TestCase::STARTED, name)
               begin
                 begin
+                  mocha_setup
                   run_setup
                   run_test
                   mocha_verify(assertion_counter)

--- a/lib/mocha/integration/test_unit/gem_version_203_to_220.rb
+++ b/lib/mocha/integration/test_unit/gem_version_203_to_220.rb
@@ -26,6 +26,7 @@ module Mocha
               yield(Test::Unit::TestCase::STARTED, name)
               begin
                 begin
+                  mocha_setup
                   run_setup
                   run_test
                   mocha_verify(assertion_counter)

--- a/lib/mocha/integration/test_unit/gem_version_230_to_250.rb
+++ b/lib/mocha/integration/test_unit/gem_version_230_to_250.rb
@@ -28,6 +28,7 @@ module Mocha
               yield(Test::Unit::TestCase::STARTED_OBJECT, self)
               begin
                 begin
+                  mocha_setup
                   run_setup
                   run_test
                   run_cleanup

--- a/lib/mocha/integration/test_unit/ruby_version_185_and_below.rb
+++ b/lib/mocha/integration/test_unit/ruby_version_185_and_below.rb
@@ -25,6 +25,7 @@ module Mocha
             @_result = result
             begin
               begin
+                mocha_setup
                 setup
                 __send__(@method_name)
                 mocha_verify(assertion_counter)

--- a/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb
+++ b/lib/mocha/integration/test_unit/ruby_version_186_and_above.rb
@@ -25,6 +25,7 @@ module Mocha
             @_result = result
             begin
               begin
+                mocha_setup
                 setup
                 __send__(@method_name)
                 mocha_verify(assertion_counter)

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -55,9 +55,7 @@ module Mocha
 
       def teardown
         instance.teardown
-      end
-
-      def reset_instance
+      ensure
         @instances.pop
         @instances = nil if instances.empty?
       end

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -7,16 +7,40 @@ require 'mocha/state_machine'
 require 'mocha/logger'
 require 'mocha/configuration'
 require 'mocha/stubbing_error'
+require 'mocha/not_initialized_error'
 require 'mocha/expectation_error_factory'
 
 module Mocha
 
   class Mockery
 
+    class Null < self
+
+      def add_mock(*)
+        raise_not_initialized_error
+      end
+
+      def add_state_machine(*)
+        raise_not_initialized_error
+      end
+
+      def stubba
+        Central::Null.new(&method(:raise_not_initialized_error))
+      end
+
+      private
+
+      def raise_not_initialized_error
+        message = 'Mocha methods cannot be used outside the context of a test'
+        raise NotInitializedError.new(message, caller)
+      end
+
+    end
+
     class << self
 
       def instance
-        instances.last
+        instances.last || Null.new
       end
 
       def setup
@@ -35,6 +59,7 @@ module Mocha
 
       def reset_instance
         @instances.pop
+        @instances = nil if instances.empty?
       end
 
       private

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -16,7 +16,13 @@ module Mocha
     class << self
 
       def instance
-        @instance ||= new
+        instances.last
+      end
+
+      def setup
+        mockery = new
+        mockery.logger = instance.logger unless instances.empty?
+        @instances.push(mockery)
       end
 
       def verify(*args)
@@ -28,7 +34,13 @@ module Mocha
       end
 
       def reset_instance
-        @instance = nil
+        @instances.pop
+      end
+
+      private
+
+      def instances
+        @instances ||= []
       end
 
     end

--- a/lib/mocha/not_initialized_error.rb
+++ b/lib/mocha/not_initialized_error.rb
@@ -1,18 +1,9 @@
-require 'mocha/backtrace_filter'
+require 'mocha/error_with_filtered_backtrace'
 
 module Mocha
 
   # Exception raised when Mocha has not been initialized, e.g. outside the
   # context of a test.
-  class NotInitializedError < StandardError
-
-    # @private
-    def initialize(message = nil, backtrace = [])
-      super(message)
-      filter = BacktraceFilter.new
-      set_backtrace(filter.filtered(backtrace))
-    end
-
-  end
+  class NotInitializedError < ErrorWithFilteredBacktrace; end
 
 end

--- a/lib/mocha/not_initialized_error.rb
+++ b/lib/mocha/not_initialized_error.rb
@@ -1,0 +1,18 @@
+require 'mocha/backtrace_filter'
+
+module Mocha
+
+  # Exception raised when Mocha has not been initialized, e.g. outside the
+  # context of a test.
+  class NotInitializedError < StandardError
+
+    # @private
+    def initialize(message = nil, backtrace = [])
+      super(message)
+      filter = BacktraceFilter.new
+      set_backtrace(filter.filtered(backtrace))
+    end
+
+  end
+
+end

--- a/lib/mocha/stubbing_error.rb
+++ b/lib/mocha/stubbing_error.rb
@@ -1,19 +1,10 @@
-require 'mocha/backtrace_filter'
+require 'mocha/error_with_filtered_backtrace'
 
 module Mocha
 
   # Exception raised when stubbing a particular method is not allowed.
   #
   # @see Configuration.prevent
-  class StubbingError < StandardError
-
-    # @private
-    def initialize(message = nil, backtrace = [])
-      super(message)
-      filter = BacktraceFilter.new
-      set_backtrace(filter.filtered(backtrace))
-    end
-
-  end
+  class StubbingError < ErrorWithFilteredBacktrace; end
 
 end

--- a/test/acceptance/acceptance_test_helper.rb
+++ b/test/acceptance/acceptance_test_helper.rb
@@ -27,13 +27,11 @@ module AcceptanceTest
     Mocha::Configuration.reset_configuration
     @logger = FakeLogger.new
     mockery = Mocha::Mockery.instance
-    @original_logger = mockery.logger
     mockery.logger = @logger
   end
 
   def teardown_acceptance_test
     Mocha::Configuration.reset_configuration
-    Mocha::Mockery.instance.logger = @original_logger
   end
 
   include Introspection::Assertions

--- a/test/acceptance/prevent_use_of_mocha_outside_test_test.rb
+++ b/test/acceptance/prevent_use_of_mocha_outside_test_test.rb
@@ -8,7 +8,7 @@ class PreventUseOfMochaOutsideTestTest < Mocha::TestCase
 
   def setup
     setup_acceptance_test
-    Mocha::Mockery.reset_instance
+    mocha_teardown
   end
 
   def teardown

--- a/test/acceptance/prevent_use_of_mocha_outside_test_test.rb
+++ b/test/acceptance/prevent_use_of_mocha_outside_test_test.rb
@@ -1,0 +1,79 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+require 'mocha/setup'
+require 'mocha/not_initialized_error'
+
+class PreventUseOfMochaOutsideTestTest < Mocha::TestCase
+
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+    Mocha::Mockery.reset_instance
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_should_raise_exception_when_mock_called_outside_test
+    assert_raises(Mocha::NotInitializedError) { mock('object') }
+  end
+
+  def test_should_raise_exception_when_stub_called_outside_test
+    assert_raises(Mocha::NotInitializedError) { stub('object') }
+  end
+
+  def test_should_raise_exception_when_stub_everything_called_outside_test
+    assert_raises(Mocha::NotInitializedError) { stub_everything('object') }
+  end
+
+  def test_should_raise_exception_when_states_called_outside_test
+    assert_raises(Mocha::NotInitializedError) { states('state-machine') }
+  end
+
+  def test_should_raise_exception_when_expects_called_on_instance_outside_test
+    instance = Class.new.new
+    assert_raises(Mocha::NotInitializedError) { instance.expects(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_expects_called_on_class_outside_test
+    klass = Class.new
+    assert_raises(Mocha::NotInitializedError) { klass.expects(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_expects_called_on_any_instance_outside_test
+    klass = Class.new
+    assert_raises(Mocha::NotInitializedError) { klass.any_instance.expects(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_stubs_called_on_instance_outside_test
+    instance = Class.new.new
+    assert_raises(Mocha::NotInitializedError) { instance.stubs(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_stubs_called_on_class_outside_test
+    klass = Class.new
+    assert_raises(Mocha::NotInitializedError) { klass.stubs(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_stubs_called_on_any_instance_outside_test
+    klass = Class.new
+    assert_raises(Mocha::NotInitializedError) { klass.any_instance.stubs(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_unstub_called_on_instance_outside_test
+    instance = Class.new.new
+    assert_raises(Mocha::NotInitializedError) { instance.unstub(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_unstub_called_on_class_outside_test
+    klass = Class.new
+    assert_raises(Mocha::NotInitializedError) { klass.unstub(:expected_method) }
+  end
+
+  def test_should_raise_exception_when_unstub_called_on_any_instance_outside_test
+    klass = Class.new
+    assert_raises(Mocha::NotInitializedError) { klass.any_instance.unstub(:expected_method) }
+  end
+
+end

--- a/test/unit/hooks_test.rb
+++ b/test/unit/hooks_test.rb
@@ -4,7 +4,7 @@ require 'mocha/hooks'
 class HooksTest < Mocha::TestCase
   class Mocha::Mockery
     class << self
-      attr_writer :instance
+      attr_writer :instances
     end
   end
 
@@ -19,11 +19,11 @@ class HooksTest < Mocha::TestCase
 
   def test_ensure_mockery_instance_is_reset_even_when_an_exception_is_raised_in_mockery_teardown
     fake_test_case = Object.new.extend(Mocha::Hooks)
-    original_mockery = FakeMockery.new
-    Mocha::Mockery.instance = original_mockery
+    mockery = FakeMockery.new
+    Mocha::Mockery.instances = [mockery]
 
     fake_test_case.mocha_teardown rescue nil
 
-    assert_not_same Mocha::Mockery.instance, original_mockery
+    assert_nil Mocha::Mockery.instance
   end
 end

--- a/test/unit/hooks_test.rb
+++ b/test/unit/hooks_test.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/hooks'
+require 'mocha/mockery'
 
 class HooksTest < Mocha::TestCase
   class Mocha::Mockery
@@ -24,6 +25,6 @@ class HooksTest < Mocha::TestCase
 
     fake_test_case.mocha_teardown rescue nil
 
-    assert_nil Mocha::Mockery.instance
+    assert_kind_of Mocha::Mockery::Null, Mocha::Mockery.instance
   end
 end

--- a/test/unit/mockery_test.rb
+++ b/test/unit/mockery_test.rb
@@ -17,6 +17,13 @@ class MockeryTest < Mocha::TestCase
     Mockery.reset_instance
   end
 
+  def test_should_return_null_mockery_if_not_setup
+    Mockery.reset_instance
+    mockery = Mockery.instance
+    assert_not_nil mockery
+    assert_kind_of Mockery::Null, mockery
+  end
+
   def test_should_return_instance_of_mockery
     mockery = Mockery.instance
     assert_not_nil mockery

--- a/test/unit/mockery_test.rb
+++ b/test/unit/mockery_test.rb
@@ -9,7 +9,15 @@ class MockeryTest < Mocha::TestCase
   include Mocha
   include DeprecationDisabler
 
-  def test_should_build_instance_of_mockery
+  def setup
+    Mockery.setup
+  end
+
+  def teardown
+    Mockery.reset_instance
+  end
+
+  def test_should_return_instance_of_mockery
     mockery = Mockery.instance
     assert_not_nil mockery
     assert_kind_of Mockery, mockery

--- a/test/unit/mockery_test.rb
+++ b/test/unit/mockery_test.rb
@@ -14,11 +14,11 @@ class MockeryTest < Mocha::TestCase
   end
 
   def teardown
-    Mockery.reset_instance
+    Mockery.teardown
   end
 
   def test_should_return_null_mockery_if_not_setup
-    Mockery.reset_instance
+    Mockery.teardown
     mockery = Mockery.instance
     assert_not_nil mockery
     assert_kind_of Mockery::Null, mockery
@@ -38,7 +38,7 @@ class MockeryTest < Mocha::TestCase
 
   def test_should_expire_mockery_instance_cache
     mockery_1 = Mockery.instance
-    Mockery.reset_instance
+    Mockery.teardown
     mockery_2 = Mockery.instance
     assert_not_same mockery_1, mockery_2
   end

--- a/test/unit/object_methods_test.rb
+++ b/test/unit/object_methods_test.rb
@@ -1,12 +1,18 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/object_methods'
+require 'mocha/mockery'
 require 'mocha/mock'
 require 'mocha/expectation_error_factory'
 
 class ObjectMethodsTest < Mocha::TestCase
 
   def setup
+    Mocha::Mockery.setup
     @object = Object.new.extend(Mocha::ObjectMethods)
+  end
+
+  def teardown
+    Mocha::Mockery.reset_instance
   end
 
   def test_should_build_mocha_referring_to_self

--- a/test/unit/object_methods_test.rb
+++ b/test/unit/object_methods_test.rb
@@ -12,7 +12,7 @@ class ObjectMethodsTest < Mocha::TestCase
   end
 
   def teardown
-    Mocha::Mockery.reset_instance
+    Mocha::Mockery.teardown
   end
 
   def test_should_build_mocha_referring_to_self


### PR DESCRIPTION
This change means that any attempt to use Mocha outside the context of a test or example will result in a `Mocha::NotInitializedError` being raised with the following message: "Mocha methods cannot be used outside the context of a test".

Fixes #292
Fixes #293 (indirectly)
Supersedes #319