### PR TITLE
Avoid mocks for partial mocking leaking into subsequent tests

### DIFF
--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -19,8 +19,12 @@ module Mocha
         @stubba_object = klass
       end
 
-      def mocha
-        @mocha ||= Mocha::Mockery.instance.mock_impersonating_any_instance_of(@stubba_object)
+      def mocha(instantiate = true)
+        if instantiate
+          @mocha ||= Mocha::Mockery.instance.mock_impersonating_any_instance_of(@stubba_object)
+        else
+          defined?(@mocha) ? @mocha : nil
+        end
       end
 
       def stubba_method

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -14,8 +14,12 @@ module Mocha
     alias_method :_method, :method
 
     # @private
-    def mocha
-      @mocha ||= Mocha::Mockery.instance.mock_impersonating(self)
+    def mocha(instantiate = true)
+      if instantiate
+        @mocha ||= Mocha::Mockery.instance.mock_impersonating(self)
+      else
+        defined?(@mocha) ? @mocha : nil
+      end
     end
 
     # @private

--- a/lib/mocha/receivers.rb
+++ b/lib/mocha/receivers.rb
@@ -9,7 +9,8 @@ module Mocha
     def mocks
       object, mocks = @object, []
       while object do
-        mocks << object.mocha
+        mocha = object.mocha(false)
+        mocks << mocha if mocha
         object = object.is_a?(Class) ? object.superclass : nil
       end
       mocks
@@ -26,7 +27,8 @@ module Mocha
     def mocks
       klass, mocks = @klass, []
       while klass do
-        mocks << klass.any_instance.mocha
+        mocha = klass.any_instance.mocha(false)
+        mocks << mocha if mocha
         klass = klass.superclass
       end
       mocks

--- a/test/acceptance/stub_any_instance_method_defined_on_superclass_test.rb
+++ b/test/acceptance/stub_any_instance_method_defined_on_superclass_test.rb
@@ -31,4 +31,34 @@ class StubAnyInstanceMethodDefinedOnSuperclassTest < Mocha::TestCase
     end
     assert_equal :original_return_value, instance.my_superclass_method
   end
+
+  def test_expect_method_on_any_instance_of_superclass_even_if_preceded_by_test_expecting_method_on_any_instance_of_subclass
+    superklass = Class.new do
+      def self.inspect
+        'superklass'
+      end
+      def my_instance_method; end
+    end
+    klass = Class.new(superklass) do
+      def self.inspect
+        'klass'
+      end
+      def my_instance_method; end
+    end
+    test_result = run_as_tests(
+      :test_1 => lambda {
+        klass.any_instance.expects(:my_instance_method)
+        klass.new.my_instance_method
+      },
+      :test_2 => lambda {
+        superklass.any_instance.expects(:my_instance_method)
+      }
+    )
+    assert_failed(test_result)
+    assert_equal [
+      "not all expectations were satisfied",
+      "unsatisfied expectations:",
+      "- expected exactly once, not yet invoked: #<AnyInstance:superklass>.my_instance_method(any_parameters)"
+    ], test_result.failure_message_lines
+  end
 end

--- a/test/unit/class_methods_test.rb
+++ b/test/unit/class_methods_test.rb
@@ -1,11 +1,18 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/class_methods'
 require 'mocha/object_methods'
+require 'mocha/mockery'
+require 'mocha/names'
 
 class ClassMethodsTest < Mocha::TestCase
 
   def setup
+    Mocha::Mockery.setup
     @klass = Class.new.extend(Mocha::ClassMethods, Mocha::ObjectMethods)
+  end
+
+  def teardown
+    Mocha::Mockery.teardown
   end
 
   def test_should_build_any_instance_object
@@ -18,6 +25,30 @@ class ClassMethodsTest < Mocha::TestCase
     any_instance_1 = @klass.any_instance
     any_instance_2 = @klass.any_instance
     assert_equal any_instance_1, any_instance_2
+  end
+
+  def test_any_instance_should_build_mocha_referring_to_klass
+    mocha = @klass.any_instance.mocha
+    assert_not_nil mocha
+    assert mocha.is_a?(Mocha::Mock)
+    expected_name = Mocha::ImpersonatingAnyInstanceName.new(@klass).mocha_inspect
+    assert_equal expected_name, mocha.mocha_inspect
+  end
+
+  def test_any_instance_should_not_build_mocha_if_instantiate_is_false
+    assert_nil @klass.any_instance.mocha(false)
+  end
+
+  def test_any_instance_should_reuse_existing_mocha
+    mocha_1 = @klass.any_instance.mocha
+    mocha_2 = @klass.any_instance.mocha
+    assert_equal mocha_1, mocha_2
+  end
+
+  def test_any_instance_should_reuse_existing_mocha_even_if_instantiate_is_false
+    mocha_1 = @klass.any_instance.mocha
+    mocha_2 = @klass.any_instance.mocha(false)
+    assert_equal mocha_1, mocha_2
   end
 
   def test_should_use_stubba_class_method_for_class

--- a/test/unit/object_methods_test.rb
+++ b/test/unit/object_methods_test.rb
@@ -3,6 +3,7 @@ require 'mocha/object_methods'
 require 'mocha/mockery'
 require 'mocha/mock'
 require 'mocha/expectation_error_factory'
+require 'mocha/names'
 
 class ObjectMethodsTest < Mocha::TestCase
 
@@ -19,12 +20,23 @@ class ObjectMethodsTest < Mocha::TestCase
     mocha = @object.mocha
     assert_not_nil mocha
     assert mocha.is_a?(Mocha::Mock)
-    assert_equal @object.mocha_inspect, mocha.mocha_inspect
+    expected_name = Mocha::ImpersonatingName.new(@object).mocha_inspect
+    assert_equal expected_name, mocha.mocha_inspect
+  end
+
+  def test_should_not_build_mocha_if_instantiate_is_false
+    assert_nil @object.mocha(false)
   end
 
   def test_should_reuse_existing_mocha
     mocha_1 = @object.mocha
     mocha_2 = @object.mocha
+    assert_equal mocha_1, mocha_2
+  end
+
+  def test_should_reuse_existing_mocha_even_if_instantiate_is_false
+    mocha_1 = @object.mocha
+    mocha_2 = @object.mocha(false)
     assert_equal mocha_1, mocha_2
   end
 

--- a/test/unit/receivers_test.rb
+++ b/test/unit/receivers_test.rb
@@ -4,13 +4,31 @@ require 'mocha/receivers'
 class ObjectReceiverTest < Mocha::TestCase
   include Mocha
 
-  class FakeObject < Struct.new(:mocha)
+  class FakeObject
+    def initialize(mocha)
+      @mocha = mocha
+    end
+
+    def mocha(_)
+      @mocha
+    end
+
     def is_a?(klass)
       false
     end
   end
 
-  class FakeClass < Struct.new(:superclass, :mocha)
+  class FakeClass
+    attr_reader :superclass
+
+    def initialize(superclass, mocha)
+      @superclass, @mocha = superclass, mocha
+    end
+
+    def mocha(_)
+      @mocha
+    end
+
     def is_a?(klass)
       klass == Class
     end
@@ -35,6 +53,16 @@ class AnyInstanceReceiverTest < Mocha::TestCase
   include Mocha
 
   class FakeAnyInstanceClass
+    class AnyInstance
+      def initialize(mocha)
+        @mocha = mocha
+      end
+
+      def mocha(_)
+        @mocha
+      end
+    end
+
     attr_reader :superclass
 
     def initialize(superclass, mocha)
@@ -42,7 +70,7 @@ class AnyInstanceReceiverTest < Mocha::TestCase
     end
 
     def any_instance
-      Struct.new(:mocha).new(@mocha)
+      AnyInstance.new(@mocha)
     end
   end
 


### PR DESCRIPTION
Previously `ObjectMethods#mocha` & `ClassMethods::AnyInstance#mocha` were building mock objects for ancestor classes when `ObjectReceiver#mocks` or `AnyInstanceReceiver#mocks` was called from `Mock#all_expectations` as part of `Mock#method_missing`.

Since these mock objects were not associated with a corresponding `ClassMethod` or `AnyInstanceMethod` registered with `Central` via `Mockery#mock_impersonating` or `Mockery#mock_impersonating_any_instance_of`, they were not being reset as part of `Central#unstub_all` via `Mockery#teardown` and this state was leaking into subsequent tests.

You can see an example of this in #298. I've captured a more general case of this in the new acceptance test method in `StubAnyInstanceMethodDefinedOnSuperclassTest` which was failing before the fix in this commit.

I've also added a similar acceptance test method to `StubClassMethodDefinedOnSuperclassTest` which was also failing before the fix in this commit.

I'm not particularly happy with the fix, but I think it'll do for now.