### PR TITLE
Fix object inspection calling instance methods on object

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -5,7 +5,7 @@ module Mocha
     def mocha_inspect
       address = __id__ * 2
       address += 0x100000000 if address < 0
-      inspect =~ /#</ ? "#<#{self.class}:0x#{format('%x', address)}>" : inspect
+      inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%x', address)}>" : inspect
     end
   end
 

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -49,7 +49,7 @@ class ObjectInspectTest < Mocha::TestCase
   def test_should_not_call_object_instance_methods
     object = Object.new
     class << object
-      def format(*args)
+      def format(*)
         'internal_format'
       end
     end

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -45,4 +45,14 @@ class ObjectInspectTest < Mocha::TestCase
 
     assert_equal [:__id__], calls.uniq
   end
+
+  def test_should_not_call_object_instance_methods
+    object = Object.new
+    class << object
+      def format(*args)
+        'internal_format'
+      end
+    end
+    assert_no_match(/internal_format/, object.mocha_inspect)
+  end
 end


### PR DESCRIPTION
This fixes #342 by calling `Kernel.format` directly when inspecting an object.

I also noticed the same formatting present in `expectation.rb` (line 586) and 'names.rb' (line 40). Since these don't look to be prepended to any objects I'm assuming they're safe as they are but please let me know if that isn't the case.