### PR TITLE
Remove dependency on metaclass gem

### DIFF
--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -1,5 +1,5 @@
 require 'mocha/ruby_version'
-require 'metaclass'
+require 'mocha/singleton_class'
 
 module Mocha
   class ClassMethod
@@ -77,7 +77,7 @@ module Mocha
         end
       end
       return unless original_visibility
-      Module.instance_method(original_visibility).bind(stubbee.__metaclass__).call(method_name)
+      Module.instance_method(original_visibility).bind(stubbee.singleton_class).call(method_name)
     end
 
     def matches?(other)
@@ -141,7 +141,7 @@ module Mocha
     end
 
     def original_method_owner
-      stubbee.__metaclass__
+      stubbee.singleton_class
     end
   end
 end

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -271,6 +271,8 @@ module Mocha
 
     alias_method :__stubs__, :stubs
 
+    alias_method :__singleton_class__, :singleton_class
+
     alias_method :quacks_like, :responds_like
     alias_method :quacks_like_instance_of, :responds_like_instance_of
 
@@ -348,7 +350,7 @@ module Mocha
 
     # @private
     def ensure_method_not_already_defined(method_name)
-      singleton_class.send(:undef_method, method_name) if singleton_class.method_defined?(method_name) || singleton_class.private_method_defined?(method_name)
+      __singleton_class__.send(:undef_method, method_name) if __singleton_class__.method_defined?(method_name) || __singleton_class__.private_method_defined?(method_name)
     end
 
     # @private

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -1,4 +1,4 @@
-require 'metaclass'
+require 'mocha/singleton_class'
 require 'mocha/expectation'
 require 'mocha/expectation_list'
 require 'mocha/names'
@@ -348,7 +348,7 @@ module Mocha
 
     # @private
     def ensure_method_not_already_defined(method_name)
-      __metaclass__.send(:undef_method, method_name) if __metaclass__.method_defined?(method_name) || __metaclass__.private_method_defined?(method_name)
+      singleton_class.send(:undef_method, method_name) if singleton_class.method_defined?(method_name) || singleton_class.private_method_defined?(method_name)
     end
 
     # @private

--- a/lib/mocha/singleton_class.rb
+++ b/lib/mocha/singleton_class.rb
@@ -1,0 +1,9 @@
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('1.9.2')
+  unless Kernel.method_defined?(:singleton_class)
+    module Kernel
+      def singleton_class
+        class << self; self; end
+      end
+    end
+  end
+end

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.summary = 'Mocking and stubbing library'
 
-  s.add_dependency('metaclass', '~> 0.0.1')
-
   unless s.respond_to?(:add_development_dependency)
     class << s
       def add_development_dependency(*args)

--- a/test/method_definer.rb
+++ b/test/method_definer.rb
@@ -1,9 +1,9 @@
-require 'metaclass'
+require 'mocha/singleton_class'
 
 module Mocha
   module ObjectMethods
     def define_instance_method(method_symbol, &block)
-      __metaclass__.send(:define_method, method_symbol, block)
+      singleton_class.send(:define_method, method_symbol, block)
     end
 
     def replace_instance_method(method_symbol, &block)
@@ -12,7 +12,7 @@ module Mocha
     end
 
     def define_instance_accessor(*symbols)
-      symbols.each { |symbol| __metaclass__.send(:attr_accessor, symbol) }
+      symbols.each { |symbol| singleton_class.send(:attr_accessor, symbol) }
     end
   end
 end

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'method_definer'
 require 'mocha/mock'
+require 'mocha/singleton_class'
 
 require 'mocha/class_method'
 
@@ -10,7 +11,7 @@ class ClassMethodTest < Mocha::TestCase
   unless RUBY_V2_PLUS
     def test_should_hide_original_method
       klass = Class.new { def self.method_x; end }
-      klass.__metaclass__.send(:alias_method, :_method, :method)
+      klass.singleton_class.send(:alias_method, :_method, :method)
       method = ClassMethod.new(klass, :method_x)
 
       method.hide_original_method
@@ -85,7 +86,7 @@ class ClassMethodTest < Mocha::TestCase
         :original_result
       end
     end
-    klass.__metaclass__.send(:alias_method, :_method, :method)
+    klass.singleton_class.send(:alias_method, :_method, :method)
     method = ClassMethod.new(klass, :method_x)
 
     method.hide_original_method
@@ -103,7 +104,7 @@ class ClassMethodTest < Mocha::TestCase
         block.call if block_given?
       end
     end
-    klass.__metaclass__.send(:alias_method, :_method, :method)
+    klass.singleton_class.send(:alias_method, :_method, :method)
     method = ClassMethod.new(klass, :method_x)
 
     method.hide_original_method

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -56,8 +56,7 @@ class MockTest < Mocha::TestCase
       :singleton_method_undefined,
       :initialize,
       :String,
-      :singleton_method_added,
-      :singleton_class
+      :singleton_method_added
     ]
   }.freeze
 

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -56,7 +56,8 @@ class MockTest < Mocha::TestCase
       :singleton_method_undefined,
       :initialize,
       :String,
-      :singleton_method_added
+      :singleton_method_added,
+      :singleton_class
     ]
   }.freeze
 


### PR DESCRIPTION
The `singleton_class` method has been available since Ruby v1.9.2 and so it seems better to avoid this dependency, especially as it's very simple to implement it for earlier Ruby versions.

While the singleton_class method is [documented on the `Object` class][1], it's actually implemented on the `Kernel` module. See [this comment in `object.c`][2] in the Ruby source and [the implementation in the `backports` gem][3].

Note that previously the `metaclass` gem implemented the method using a double-underscore prefix and suffix which meant that the method was automatically excluded from the tests involving `OBJECT_METHODS` in `MockTest`. So I've had to explicitly add the `singleton_class` method to the list of excluded methods for these tests.

Fixes #49.

[1]: http://ruby-doc.org/core-1.9.2/Object.html#method-i-singleton_class
[2]: https://github.com/ruby/ruby/blob/c8e9e0b74b7fb2e225af8708426389db88f80683/object.c#L4120
[3]: https://github.com/marcandre/backports/blob/edd1109ae8865d58daf34d256bcf075520f5ffdf/lib/backports/1.9.2/kernel/singleton_class.rb
