### PR TITLE
Upgrade JRuby to v9.2.7.0 in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - ruby-head
-  - jruby-9.1.17.0
+  - jruby-9.2.7.0
   - jruby-head
   - truffleruby
 gemfile:
@@ -27,7 +27,7 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: ruby-head
@@ -102,7 +102,7 @@ matrix:
     - rvm: truffleruby
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: jruby-head


### PR DESCRIPTION
Release: https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html

I'm seeing build failures for this upgrade for the builds using JRuby v9.2.7.0 (e.g. [this one][1]) with error: "You must use Bundler 2 or greater with this lockfile".

I strongly suspect this is due to [this JRuby issue][2] which has been fixed but not yet released.

[1]: https://travis-ci.org/freerange/mocha/jobs/546393392
[2]: https://github.com/jruby/jruby/issues/5686