### PR TITLE
Refactor class method and any instance method

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -11,24 +11,6 @@ module Mocha
       stubbee.any_instance.reset_mocha
     end
 
-    def hide_original_method
-      return unless (@original_visibility = method_visibility(method))
-      begin
-        if RUBY_V2_PLUS
-          prepend_module
-        else
-          @original_method = original_method(method)
-          if original_method_defined_on_stubbee?
-            remove_original_method_from_stubbee
-          end
-        end
-      # rubocop:disable Lint/HandleExceptions
-      rescue NameError
-        # deal with nasties like ActiveRecord::Associations::AssociationProxy
-      end
-      # rubocop:enable Lint/HandleExceptions
-    end
-
     def define_new_method
       definition_target.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
         def #{method}(*args, &block)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -18,12 +18,6 @@ module Mocha
       Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
-    def method_visibility
-      (original_method_owner.public_method_defined?(method_name) && :public) ||
-        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
-        (original_method_owner.private_method_defined?(method_name) && :private)
-    end
-
     private
 
     def store_original_method

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -18,7 +18,7 @@ module Mocha
           prepend_module
         else
           @original_method = original_method(method)
-          if @original_method && @original_method.owner == stubbee
+          if original_method_defined_on_stubbee?
             stubbee.send(:remove_method, method)
           end
         end
@@ -56,6 +56,10 @@ module Mocha
 
     def original_method(method)
       stubbee.instance_method(method)
+    end
+
+    def original_method_defined_on_stubbee?
+      @original_method && @original_method.owner == stubbee
     end
 
     def prepend_module

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,7 +14,7 @@ module Mocha
     def restore_original_method
       return if RUBY_V2_PLUS
       return unless original_method_defined_on_stubbee?
-      default_stub_method_owner.send(:define_method, method_name, @original_method)
+      default_stub_method_owner.send(:define_method, method_name, original_method)
       Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
     end
 
@@ -26,12 +26,12 @@ module Mocha
 
     private
 
-    def original_method
-      default_stub_method_owner.instance_method(method_name)
+    def store_original_method
+      @original_method = default_stub_method_owner.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_stub_method_owner
+      original_method && original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -34,10 +34,6 @@ module Mocha
       original_method && original_method.owner == default_stub_method_owner
     end
 
-    def remove_original_method_from_stubbee
-      default_stub_method_owner.send(:remove_method, method_name)
-    end
-
     def stub_method_definition
       method_implementation = <<-CODE
       def #{method_name}(*args, &block)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -38,11 +38,6 @@ module Mocha
       default_stub_method_owner.send(:remove_method, method_name)
     end
 
-    def prepend_module
-      @stub_method_owner = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @stub_method_owner
-    end
-
     def stub_method_definition
       method_implementation = <<-CODE
       def #{method_name}(*args, &block)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -26,7 +26,7 @@ module Mocha
 
     private
 
-    def original_method(method_name)
+    def original_method
       default_stub_method_owner.instance_method(method_name)
     end
 

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,34 +13,34 @@ module Mocha
 
     def restore_original_method
       return if RUBY_V2_PLUS
-      return unless @original_method && @original_method.owner == default_definition_target
-      default_definition_target.send(:define_method, method_name, @original_method)
-      Module.instance_method(@original_visibility).bind(default_definition_target).call(method_name)
+      return unless @original_method && @original_method.owner == default_stub_method_owner
+      default_stub_method_owner.send(:define_method, method_name, @original_method)
+      Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
     end
 
     def method_visibility(method_name)
-      (default_definition_target.public_instance_methods(true).include?(method_name) && :public) ||
-        (default_definition_target.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (default_definition_target.private_instance_methods(true).include?(method_name) && :private)
+      (default_stub_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
+        (default_stub_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (default_stub_method_owner.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
     def original_method(method_name)
-      default_definition_target.instance_method(method_name)
+      default_stub_method_owner.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_definition_target
+      @original_method && @original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee
-      default_definition_target.send(:remove_method, method_name)
+      default_stub_method_owner.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      default_definition_target.__send__ :prepend, @definition_target
+      default_stub_method_owner.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition
@@ -52,7 +52,7 @@ module Mocha
       [method_implementation, __FILE__, __LINE__ - 4]
     end
 
-    def default_definition_target
+    def default_stub_method_owner
       stubbee
     end
   end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -18,7 +18,7 @@ module Mocha
           @definition_target = PrependedModule.new
           stubbee.__send__ :prepend, @definition_target
         else
-          @original_method = stubbee.instance_method(method)
+          @original_method = original_method(method)
           if @original_method && @original_method.owner == stubbee
             stubbee.send(:remove_method, method)
           end
@@ -54,6 +54,10 @@ module Mocha
     end
 
     private
+
+    def original_method(method)
+      stubbee.instance_method(method)
+    end
 
     def definition_target
       @definition_target ||= stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -39,8 +39,8 @@ module Mocha
     end
 
     def prepend_module
-      @definition_target = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @definition_target
+      @stub_method_owner = PrependedModule.new
+      default_stub_method_owner.__send__ :prepend, @stub_method_owner
     end
 
     def stub_method_definition

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -19,9 +19,9 @@ module Mocha
     end
 
     def method_visibility
-      (original_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
-        (original_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (original_method_owner.private_instance_methods(true).include?(method_name) && :private)
+      (original_method_owner.public_method_defined?(method_name) && :public) ||
+        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
+        (original_method_owner.private_method_defined?(method_name) && :private)
     end
 
     private

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -18,7 +18,7 @@ module Mocha
       Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
     end
 
-    def method_visibility(method_name)
+    def method_visibility
       (default_stub_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
         (default_stub_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
         (default_stub_method_owner.private_instance_methods(true).include?(method_name) && :private)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -52,10 +52,6 @@ module Mocha
       [method_implementation, __FILE__, __LINE__ - 4]
     end
 
-    def definition_target
-      @definition_target ||= default_definition_target
-    end
-
     def default_definition_target
       stubbee
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,7 +13,7 @@ module Mocha
 
     def restore_original_method
       return if use_prepended_module_for_stub_method?
-      return unless original_method_defined_on_stubbee?
+      return unless stub_method_overwrites_original_method?
       default_stub_method_owner.send(:define_method, method_name, original_method)
       Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -19,7 +19,7 @@ module Mocha
         else
           @original_method = original_method(method)
           if original_method_defined_on_stubbee?
-            stubbee.send(:remove_method, method)
+            remove_original_method_from_stubbee
           end
         end
       # rubocop:disable Lint/HandleExceptions
@@ -60,6 +60,10 @@ module Mocha
 
     def original_method_defined_on_stubbee?
       @original_method && @original_method.owner == stubbee
+    end
+
+    def remove_original_method_from_stubbee
+      stubbee.send(:remove_method, method)
     end
 
     def prepend_module

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -40,10 +40,6 @@ module Mocha
       Module.instance_method(@original_visibility).bind(definition_target).call(method)
     end
 
-    def remove_new_method
-      definition_target.send(:remove_method, method)
-    end
-
     def restore_original_method
       return if RUBY_V2_PLUS
       return unless @original_method && @original_method.owner == stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -30,10 +30,6 @@ module Mocha
       @original_method = default_stub_method_owner.instance_method(method_name)
     end
 
-    def original_method_defined_on_stubbee?
-      original_method && original_method.owner == default_stub_method_owner
-    end
-
     def stub_method_definition
       method_implementation = <<-CODE
       def #{method_name}(*args, &block)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,34 +13,34 @@ module Mocha
 
     def restore_original_method
       return if RUBY_V2_PLUS
-      return unless @original_method && @original_method.owner == stubbee
-      stubbee.send(:define_method, method_name, @original_method)
-      Module.instance_method(@original_visibility).bind(stubbee).call(method_name)
+      return unless @original_method && @original_method.owner == default_definition_target
+      default_definition_target.send(:define_method, method_name, @original_method)
+      Module.instance_method(@original_visibility).bind(default_definition_target).call(method_name)
     end
 
     def method_visibility(method_name)
-      (stubbee.public_instance_methods(true).include?(method_name) && :public) ||
-        (stubbee.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (stubbee.private_instance_methods(true).include?(method_name) && :private)
+      (default_definition_target.public_instance_methods(true).include?(method_name) && :public) ||
+        (default_definition_target.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (default_definition_target.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
     def original_method(method_name)
-      stubbee.instance_method(method_name)
+      default_definition_target.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == stubbee
+      @original_method && @original_method.owner == default_definition_target
     end
 
     def remove_original_method_from_stubbee
-      stubbee.send(:remove_method, method_name)
+      default_definition_target.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      stubbee.__send__ :prepend, @definition_target
+      default_definition_target.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,20 +14,20 @@ module Mocha
     def restore_original_method
       return if use_prepended_module_for_stub_method?
       return unless stub_method_overwrites_original_method?
-      default_stub_method_owner.send(:define_method, method_name, original_method)
-      Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
+      original_method_owner.send(:define_method, method_name, original_method)
+      Module.instance_method(@original_visibility).bind(original_method_owner).call(method_name)
     end
 
     def method_visibility
-      (default_stub_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
-        (default_stub_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
-        (default_stub_method_owner.private_instance_methods(true).include?(method_name) && :private)
+      (original_method_owner.public_instance_methods(true).include?(method_name) && :public) ||
+        (original_method_owner.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (original_method_owner.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
     def store_original_method
-      @original_method = default_stub_method_owner.instance_method(method_name)
+      @original_method = original_method_owner.instance_method(method_name)
     end
 
     def stub_method_definition
@@ -39,7 +39,7 @@ module Mocha
       [method_implementation, __FILE__, __LINE__ - 4]
     end
 
-    def default_stub_method_owner
+    def original_method_owner
       stubbee
     end
   end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,7 +15,7 @@ module Mocha
       return if use_prepended_module_for_stub_method?
       return unless stub_method_overwrites_original_method?
       original_method_owner.send(:define_method, method_name, original_method)
-      Module.instance_method(@original_visibility).bind(original_method_owner).call(method_name)
+      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
     def method_visibility

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -12,7 +12,7 @@ module Mocha
     end
 
     def restore_original_method
-      return if RUBY_V2_PLUS
+      return if use_prepended_module_for_stub_method?
       return unless original_method_defined_on_stubbee?
       default_stub_method_owner.send(:define_method, method_name, original_method)
       Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -53,7 +53,11 @@ module Mocha
     end
 
     def definition_target
-      @definition_target ||= stubbee
+      @definition_target ||= default_definition_target
+    end
+
+    def default_definition_target
+      stubbee
     end
   end
 end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,20 +14,20 @@ module Mocha
     def restore_original_method
       return if RUBY_V2_PLUS
       return unless @original_method && @original_method.owner == stubbee
-      stubbee.send(:define_method, method, @original_method)
-      Module.instance_method(@original_visibility).bind(stubbee).call(method)
+      stubbee.send(:define_method, method_name, @original_method)
+      Module.instance_method(@original_visibility).bind(stubbee).call(method_name)
     end
 
-    def method_visibility(method)
-      (stubbee.public_instance_methods(true).include?(method) && :public) ||
-        (stubbee.protected_instance_methods(true).include?(method) && :protected) ||
-        (stubbee.private_instance_methods(true).include?(method) && :private)
+    def method_visibility(method_name)
+      (stubbee.public_instance_methods(true).include?(method_name) && :public) ||
+        (stubbee.protected_instance_methods(true).include?(method_name) && :protected) ||
+        (stubbee.private_instance_methods(true).include?(method_name) && :private)
     end
 
     private
 
-    def original_method(method)
-      stubbee.instance_method(method)
+    def original_method(method_name)
+      stubbee.instance_method(method_name)
     end
 
     def original_method_defined_on_stubbee?
@@ -35,7 +35,7 @@ module Mocha
     end
 
     def remove_original_method_from_stubbee
-      stubbee.send(:remove_method, method)
+      stubbee.send(:remove_method, method_name)
     end
 
     def prepend_module
@@ -45,8 +45,8 @@ module Mocha
 
     def stub_method_definition
       method_implementation = <<-CODE
-      def #{method}(*args, &block)
-        self.class.any_instance.mocha.method_missing(:#{method}, *args, &block)
+      def #{method_name}(*args, &block)
+        self.class.any_instance.mocha.method_missing(:#{method_name}, *args, &block)
       end
       CODE
       [method_implementation, __FILE__, __LINE__ - 4]

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,7 +13,7 @@ module Mocha
 
     def restore_original_method
       return if RUBY_V2_PLUS
-      return unless @original_method && @original_method.owner == default_stub_method_owner
+      return unless original_method_defined_on_stubbee?
       default_stub_method_owner.send(:define_method, method_name, @original_method)
       Module.instance_method(@original_visibility).bind(default_stub_method_owner).call(method_name)
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -11,12 +11,6 @@ module Mocha
       stubbee.any_instance.reset_mocha
     end
 
-    def define_new_method
-      definition_target.class_eval(*stub_method_definition)
-      return unless @original_visibility
-      Module.instance_method(@original_visibility).bind(definition_target).call(method)
-    end
-
     def restore_original_method
       return if RUBY_V2_PLUS
       return unless @original_method && @original_method.owner == stubbee

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,8 +15,7 @@ module Mocha
       return unless (@original_visibility = method_visibility(method))
       begin
         if RUBY_V2_PLUS
-          @definition_target = PrependedModule.new
-          stubbee.__send__ :prepend, @definition_target
+          prepend_module
         else
           @original_method = original_method(method)
           if @original_method && @original_method.owner == stubbee
@@ -57,6 +56,11 @@ module Mocha
 
     def original_method(method)
       stubbee.instance_method(method)
+    end
+
+    def prepend_module
+      @definition_target = PrependedModule.new
+      stubbee.__send__ :prepend, @definition_target
     end
 
     def definition_target

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -36,7 +36,7 @@ module Mocha
     end
 
     def hide_original_method
-      return unless (@original_visibility = method_visibility(method_name))
+      return unless (@original_visibility = method_visibility)
       if use_prepended_module_for_stub_method?
         use_prepended_module_for_stub_method
       else
@@ -90,7 +90,7 @@ module Mocha
       "#{stubbee}.#{method_name}"
     end
 
-    def method_visibility(method_name)
+    def method_visibility
       symbol = method_name.to_sym
       metaclass = default_stub_method_owner
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -39,8 +39,7 @@ module Mocha
       return unless (@original_visibility = method_visibility(method))
       begin
         if RUBY_V2_PLUS
-          @definition_target = PrependedModule.new
-          stubbee.__metaclass__.__send__ :prepend, @definition_target
+          prepend_module
         else
           @original_method = original_method(method)
           if @original_method && @original_method.owner == stubbee.__metaclass__
@@ -108,6 +107,11 @@ module Mocha
 
     def original_method(method)
       stubbee._method(method)
+    end
+
+    def prepend_module
+      @definition_target = PrependedModule.new
+      stubbee.__metaclass__.__send__ :prepend, @definition_target
     end
 
     def definition_target

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -39,7 +39,7 @@ module Mocha
       return unless (@original_visibility = method_visibility(method_name))
       begin
         if RUBY_V2_PLUS
-          prepend_module
+          use_prepended_module_for_stub_method
         else
           @original_method = original_method(method_name)
           if original_method_defined_on_stubbee?
@@ -113,7 +113,7 @@ module Mocha
       default_stub_method_owner.send(:remove_method, method_name)
     end
 
-    def prepend_module
+    def use_prepended_module_for_stub_method
       @stub_method_owner = PrependedModule.new
       default_stub_method_owner.__send__ :prepend, @stub_method_owner
     end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -65,14 +65,14 @@ module Mocha
 
     def restore_original_method
       return if RUBY_V2_PLUS
-      if @original_method && @original_method.owner == default_definition_target
+      if @original_method && @original_method.owner == default_stub_method_owner
         if PRE_RUBY_V19
           original_method = @original_method
-          default_definition_target.send(:define_method, method_name) do |*args, &block|
+          default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
             original_method.call(*args, &block)
           end
         else
-          default_definition_target.send(:define_method, method_name, @original_method)
+          default_stub_method_owner.send(:define_method, method_name, @original_method)
         end
       end
       return unless @original_visibility
@@ -92,7 +92,7 @@ module Mocha
 
     def method_visibility(method_name)
       symbol = method_name.to_sym
-      metaclass = default_definition_target
+      metaclass = default_stub_method_owner
 
       (metaclass.public_method_defined?(symbol) && :public) ||
         (metaclass.protected_method_defined?(symbol) && :protected) ||
@@ -106,16 +106,16 @@ module Mocha
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_definition_target
+      @original_method && @original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee
-      default_definition_target.send(:remove_method, method_name)
+      default_stub_method_owner.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      default_definition_target.__send__ :prepend, @definition_target
+      default_stub_method_owner.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition
@@ -128,10 +128,10 @@ module Mocha
     end
 
     def definition_target
-      @definition_target ||= default_definition_target
+      @definition_target ||= default_stub_method_owner
     end
 
-    def default_definition_target
+    def default_stub_method_owner
       stubbee.__metaclass__
     end
   end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -37,20 +37,20 @@ module Mocha
 
     def hide_original_method
       return unless (@original_visibility = method_visibility(method_name))
-      begin
-        if use_prepended_module_for_stub_method?
-          use_prepended_module_for_stub_method
-        else
+      if use_prepended_module_for_stub_method?
+        use_prepended_module_for_stub_method
+      else
+        begin
           store_original_method
-          if original_method_defined_on_stubbee?
-            remove_original_method_from_stubbee
-          end
+        # rubocop:disable Lint/HandleExceptions
+        rescue NameError
+          # deal with nasties like ActiveRecord::Associations::AssociationProxy
         end
-      # rubocop:disable Lint/HandleExceptions
-      rescue NameError
-        # deal with nasties like ActiveRecord::Associations::AssociationProxy
+        # rubocop:enable Lint/HandleExceptions
+        if original_method_defined_on_stubbee?
+          remove_original_method_from_stubbee
+        end
       end
-      # rubocop:enable Lint/HandleExceptions
     end
 
     def define_new_method

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -92,12 +92,11 @@ module Mocha
     end
 
     def method_visibility
-      symbol = method_name.to_sym
       metaclass = original_method_owner
 
-      (metaclass.public_method_defined?(symbol) && :public) ||
-        (metaclass.protected_method_defined?(symbol) && :protected) ||
-        (metaclass.private_method_defined?(symbol) && :private)
+      (metaclass.public_method_defined?(method_name) && :public) ||
+        (metaclass.protected_method_defined?(method_name) && :protected) ||
+        (metaclass.private_method_defined?(method_name) && :private)
     end
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -37,7 +37,7 @@ module Mocha
 
     def hide_original_method
       return unless method_defined_in_stubbee_or_in_ancestor_chain?
-      @original_visibility = method_visibility
+      store_original_method_visibility
       if use_prepended_module_for_stub_method?
         use_prepended_module_for_stub_method
       else
@@ -56,8 +56,8 @@ module Mocha
 
     def define_new_method
       stub_method_owner.class_eval(*stub_method_definition)
-      return unless @original_visibility
-      Module.instance_method(@original_visibility).bind(stub_method_owner).call(method_name)
+      return unless original_visibility
+      Module.instance_method(original_visibility).bind(stub_method_owner).call(method_name)
     end
 
     def remove_new_method
@@ -76,8 +76,8 @@ module Mocha
           original_method_owner.send(:define_method, method_name, original_method)
         end
       end
-      return unless @original_visibility
-      Module.instance_method(@original_visibility).bind(stubbee.__metaclass__).call(method_name)
+      return unless original_visibility
+      Module.instance_method(original_visibility).bind(stubbee.__metaclass__).call(method_name)
     end
 
     def matches?(other)
@@ -103,10 +103,14 @@ module Mocha
 
     private
 
-    attr_reader :original_method
+    attr_reader :original_method, :original_visibility
 
     def store_original_method
       @original_method = stubbee._method(method_name)
+    end
+
+    def store_original_method_visibility
+      @original_visibility = method_visibility
     end
 
     def stub_method_overwrites_original_method?

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -41,7 +41,7 @@ module Mocha
         if RUBY_V2_PLUS
           use_prepended_module_for_stub_method
         else
-          @original_method = original_method(method_name)
+          @original_method = original_method
           if original_method_defined_on_stubbee?
             remove_original_method_from_stubbee
           end
@@ -101,7 +101,7 @@ module Mocha
 
     private
 
-    def original_method(method_name)
+    def original_method
       stubbee._method(method_name)
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -69,11 +69,11 @@ module Mocha
       if stub_method_overwrites_original_method?
         if PRE_RUBY_V19
           original_method_in_scope = original_method
-          default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
+          original_method_owner.send(:define_method, method_name) do |*args, &block|
             original_method_in_scope.call(*args, &block)
           end
         else
-          default_stub_method_owner.send(:define_method, method_name, original_method)
+          original_method_owner.send(:define_method, method_name, original_method)
         end
       end
       return unless @original_visibility
@@ -93,7 +93,7 @@ module Mocha
 
     def method_visibility
       symbol = method_name.to_sym
-      metaclass = default_stub_method_owner
+      metaclass = original_method_owner
 
       (metaclass.public_method_defined?(symbol) && :public) ||
         (metaclass.protected_method_defined?(symbol) && :protected) ||
@@ -110,11 +110,11 @@ module Mocha
     end
 
     def stub_method_overwrites_original_method?
-      original_method && original_method.owner == default_stub_method_owner
+      original_method && original_method.owner == original_method_owner
     end
 
     def remove_original_method_from_stubbee
-      default_stub_method_owner.send(:remove_method, method_name)
+      original_method_owner.send(:remove_method, method_name)
     end
 
     def use_prepended_module_for_stub_method?
@@ -123,7 +123,7 @@ module Mocha
 
     def use_prepended_module_for_stub_method
       @stub_method_owner = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @stub_method_owner
+      original_method_owner.__send__ :prepend, @stub_method_owner
     end
 
     def stub_method_definition
@@ -136,10 +136,10 @@ module Mocha
     end
 
     def stub_method_owner
-      @stub_method_owner ||= default_stub_method_owner
+      @stub_method_owner ||= original_method_owner
     end
 
-    def default_stub_method_owner
+    def original_method_owner
       stubbee.__metaclass__
     end
   end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -65,14 +65,14 @@ module Mocha
 
     def restore_original_method
       return if RUBY_V2_PLUS
-      if @original_method && @original_method.owner == stubbee.__metaclass__
+      if @original_method && @original_method.owner == default_definition_target
         if PRE_RUBY_V19
           original_method = @original_method
-          stubbee.__metaclass__.send(:define_method, method_name) do |*args, &block|
+          default_definition_target.send(:define_method, method_name) do |*args, &block|
             original_method.call(*args, &block)
           end
         else
-          stubbee.__metaclass__.send(:define_method, method_name, @original_method)
+          default_definition_target.send(:define_method, method_name, @original_method)
         end
       end
       return unless @original_visibility
@@ -92,7 +92,7 @@ module Mocha
 
     def method_visibility(method_name)
       symbol = method_name.to_sym
-      metaclass = stubbee.__metaclass__
+      metaclass = default_definition_target
 
       (metaclass.public_method_defined?(symbol) && :public) ||
         (metaclass.protected_method_defined?(symbol) && :protected) ||
@@ -106,16 +106,16 @@ module Mocha
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == stubbee.__metaclass__
+      @original_method && @original_method.owner == default_definition_target
     end
 
     def remove_original_method_from_stubbee
-      stubbee.__metaclass__.send(:remove_method, method_name)
+      default_definition_target.send(:remove_method, method_name)
     end
 
     def prepend_module
       @definition_target = PrependedModule.new
-      stubbee.__metaclass__.__send__ :prepend, @definition_target
+      default_definition_target.__send__ :prepend, @definition_target
     end
 
     def stub_method_definition

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -42,7 +42,7 @@ module Mocha
           prepend_module
         else
           @original_method = original_method(method)
-          if @original_method && @original_method.owner == stubbee.__metaclass__
+          if original_method_defined_on_stubbee?
             stubbee.__metaclass__.send(:remove_method, method)
           end
         end
@@ -107,6 +107,10 @@ module Mocha
 
     def original_method(method)
       stubbee._method(method)
+    end
+
+    def original_method_defined_on_stubbee?
+      @original_method && @original_method.owner == stubbee.__metaclass__
     end
 
     def prepend_module

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -92,11 +92,9 @@ module Mocha
     end
 
     def method_visibility
-      metaclass = original_method_owner
-
-      (metaclass.public_method_defined?(method_name) && :public) ||
-        (metaclass.protected_method_defined?(method_name) && :protected) ||
-        (metaclass.private_method_defined?(method_name) && :private)
+      (original_method_owner.public_method_defined?(method_name) && :public) ||
+        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
+        (original_method_owner.private_method_defined?(method_name) && :private)
     end
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -65,7 +65,7 @@ module Mocha
 
     def restore_original_method
       return if RUBY_V2_PLUS
-      if @original_method && @original_method.owner == default_stub_method_owner
+      if original_method_defined_on_stubbee?
         if PRE_RUBY_V19
           original_method = @original_method
           default_stub_method_owner.send(:define_method, method_name) do |*args, &block|

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -47,7 +47,7 @@ module Mocha
           # deal with nasties like ActiveRecord::Associations::AssociationProxy
         end
         # rubocop:enable Lint/HandleExceptions
-        if original_method_defined_on_stubbee?
+        if stub_method_overwrites_original_method?
           remove_original_method_from_stubbee
         end
       end
@@ -65,7 +65,7 @@ module Mocha
 
     def restore_original_method
       return if use_prepended_module_for_stub_method?
-      if original_method_defined_on_stubbee?
+      if stub_method_overwrites_original_method?
         if PRE_RUBY_V19
           original_method_in_scope = original_method
           default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
@@ -107,7 +107,7 @@ module Mocha
       @original_method = stubbee._method(method_name)
     end
 
-    def original_method_defined_on_stubbee?
+    def stub_method_overwrites_original_method?
       original_method && original_method.owner == default_stub_method_owner
     end
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -43,7 +43,7 @@ module Mocha
         else
           @original_method = original_method(method)
           if original_method_defined_on_stubbee?
-            stubbee.__metaclass__.send(:remove_method, method)
+            remove_original_method_from_stubbee
           end
         end
       # rubocop:disable Lint/HandleExceptions
@@ -111,6 +111,10 @@ module Mocha
 
     def original_method_defined_on_stubbee?
       @original_method && @original_method.owner == stubbee.__metaclass__
+    end
+
+    def remove_original_method_from_stubbee
+      stubbee.__metaclass__.send(:remove_method, method)
     end
 
     def prepend_module

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -5,13 +5,13 @@ module Mocha
   class ClassMethod
     PrependedModule = Class.new(Module)
 
-    attr_reader :stubbee, :method
+    attr_reader :stubbee, :method_name
 
-    def initialize(stubbee, method)
+    def initialize(stubbee, method_name)
       @stubbee = stubbee
       @original_method = nil
       @original_visibility = nil
-      @method = PRE_RUBY_V19 ? method.to_s : method.to_sym
+      @method_name = PRE_RUBY_V19 ? method_name.to_s : method_name.to_sym
     end
 
     def stub
@@ -22,7 +22,7 @@ module Mocha
     def unstub
       remove_new_method
       restore_original_method
-      mock.unstub(method.to_sym)
+      mock.unstub(method_name.to_sym)
       return if mock.any_expectations?
       reset_mocha
     end
@@ -36,12 +36,12 @@ module Mocha
     end
 
     def hide_original_method
-      return unless (@original_visibility = method_visibility(method))
+      return unless (@original_visibility = method_visibility(method_name))
       begin
         if RUBY_V2_PLUS
           prepend_module
         else
-          @original_method = original_method(method)
+          @original_method = original_method(method_name)
           if original_method_defined_on_stubbee?
             remove_original_method_from_stubbee
           end
@@ -56,11 +56,11 @@ module Mocha
     def define_new_method
       definition_target.class_eval(*stub_method_definition)
       return unless @original_visibility
-      Module.instance_method(@original_visibility).bind(definition_target).call(method)
+      Module.instance_method(@original_visibility).bind(definition_target).call(method_name)
     end
 
     def remove_new_method
-      definition_target.send(:remove_method, method)
+      definition_target.send(:remove_method, method_name)
     end
 
     def restore_original_method
@@ -68,30 +68,30 @@ module Mocha
       if @original_method && @original_method.owner == stubbee.__metaclass__
         if PRE_RUBY_V19
           original_method = @original_method
-          stubbee.__metaclass__.send(:define_method, method) do |*args, &block|
+          stubbee.__metaclass__.send(:define_method, method_name) do |*args, &block|
             original_method.call(*args, &block)
           end
         else
-          stubbee.__metaclass__.send(:define_method, method, @original_method)
+          stubbee.__metaclass__.send(:define_method, method_name, @original_method)
         end
       end
       return unless @original_visibility
-      Module.instance_method(@original_visibility).bind(stubbee.__metaclass__).call(method)
+      Module.instance_method(@original_visibility).bind(stubbee.__metaclass__).call(method_name)
     end
 
     def matches?(other)
       return false unless other.class == self.class
-      (stubbee.object_id == other.stubbee.object_id) && (method == other.method)
+      (stubbee.object_id == other.stubbee.object_id) && (method_name == other.method_name)
     end
 
     alias_method :==, :eql?
 
     def to_s
-      "#{stubbee}.#{method}"
+      "#{stubbee}.#{method_name}"
     end
 
-    def method_visibility(method)
-      symbol = method.to_sym
+    def method_visibility(method_name)
+      symbol = method_name.to_sym
       metaclass = stubbee.__metaclass__
 
       (metaclass.public_method_defined?(symbol) && :public) ||
@@ -101,8 +101,8 @@ module Mocha
 
     private
 
-    def original_method(method)
-      stubbee._method(method)
+    def original_method(method_name)
+      stubbee._method(method_name)
     end
 
     def original_method_defined_on_stubbee?
@@ -110,7 +110,7 @@ module Mocha
     end
 
     def remove_original_method_from_stubbee
-      stubbee.__metaclass__.send(:remove_method, method)
+      stubbee.__metaclass__.send(:remove_method, method_name)
     end
 
     def prepend_module
@@ -120,8 +120,8 @@ module Mocha
 
     def stub_method_definition
       method_implementation = <<-CODE
-      def #{method}(*args, &block)
-        mocha.method_missing(:#{method}, *args, &block)
+      def #{method_name}(*args, &block)
+        mocha.method_missing(:#{method_name}, *args, &block)
       end
       CODE
       [method_implementation, __FILE__, __LINE__ - 4]

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -128,7 +128,11 @@ module Mocha
     end
 
     def definition_target
-      @definition_target ||= stubbee.__metaclass__
+      @definition_target ||= default_definition_target
+    end
+
+    def default_definition_target
+      stubbee.__metaclass__
     end
   end
 end

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -54,13 +54,13 @@ module Mocha
     end
 
     def define_new_method
-      definition_target.class_eval(*stub_method_definition)
+      stub_method_owner.class_eval(*stub_method_definition)
       return unless @original_visibility
-      Module.instance_method(@original_visibility).bind(definition_target).call(method_name)
+      Module.instance_method(@original_visibility).bind(stub_method_owner).call(method_name)
     end
 
     def remove_new_method
-      definition_target.send(:remove_method, method_name)
+      stub_method_owner.send(:remove_method, method_name)
     end
 
     def restore_original_method
@@ -114,8 +114,8 @@ module Mocha
     end
 
     def prepend_module
-      @definition_target = PrependedModule.new
-      default_stub_method_owner.__send__ :prepend, @definition_target
+      @stub_method_owner = PrependedModule.new
+      default_stub_method_owner.__send__ :prepend, @stub_method_owner
     end
 
     def stub_method_definition
@@ -127,8 +127,8 @@ module Mocha
       [method_implementation, __FILE__, __LINE__ - 4]
     end
 
-    def definition_target
-      @definition_target ||= default_stub_method_owner
+    def stub_method_owner
+      @stub_method_owner ||= default_stub_method_owner
     end
 
     def default_stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -36,7 +36,8 @@ module Mocha
     end
 
     def hide_original_method
-      return unless (@original_visibility = method_visibility)
+      return unless method_defined_in_stubbee_or_in_ancestor_chain?
+      @original_visibility = method_visibility
       if use_prepended_module_for_stub_method?
         use_prepended_module_for_stub_method
       else
@@ -98,6 +99,7 @@ module Mocha
         (metaclass.protected_method_defined?(symbol) && :protected) ||
         (metaclass.private_method_defined?(symbol) && :private)
     end
+    alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -41,7 +41,7 @@ module Mocha
         if RUBY_V2_PLUS
           use_prepended_module_for_stub_method
         else
-          @original_method = original_method
+          store_original_method
           if original_method_defined_on_stubbee?
             remove_original_method_from_stubbee
           end
@@ -67,12 +67,12 @@ module Mocha
       return if RUBY_V2_PLUS
       if original_method_defined_on_stubbee?
         if PRE_RUBY_V19
-          original_method = @original_method
+          original_method_in_scope = original_method
           default_stub_method_owner.send(:define_method, method_name) do |*args, &block|
-            original_method.call(*args, &block)
+            original_method_in_scope.call(*args, &block)
           end
         else
-          default_stub_method_owner.send(:define_method, method_name, @original_method)
+          default_stub_method_owner.send(:define_method, method_name, original_method)
         end
       end
       return unless @original_visibility
@@ -101,12 +101,14 @@ module Mocha
 
     private
 
-    def original_method
-      stubbee._method(method_name)
+    attr_reader :original_method
+
+    def store_original_method
+      @original_method = stubbee._method(method_name)
     end
 
     def original_method_defined_on_stubbee?
-      @original_method && @original_method.owner == default_stub_method_owner
+      original_method && original_method.owner == default_stub_method_owner
     end
 
     def remove_original_method_from_stubbee

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -42,7 +42,7 @@ module Mocha
           @definition_target = PrependedModule.new
           stubbee.__metaclass__.__send__ :prepend, @definition_target
         else
-          @original_method = stubbee._method(method)
+          @original_method = original_method(method)
           if @original_method && @original_method.owner == stubbee.__metaclass__
             stubbee.__metaclass__.send(:remove_method, method)
           end
@@ -105,6 +105,10 @@ module Mocha
     end
 
     private
+
+    def original_method(method)
+      stubbee._method(method)
+    end
 
     def definition_target
       @definition_target ||= stubbee.__metaclass__

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -38,7 +38,7 @@ module Mocha
     def hide_original_method
       return unless (@original_visibility = method_visibility(method_name))
       begin
-        if RUBY_V2_PLUS
+        if use_prepended_module_for_stub_method?
           use_prepended_module_for_stub_method
         else
           store_original_method
@@ -64,7 +64,7 @@ module Mocha
     end
 
     def restore_original_method
-      return if RUBY_V2_PLUS
+      return if use_prepended_module_for_stub_method?
       if original_method_defined_on_stubbee?
         if PRE_RUBY_V19
           original_method_in_scope = original_method
@@ -113,6 +113,10 @@ module Mocha
 
     def remove_original_method_from_stubbee
       default_stub_method_owner.send(:remove_method, method_name)
+    end
+
+    def use_prepended_module_for_stub_method?
+      RUBY_V2_PLUS
     end
 
     def use_prepended_module_for_stub_method

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -54,11 +54,7 @@ module Mocha
     end
 
     def define_new_method
-      definition_target.class_eval(<<-CODE, __FILE__, __LINE__ + 1)
-        def #{method}(*args, &block)
-          mocha.method_missing(:#{method}, *args, &block)
-        end
-      CODE
+      definition_target.class_eval(*stub_method_definition)
       return unless @original_visibility
       Module.instance_method(@original_visibility).bind(definition_target).call(method)
     end
@@ -120,6 +116,15 @@ module Mocha
     def prepend_module
       @definition_target = PrependedModule.new
       stubbee.__metaclass__.__send__ :prepend, @definition_target
+    end
+
+    def stub_method_definition
+      method_implementation = <<-CODE
+      def #{method}(*args, &block)
+        mocha.method_missing(:#{method}, *args, &block)
+      end
+      CODE
+      [method_implementation, __FILE__, __LINE__ - 4]
     end
 
     def definition_target

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 35
+    expected_line_number = 17
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 40
+    expected_line_number = 36
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 37
+    expected_line_number = 36
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 44
+    expected_line_number = 40
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 36
+    expected_line_number = 30
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -43,6 +43,30 @@ class AnyInstanceMethodTest < Mocha::TestCase
     assert mocha.__verified__?
   end
 
+  def test_should_include_the_filename_and_line_number_in_exceptions
+    klass = Class.new { def method_x; end }
+    method = AnyInstanceMethod.new(klass, :method_x)
+    mocha = build_mock
+    mocha.stubs(:method_x).raises(Exception)
+    any_instance = Object.new
+    any_instance.define_instance_method(:mocha) { mocha }
+    klass.define_instance_method(:any_instance) { any_instance }
+
+    method.hide_original_method
+    method.define_new_method
+
+    expected_filename = 'any_instance_method.rb'
+    expected_line_number = 37
+
+    exception = assert_raises(Exception) { klass.new.method_x }
+    matching_line = exception.backtrace.find do |line|
+      filename, line_number, _context = line.split(':')
+      filename.include?(expected_filename) && line_number.to_i == expected_line_number
+    end
+
+    assert_not_nil matching_line, "Expected to find #{expected_filename}:#{expected_line_number} in the backtrace:\n #{exception.backtrace.join("\n")}"
+  end
+
   def test_should_restore_original_method
     klass = Class.new do
       def method_x

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 17
+    expected_line_number = 55
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 36
+    expected_line_number = 35
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 55
+    expected_line_number = 49
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 49
+    expected_line_number = 44
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 61
+    expected_line_number = 60
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -48,6 +48,28 @@ class ClassMethodTest < Mocha::TestCase
     assert mocha.__verified__?
   end
 
+  def test_should_include_the_filename_and_line_number_in_exceptions
+    klass = Class.new { def self.method_x; end }
+    mocha = build_mock
+    klass.define_instance_method(:mocha) { mocha }
+    mocha.stubs(:method_x).raises(Exception)
+    method = ClassMethod.new(klass, :method_x)
+
+    method.hide_original_method
+    method.define_new_method
+
+    expected_filename = 'class_method.rb'
+    expected_line_number = 61
+
+    exception = assert_raises(Exception) { klass.method_x }
+    matching_line = exception.backtrace.find do |line|
+      filename, line_number, _context = line.split(':')
+      filename.include?(expected_filename) && line_number.to_i == expected_line_number
+    end
+
+    assert_not_nil matching_line, "Expected to find #{expected_filename}:#{expected_line_number} in the backtrace:\n #{exception.backtrace.join("\n")}"
+  end
+
   def test_should_remove_new_method
     klass = Class.new { def self.method_x; end }
     method = ClassMethod.new(klass, :method_x)

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 59
+    expected_line_number = 124
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 130
+    expected_line_number = 132
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 136
+    expected_line_number = 135
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 132
+    expected_line_number = 136
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 124
+    expected_line_number = 126
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 60
+    expected_line_number = 59
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 126
+    expected_line_number = 130
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -59,7 +59,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 135
+    expected_line_number = 133
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|


### PR DESCRIPTION
Supersedes #269 by @chrisroos & @floehopper.

This PR is based on the changes in the `refactor-class-method-and-any-instance-method` branch rebased against the Rubocop changes in `master`.

This branch reduces some duplication between `ClassMethod` and `AnyInstanceMethod`, and aims to make the code clearer through the use of intention revealing method names.

Removing the duplication should hopefully help us avoid the sort of situation we encountered when we made a change to `ClassMethod#hide_original_method` without also updating the implementation in `AnyInstanceMethod`. See "ClassMethod and AnyInstanceMethod divergence" below for more information about this.

There are still some overridden methods in `AnyInstanceMethod` (notably `restore_original_method` and `stub_method_definition`) that it'd be good to investigate in future to see whether we can remove more duplication - captured in https://github.com/freerange/mocha/issues/359.

## ClassMethod and AnyInstanceMethod divergence

* [PR 248](https://github.com/freerange/mocha/pull/248) changed `ClassMethod#hide_original_method` to use the new `#method_visibility` method instead of `method_exists?`.
  * NOTE. The changes in PR 248 were actually added to master manually. The main change being in https://github.com/freerange/mocha/commit/e87c03b068efc48267fbcd5a295514077c52b901.
* We added tests around this subtle change in behaviour (introduced in PR 248), in https://github.com/freerange/mocha/commit/5f768de62a6b6fb2c1c275b5830bc6471722cce4.
* At the point we merged PR 248, `AnyInstanceMethod#hide_original_method` was still using its own version of `method_exists?`
  * We updated this to mirror the changes in `ClassMethod` in [PR 262](https://github.com/freerange/mocha/pull/262).
* PR 248 made `InstanceMethod#method_exists?` redundant.
  * This redundant method was removed in https://github.com/freerange/mocha/commit/8f58eddf0ff658ad255cf60cedab3c767bbb15c7.
* PR 248 made `ModuleMethod#method_exists?` redundant.
  * This redundant method was removed in https://github.com/freerange/mocha/commit/fe1d49d124ac4af15e5f4fa0670f0f43be1fed4d and some tests were added to check the behaviour added in the original commit from Grosser.

## TODO

- [x] Explain the motivation in PR description/branch
  * We're mostly interested in reducing the chance of changes being made to ClassMethod and not to AnyInstanceMethod.
- [x] Do we need different implementations of `stubbed_method_implementation` (in `ClassMethod` and `AnyInstanceMethod`)?
- [x] Can you check that the documentation generated after these changes makes sense? I'm pretty sure the affected files are all excluded from the documentation, but it'd be worth double-checking.
- [x] Commit: "Extract ClassMethod#stubbed_method_implementation"
  * Explain in the commit note why I'm happy to accept the LINE+1 still.
    * Ensure the tests still make sense
  * Rename method to `stub_method_definition`
- [x] Commit: "Reduce scope of `rescue` in #hide_original_method"
  * Is my commit note correct? It says that we only have tests for AnyInstanceMethod and not for ClassMethod but it looks as though it might be the other way round.
- [x] Rename `#original_method_defined_on_stubbee?`.
  * We're actually interested in whether the method was originally defined on the stubbee or the stubbee's metaclass in the case of AnyInstanceMethod.
  * Consider something like `#stub_method_overwrites_original_method?`.
- [x] Commit "Use default_definition_target to DRY up code" appears to mean that `AnyInstanceMethod#method_visibility` isn't required (i.e. I can delete that method without any of the tests failing). This is unexpected!
- [x] Rename `#default_stub_method_owner`.
  * Something like `#original_method_owner` or `#default_owner_of_stub_method` would probably be clearer.
  * In further discussion we realised that this name is probably OK but it might be that we're overloading its use. Introducing an alias based on how we're using it might make things clearer.
- [x] Address comment: https://github.com/freerange/mocha/commit/fa690ba61f774d8211884cd9d78bd16055cdf9b3#commitcomment-29950013
- [x] Address comment: https://github.com/freerange/mocha/commit/65db7ccd8508bf528b3a2a53c9b12aa7efd7be8f#commitcomment-29950034
- [x] Address comment: https://github.com/freerange/mocha/commit/b99f23f3502f4d0af6c3b160da0496f9941354e4#commitcomment-29949982
