### PR TITLE
Use Kernel#warn for deprecations

### DIFF
--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -13,7 +13,7 @@ module Mocha
         unless mode == :disabled
           filter = BacktraceFilter.new
           location = filter.filtered(caller)[0]
-          $stderr.puts "Mocha deprecation warning at #{location}: #{message}"
+          warn "Mocha deprecation warning at #{location}: #{message}"
         end
       end
 


### PR DESCRIPTION
That makes it possible to override `Warning.warn` starting with Ruby 2.5.0

See more at https://bugs.ruby-lang.org/issues/12299