### PR TITLE
Simplify/consistent-ify ClassMethods#method_exists? & ObjectMethods#method_exists?

### DIFF
--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -86,10 +86,10 @@ module Mocha
       "#{stubbee}.#{method_name}"
     end
 
-    def method_visibility
-      original_method_owner.method_visibility(method_name)
+    def method_exists?
+      original_method_owner.method_exists?(method_name)
     end
-    alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
+    alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_exists?
 
     private
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -36,7 +36,7 @@ module Mocha
     end
 
     def hide_original_method
-      return unless method_defined_in_stubbee_or_in_ancestor_chain?
+      return unless method_exists?
       store_original_method_visibility
       if use_prepended_module_for_stub_method?
         use_prepended_module_for_stub_method
@@ -89,7 +89,6 @@ module Mocha
     def method_exists?
       original_method_owner.method_exists?(method_name)
     end
-    alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_exists?
 
     private
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -87,9 +87,7 @@ module Mocha
     end
 
     def method_visibility
-      (original_method_owner.public_method_defined?(method_name) && :public) ||
-        (original_method_owner.protected_method_defined?(method_name) && :protected) ||
-        (original_method_owner.private_method_defined?(method_name) && :private)
+      original_method_owner.method_visibility(method_name)
     end
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -101,7 +101,7 @@ module Mocha
     attr_reader :original_method, :original_visibility
 
     def store_original_method_visibility
-      @original_visibility = method_visibility
+      @original_visibility = original_method_owner.method_visibility(method_name)
     end
 
     def stub_method_overwrites_original_method?

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -36,7 +36,7 @@ module Mocha
     end
 
     def hide_original_method
-      return unless method_exists?
+      return unless original_method_owner.method_exists?(method_name)
       store_original_method_visibility
       if use_prepended_module_for_stub_method?
         use_prepended_module_for_stub_method
@@ -84,10 +84,6 @@ module Mocha
 
     def to_s
       "#{stubbee}.#{method_name}"
-    end
-
-    def method_exists?
-      original_method_owner.method_exists?(method_name)
     end
 
     private

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -60,5 +60,6 @@ module Mocha
         (protected_method_defined?(method) && :protected) ||
         (private_method_defined?(method) && :private)
     end
+    alias_method :method_exists?, :method_visibility
   end
 end

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -33,11 +33,17 @@ module Mocha
       def method_exists?(method, include_public_methods = true)
         if include_public_methods
           return true if @stubba_object.public_instance_methods(true).include?(method)
-          return true if @stubba_object.allocate.respond_to?(method.to_sym)
+          return true if respond_to?(method)
         end
         return true if @stubba_object.protected_instance_methods(true).include?(method)
         return true if @stubba_object.private_instance_methods(true).include?(method)
         false
+      end
+
+      private
+
+      def respond_to?(method)
+        @stubba_object.allocate.respond_to?(method.to_sym)
       end
     end
 

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -35,9 +35,7 @@ module Mocha
           return true if @stubba_object.public_method_defined?(method)
           return true if respond_to?(method)
         end
-        return true if @stubba_object.protected_method_defined?(method)
-        return true if @stubba_object.private_method_defined?(method)
-        false
+        @stubba_object.protected_method_defined?(method) || @stubba_object.private_method_defined?(method)
       end
 
       private

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -56,5 +56,11 @@ module Mocha
       end
       @any_instance ||= AnyInstance.new(self)
     end
+
+    def method_visibility(method, include_public_methods = true)
+      (include_public_methods && public_method_defined?(method) && :public) ||
+        (protected_method_defined?(method) && :protected) ||
+        (private_method_defined?(method) && :private)
+    end
   end
 end

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -32,13 +32,11 @@ module Mocha
         @stubba_object.allocate.respond_to?(method.to_sym)
       end
 
-      attr_reader :stubba_object
-
-      private
-
       def singleton_class
         @stubba_object
       end
+
+      attr_reader :stubba_object
     end
 
     # @return [Mock] a mock object which will detect calls to any instance of this class.

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -32,11 +32,11 @@ module Mocha
 
       def method_exists?(method, include_public_methods = true)
         if include_public_methods
-          return true if @stubba_object.public_instance_methods(true).include?(method)
+          return true if @stubba_object.public_method_defined?(method)
           return true if respond_to?(method)
         end
-        return true if @stubba_object.protected_instance_methods(true).include?(method)
-        return true if @stubba_object.private_instance_methods(true).include?(method)
+        return true if @stubba_object.protected_method_defined?(method)
+        return true if @stubba_object.private_method_defined?(method)
         false
       end
 

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -30,14 +30,6 @@ module Mocha
 
       attr_reader :stubba_object
 
-      def method_exists?(method, include_public_methods = true)
-        if include_public_methods
-          return true if singleton_class.public_method_defined?(method)
-          return true if respond_to?(method)
-        end
-        singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
-      end
-
       private
 
       def singleton_class

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -32,13 +32,17 @@ module Mocha
 
       def method_exists?(method, include_public_methods = true)
         if include_public_methods
-          return true if @stubba_object.public_method_defined?(method)
+          return true if singleton_class.public_method_defined?(method)
           return true if respond_to?(method)
         end
-        @stubba_object.protected_method_defined?(method) || @stubba_object.private_method_defined?(method)
+        singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
       end
 
       private
+
+      def singleton_class
+        @stubba_object
+      end
 
       def respond_to?(method)
         @stubba_object.allocate.respond_to?(method.to_sym)

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -28,16 +28,16 @@ module Mocha
         Mocha::AnyInstanceMethod
       end
 
+      def respond_to?(method)
+        @stubba_object.allocate.respond_to?(method.to_sym)
+      end
+
       attr_reader :stubba_object
 
       private
 
       def singleton_class
         @stubba_object
-      end
-
-      def respond_to?(method)
-        @stubba_object.allocate.respond_to?(method.to_sym)
       end
     end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -133,7 +133,7 @@ module Mocha
         end
       end
       unless Mocha::Configuration.allow?(:stubbing_non_public_method)
-        if object.method_exists?(method, false)
+        if object.singleton_class.method_exists?(method, false)
           on_stubbing_non_public_method(object, method)
         end
       end
@@ -195,7 +195,7 @@ module Mocha
     private
 
     def method_exists_or_responds_to?(method, object)
-      object.method_exists?(method, true) || object.respond_to?(method.to_sym)
+      object.singleton_class.method_exists?(method, true) || object.respond_to?(method.to_sym)
     end
 
     def expectations

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -128,7 +128,7 @@ module Mocha
     def on_stubbing(object, method)
       method = PRE_RUBY_V19 ? method.to_s : method.to_sym
       check(:stubbing_non_existent_method, 'non-existent method', object, method) do
-        !method_exists_or_responds_to?(method, object)
+        !(object.singleton_class.method_exists?(method, true) || object.respond_to?(method.to_sym))
       end
       check(:stubbing_non_public_method, 'non-public method', object, method) do
         object.singleton_class.method_exists?(method, false)
@@ -158,10 +158,6 @@ module Mocha
       stubbing_error = "stubbing #{description}: #{object.mocha_inspect}.#{method}"
       raise StubbingError.new(stubbing_error, caller) if Mocha::Configuration.prevent?(action)
       logger.warn(stubbing_error) if Mocha::Configuration.warn_when?(action)
-    end
-
-    def method_exists_or_responds_to?(method, object)
-      object.singleton_class.method_exists?(method, true) || object.respond_to?(method.to_sym)
     end
 
     def expectations

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -128,7 +128,7 @@ module Mocha
     def on_stubbing(object, method)
       method = PRE_RUBY_V19 ? method.to_s : method.to_sym
       unless Mocha::Configuration.allow?(:stubbing_non_existent_method)
-        unless object.method_exists?(method, true)
+        unless method_exists_or_responds_to?(method, object)
           on_stubbing_non_existent_method(object, method)
         end
       end
@@ -193,6 +193,10 @@ module Mocha
     end
 
     private
+
+    def method_exists_or_responds_to?(method, object)
+      object.method_exists?(method, true)
+    end
 
     def expectations
       mocks.map { |mock| mock.__expectations__.to_a }.flatten

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -195,7 +195,7 @@ module Mocha
     private
 
     def method_exists_or_responds_to?(method, object)
-      object.method_exists?(method, true)
+      object.method_exists?(method, true) || object.respond_to?(method.to_sym)
     end
 
     def expectations

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -164,11 +164,11 @@ module Mocha
     # @private
     def method_exists?(method, include_public_methods = true)
       if include_public_methods
-        return true if public_methods(true).include?(method)
+        return true if singleton_class.public_method_defined?(method)
         return true if respond_to?(method.to_sym)
       end
-      return true if protected_methods(true).include?(method)
-      return true if private_methods(true).include?(method)
+      return true if singleton_class.protected_method_defined?(method)
+      return true if singleton_class.private_method_defined?(method)
       false
     end
   end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -163,8 +163,9 @@ module Mocha
 
     # @private
     def method_exists?(method, include_public_methods = true)
-      (include_public_methods && singleton_class.public_method_defined?(method)) ||
-        singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
+      (include_public_methods && singleton_class.public_method_defined?(method) && :public) ||
+        (singleton_class.protected_method_defined?(method) && :protected) ||
+        (singleton_class.private_method_defined?(method) && :private)
     end
   end
 end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -162,10 +162,11 @@ module Mocha
     end
 
     # @private
-    def method_exists?(method, include_public_methods = true)
+    def method_visibility(method, include_public_methods = true)
       (include_public_methods && singleton_class.public_method_defined?(method) && :public) ||
         (singleton_class.protected_method_defined?(method) && :protected) ||
         (singleton_class.private_method_defined?(method) && :private)
     end
+    alias_method :method_exists?, :method_visibility
   end
 end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -163,10 +163,8 @@ module Mocha
 
     # @private
     def method_exists?(method, include_public_methods = true)
-      if include_public_methods
-        return true if singleton_class.public_method_defined?(method)
-      end
-      singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
+      (include_public_methods && singleton_class.public_method_defined?(method)) ||
+        singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
     end
   end
 end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -165,7 +165,6 @@ module Mocha
     def method_exists?(method, include_public_methods = true)
       if include_public_methods
         return true if singleton_class.public_method_defined?(method)
-        return true if respond_to?(method.to_sym)
       end
       singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
     end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -167,9 +167,7 @@ module Mocha
         return true if singleton_class.public_method_defined?(method)
         return true if respond_to?(method.to_sym)
       end
-      return true if singleton_class.protected_method_defined?(method)
-      return true if singleton_class.private_method_defined?(method)
-      false
+      singleton_class.protected_method_defined?(method) || singleton_class.private_method_defined?(method)
     end
   end
 end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -163,9 +163,7 @@ module Mocha
 
     # @private
     def method_visibility(method, include_public_methods = true)
-      (include_public_methods && singleton_class.public_method_defined?(method) && :public) ||
-        (singleton_class.protected_method_defined?(method) && :protected) ||
-        (singleton_class.private_method_defined?(method) && :private)
+      singleton_class.method_visibility(method, include_public_methods)
     end
     alias_method :method_exists?, :method_visibility
   end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -160,11 +160,5 @@ module Mocha
         mockery.stubba.unstub(method)
       end
     end
-
-    # @private
-    def method_visibility(method, include_public_methods = true)
-      singleton_class.method_visibility(method, include_public_methods)
-    end
-    alias_method :method_exists?, :method_visibility
   end
 end

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -1,14 +1,22 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'method_definer'
+require 'mocha/class_methods'
 require 'mocha/mock'
 require 'mocha/any_instance_method'
 
 class AnyInstanceMethodTest < Mocha::TestCase
   include Mocha
 
+  def class_with_method(method, result = nil)
+    Class.new do
+      extend ClassMethods
+      define_method(method) { result } if method
+    end
+  end
+
   unless RUBY_V2_PLUS
     def test_should_hide_original_method
-      klass = Class.new { def method_x; end }
+      klass = class_with_method(:method_x)
       method = AnyInstanceMethod.new(klass, :method_x)
 
       method.hide_original_method
@@ -18,14 +26,14 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_not_raise_error_hiding_method_that_isnt_defined
-    klass = Class.new
+    klass = class_with_method(:irrelevant)
     method = AnyInstanceMethod.new(klass, :method_x)
 
     assert_nothing_raised { method.hide_original_method }
   end
 
   def test_should_define_a_new_method
-    klass = Class.new { def method_x; end }
+    klass = class_with_method(:method_x)
     method = AnyInstanceMethod.new(klass, :method_x)
     mocha = build_mock
     mocha.expects(:method_x).with(:param1, :param2).returns(:result)
@@ -44,7 +52,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_include_the_filename_and_line_number_in_exceptions
-    klass = Class.new { def method_x; end }
+    klass = class_with_method(:method_x)
     method = AnyInstanceMethod.new(klass, :method_x)
     mocha = build_mock
     mocha.stubs(:method_x).raises(Exception)
@@ -68,11 +76,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_restore_original_method
-    klass = Class.new do
-      def method_x
-        :original_result
-      end
-    end
+    klass = class_with_method(:method_x, :original_result)
     method = AnyInstanceMethod.new(klass, :method_x)
 
     method.hide_original_method
@@ -86,11 +90,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_not_restore_original_method_if_none_was_defined_in_first_place
-    klass = Class.new do
-      def method_x
-        :new_result
-      end
-    end
+    klass = class_with_method(:method_x, :new_result)
     method = AnyInstanceMethod.new(klass, :method_x)
 
     method.restore_original_method
@@ -100,7 +100,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_call_remove_new_method
-    klass = Class.new { def method_x; end }
+    klass = class_with_method(:method_x)
     any_instance = build_mock
     any_instance_mocha = build_mock
     any_instance.stubs(:mocha).returns(any_instance_mocha)
@@ -117,7 +117,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_call_restore_original_method
-    klass = Class.new { def method_x; end }
+    klass = class_with_method(:method_x)
     any_instance = build_mock
     any_instance_mocha = build_mock
     any_instance.stubs(:mocha).returns(any_instance_mocha)
@@ -134,7 +134,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
   end
 
   def test_should_call_mock_unstub
-    klass = Class.new { def method_x; end }
+    klass = class_with_method(:method_x)
 
     method = AnyInstanceMethod.new(klass, :method_x)
 
@@ -160,7 +160,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     mocha = Object.new
     any_instance = Object.new
     any_instance.define_instance_method(:mocha) { mocha }
-    stubbee = Class.new
+    stubbee = class_with_method(:method_x)
     stubbee.define_instance_method(:any_instance) { any_instance }
     method = AnyInstanceMethod.new(stubbee, :method_name)
     assert_equal stubbee.any_instance.mocha, method.mock


### PR DESCRIPTION
As suggested in #362.

Also addresses #270.

In fact, went a step further and got rid of `ClassMethod#method_visibility` as they were all essentially doing the same thing.

Similarly, the method doesn't exist anymore in `ObjectMethods`. `method_exists?` actually should anyway be available only on a `Class` instance, not on any `Object` instance.

Reduced some duplication in the action allow/prevent/warn check in `Mockery` as well, prompted by rubocop complaining about the combinatorial complexity of `on_stubbing` on the addition of just one expression to an `if` conditional.

Might be easier to review commit-by-commit than using just the diff.