### PR TITLE
Rely on default bundler version in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 dist: trusty
-before_install:
-  - gem install bundler -v '< 2'
 bundler_args: "--verbose"
 script: "rake test"
 rvm:


### PR DESCRIPTION
Rely on default bundler version in Travis CI builds

In [this commit][1], I added a `before_install` entry to the Travis CI configuration to install the *latest* bundler version to avoid some failing builds.

In [this commit][2], I had to restrict this to only install versions of bundler before v2 in order to avoid builds with earlier Ruby versions failing.

By removing the `before_install` entry altogether, it seems as if all builds in the Travis CI matrix are passing, so this seems like a better option.

This was motivated by a problem with JRuby v9.2.7.0 builds.

[1]: https://github.com/freerange/mocha/commit/0e3eed1475c2c722940c74d31a597252e7872dbe
[2]: https://github.com/freerange/mocha/commit/683ded9b59b6ce7a5e5fa488b08d97200e1f7f4c
