### PR TITLE
Add documentation and tests for mock(:foo)

### DIFF
--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -23,6 +23,7 @@ module Mocha
     #
     # @param [String] name identifies mock object in error messages.
     # @param [Hash] expected_methods_vs_return_values expected method name symbols as keys and corresponding return values as values - these expectations are setup as if {Mock#expects} were called multiple times.
+    # @param [Symbol] expected_method_name name of a method expected to be called once.
     # @yield optional block to be evaluated in the context of the mock object instance, giving an alternative way to setup stubbed methods.
     # @yield note that the block is evaulated by calling Mock#instance_eval and so things like instance variables declared in the test will not be available within the block.
     # @yield deprecated: use Object#tap or define stubs/expectations with an explicit receiver instead.
@@ -30,6 +31,7 @@ module Mocha
     #
     # @overload def mock(name, &block)
     # @overload def mock(expected_methods_vs_return_values = {}, &block)
+    # @overload def mock(expected_method_name, &block)
     # @overload def mock(name, expected_methods_vs_return_values = {}, &block)
     #
     # @example Using expected_methods_vs_return_values Hash to setup expectations.
@@ -38,6 +40,12 @@ module Mocha
     #     assert motor.start
     #     assert motor.stop
     #     # an error will be raised unless both Motor#start and Motor#stop have been called
+    #   end
+    # @example Using expected_method_name to get a mock that expects a single call to a single method
+    #   def test_motor_starts
+    #     motor = mock(:start)
+    #     motor.start
+    #     # an error will be raised if any other methods are called, or if Motor#start is called twice
     #   end
     # @example Using the optional block to setup expectations & stubbed methods [deprecated].
     #   def test_motor_starts_and_stops

--- a/test/acceptance/mock_test.rb
+++ b/test/acceptance/mock_test.rb
@@ -46,6 +46,30 @@ class MockTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
+  def test_build_mock_with_method_name_symbol_which_is_satisfied
+    test_result = run_as_test do
+      foo = mock(:cat)
+      foo.cat
+    end
+    assert_passed(test_result)
+  end
+
+  def test_build_mock_with_method_name_symbol_which_is_not_satisfied
+    test_result = run_as_test do
+      mock(:cat)
+    end
+    assert_failed(test_result)
+  end
+
+  def test_build_mock_with_method_name_symbol_which_is_called_twice
+    test_result = run_as_test do
+      foo = mock(:cat)
+      foo.cat
+      foo.cat
+    end
+    assert_failed(test_result)
+  end
+
   def test_should_build_mock_incorporating_two_expectations_which_are_satisifed
     test_result = run_as_test do
       foo = mock(:bar => 'bar', :baz => 'baz')


### PR DESCRIPTION
Becuse of the implementation of API#mock, it is possible to get a
quick stub by passing a symbol into it.

This commit adds documentation and tests for this usage.

----

I feel maybe this is undocumented until now since maybe this is not a feature we want to support. Feel free to reject this PR if that's the case.