### PR TITLE
Avoid calling Kernel#format from ObjectMethods#mocha_inspect

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -5,7 +5,7 @@ module Mocha
     def mocha_inspect
       address = __id__ * 2
       address += 0x100000000 if address < 0
-      inspect =~ /#</ ? "#<#{self.class}:0x#{format('%x', address)}>" : inspect
+      inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%x', address)}>" : inspect
     end
   end
 

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -45,4 +45,14 @@ class ObjectInspectTest < Mocha::TestCase
 
     assert_equal [:__id__], calls.uniq
   end
+
+  def test_should_not_call_object_instance_format_method
+    object = Object.new
+    class << object
+      def format(*)
+        'internal_format'
+      end
+    end
+    assert_no_match(/internal_format/, object.mocha_inspect)
+  end
 end


### PR DESCRIPTION
Slightly tweaked version of #343.

Previously setting an expectation on an instance of a class that defined a custom `format` method resulted in incorrect information being displayed or an ArgumentError if the arity of the `format` method was different from `Kernel#format`. By calling `Kernel.format` directly we can avoid this problem.

Fixes #342.