### PR TITLE
WIP: Quick attempt at allowing tests to run in different threads

### DIFF
--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -17,10 +17,11 @@ module Mocha
       end
 
       def mocha(instantiate = true)
+        @mochas ||= {}
         if instantiate
-          @mocha ||= Mocha::Mockery.instance.mock_impersonating_any_instance_of(@stubba_object)
+          @mochas[Thread.current] ||= Mocha::Mockery.instance.mock_impersonating_any_instance_of(@stubba_object)
         else
-          defined?(@mocha) ? @mocha : nil
+          defined?(@mochas) ? @mochas[Thread.current] : nil
         end
       end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -41,7 +41,7 @@ module Mocha
       def setup
         mockery = new
         mockery.logger = instance.logger unless instances.empty?
-        @instances.push(mockery)
+        Thread.current[:instances].push(mockery)
       end
 
       def verify(*args)
@@ -51,14 +51,14 @@ module Mocha
       def teardown
         instance.teardown
       ensure
-        @instances.pop
-        @instances = nil if instances.empty?
+        Thread.current[:instances].pop
+        Thread.current[:instances] = nil if instances.empty?
       end
 
       private
 
       def instances
-        @instances ||= []
+        Thread.current[:instances] ||= []
       end
     end
 

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -13,16 +13,19 @@ module Mocha
 
     # @private
     def mocha(instantiate = true)
+      @mochas ||= {}
       if instantiate
-        @mocha ||= Mocha::Mockery.instance.mock_impersonating(self)
+        @mochas[Thread.current] ||= Mocha::Mockery.instance.mock_impersonating(self)
       else
-        defined?(@mocha) ? @mocha : nil
+        defined?(@mochas) ? @mochas[Thread.current] : nil
       end
     end
 
     # @private
     def reset_mocha
-      @mocha = nil
+      return unless @mochas
+      @mochas[Thread.current] = nil
+      @mochas = nil if @mochas.empty?
     end
 
     # @private

--- a/multithreaded_test.rb
+++ b/multithreaded_test.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require 'minitest/hell'
+require 'mocha/minitest'
+
+class MultithreadedMockingTest < Minitest::Test
+  (1..10).each do |i|
+    define_method "test_#{i}" do
+      m = mock('m')
+      m.expects("x#{i}".to_sym)
+    end
+  end
+end
+
+class MultithreadedStubbingTest < Minitest::Test
+  (1..10).each do |i|
+    define_method "test_#{i}" do
+      s = stub('m')
+      s.stubs("x#{i}".to_sym).returns(i)
+      sleep 1
+      assert_equal i, s.public_send("x#{i}".to_sym)
+    end
+  end
+end
+
+class MultithreadedClassMethodMockingTest < Minitest::Test
+  klass = Class.new
+  (1..10).each do |i|
+    define_method "test_#{i}" do
+      klass.expects("x#{i}".to_sym)
+    end
+  end
+end
+
+class MultithreadedClassMethodStubbingTest < Minitest::Test
+  klass = Class.new
+  (1..10).each do |i|
+    define_method "test_#{i}" do
+      klass.stubs(:x).returns(i)
+      sleep 1
+      assert_equal i, klass.public_send(:x)
+    end
+  end
+end
+
+class MultithreadedAnyInstanceMethodMockingTest < Minitest::Test
+  klass = Class.new
+  (1..10).each do |i|
+    define_method "test_#{i}" do
+      klass.any_instance.expects("x#{i}".to_sym)
+    end
+  end
+end
+
+class MultithreadedAnyInstanceMethodStubbingTest < Minitest::Test
+  klass = Class.new
+  (1..10).each do |i|
+    define_method "test_#{i}" do
+      klass.any_instance.stubs(:x).returns(i)
+      sleep 1
+      assert_equal i, klass.new.public_send(:x)
+    end
+  end
+end


### PR DESCRIPTION
I ran the sample tests, which were parallelized using minitest/hell,
using the following command:

    N=10 bundle exec ruby multithreaded_test.rb

* These changes assume the setup/test/teardown sequence is run in the
same thread for any given test - it's not an attempt to allow arbitrary
multi-threading within a single test.

* Although at first glance it appears that these changes cover the most
common scenarios, I strongly suspect there are some edge cases to do
with stubbed methods potentially being defined multiple times on the
same class. This needs further investigation.

/cc @zenspider.