### PR TITLE
Reduce duplication in AnyInstanceMethod class

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -3,14 +3,6 @@ require 'mocha/class_method'
 
 module Mocha
   class AnyInstanceMethod < ClassMethod
-    def mock
-      mock_owner.mocha
-    end
-
-    def reset_mocha
-      mock_owner.reset_mocha
-    end
-
     private
 
     def mock_owner

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -11,15 +11,6 @@ module Mocha
       stubbee.any_instance.reset_mocha
     end
 
-    def restore_original_method
-      return if use_prepended_module_for_stub_method?
-      if stub_method_overwrites_original_method?
-        original_method_owner.send(:define_method, method_name, original_method_body)
-      end
-      return unless original_visibility
-      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
-    end
-
     private
 
     def original_method_body

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -4,14 +4,18 @@ require 'mocha/class_method'
 module Mocha
   class AnyInstanceMethod < ClassMethod
     def mock
-      stubbee.any_instance.mocha
+      mock_owner.mocha
     end
 
     def reset_mocha
-      stubbee.any_instance.reset_mocha
+      mock_owner.reset_mocha
     end
 
     private
+
+    def mock_owner
+      stubbee.any_instance
+    end
 
     def original_method_body
       original_method

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,13 +14,17 @@ module Mocha
     def restore_original_method
       return if use_prepended_module_for_stub_method?
       if stub_method_overwrites_original_method?
-        original_method_owner.send(:define_method, method_name, original_method)
+        original_method_owner.send(:define_method, method_name, original_method_body)
       end
       return unless original_visibility
       Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
     private
+
+    def original_method_body
+      original_method
+    end
 
     def store_original_method
       @original_method = original_method_owner.instance_method(method_name)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -18,7 +18,8 @@ module Mocha
     end
 
     def stub_method_body(method_name)
-      proc { |*args, &block| self.class.any_instance.mocha.method_missing(method_name, *args, &block) }
+      self_in_scope = self
+      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
     end
 
     def original_method_owner

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -17,11 +17,6 @@ module Mocha
       @original_method = original_method_owner.instance_method(method_name)
     end
 
-    def stub_method_body(method_name)
-      self_in_scope = self
-      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
-    end
-
     def original_method_owner
       stubbee
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,8 +13,10 @@ module Mocha
 
     def restore_original_method
       return if use_prepended_module_for_stub_method?
-      return unless stub_method_overwrites_original_method?
-      original_method_owner.send(:define_method, method_name, original_method)
+      if stub_method_overwrites_original_method?
+        original_method_owner.send(:define_method, method_name, original_method)
+      end
+      return unless original_visibility
       Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -21,13 +21,8 @@ module Mocha
       @original_method = original_method_owner.instance_method(method_name)
     end
 
-    def stub_method_definition
-      method_implementation = <<-CODE
-      def #{method_name}(*args, &block)
-        self.class.any_instance.mocha.method_missing(:#{method_name}, *args, &block)
-      end
-      CODE
-      [method_implementation, __FILE__, __LINE__ - 4]
+    def stub_method_body(method_name)
+      proc { |*args, &block| self.class.any_instance.mocha.method_missing(method_name, *args, &block) }
     end
 
     def original_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -77,7 +77,7 @@ module Mocha
         end
       end
       return unless original_visibility
-      Module.instance_method(original_visibility).bind(stubbee.singleton_class).call(method_name)
+      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
     def matches?(other)

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -55,7 +55,11 @@ module Mocha
     end
 
     def define_new_method
-      stub_method_owner.send(:define_method, method_name, stub_method_body(method_name))
+      self_in_scope = self
+      method_name_in_scope = method_name
+      stub_method_owner.send(:define_method, method_name) do |*args, &block|
+        self_in_scope.mock.method_missing(method_name_in_scope, *args, &block)
+      end
       retain_original_visibility(stub_method_owner)
     end
 
@@ -134,11 +138,6 @@ module Mocha
     def use_prepended_module_for_stub_method
       @stub_method_owner = PrependedModule.new
       original_method_owner.__send__ :prepend, @stub_method_owner
-    end
-
-    def stub_method_body(method_name)
-      self_in_scope = self
-      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
     end
 
     def stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -137,7 +137,8 @@ module Mocha
     end
 
     def stub_method_body(method_name)
-      proc { |*args, &block| mocha.method_missing(method_name, *args, &block) }
+      self_in_scope = self
+      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
     end
 
     def stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -95,29 +95,12 @@ module Mocha
 
     private
 
-    def mock_owner
-      stubbee
-    end
-
     def retain_original_visibility(method_owner)
       return unless original_visibility
       Module.instance_method(original_visibility).bind(method_owner).call(method_name)
     end
 
-    def original_method_body
-      if PRE_RUBY_V19
-        original_method_in_scope = original_method
-        proc { |*args, &block| original_method_in_scope.call(*args, &block) }
-      else
-        original_method
-      end
-    end
-
     attr_reader :original_method, :original_visibility
-
-    def store_original_method
-      @original_method = stubbee._method(method_name)
-    end
 
     def store_original_method_visibility
       @original_visibility = method_visibility
@@ -142,6 +125,23 @@ module Mocha
 
     def stub_method_owner
       @stub_method_owner ||= original_method_owner
+    end
+
+    def mock_owner
+      stubbee
+    end
+
+    def original_method_body
+      if PRE_RUBY_V19
+        original_method_in_scope = original_method
+        proc { |*args, &block| original_method_in_scope.call(*args, &block) }
+      else
+        original_method
+      end
+    end
+
+    def store_original_method
+      @original_method = stubbee._method(method_name)
     end
 
     def original_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -56,8 +56,7 @@ module Mocha
 
     def define_new_method
       stub_method_owner.send(:define_method, method_name, stub_method_body(method_name))
-      return unless original_visibility
-      Module.instance_method(original_visibility).bind(stub_method_owner).call(method_name)
+      retain_original_visibility(stub_method_owner)
     end
 
     def remove_new_method
@@ -69,8 +68,7 @@ module Mocha
       if stub_method_overwrites_original_method?
         original_method_owner.send(:define_method, method_name, original_method_body)
       end
-      return unless original_visibility
-      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
+      retain_original_visibility(original_method_owner)
     end
 
     def matches?(other)
@@ -92,6 +90,11 @@ module Mocha
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
+
+    def retain_original_visibility(method_owner)
+      return unless original_visibility
+      Module.instance_method(original_visibility).bind(method_owner).call(method_name)
+    end
 
     def original_method_body
       if PRE_RUBY_V19

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -69,12 +69,11 @@ module Mocha
       if stub_method_overwrites_original_method?
         if PRE_RUBY_V19
           original_method_in_scope = original_method
-          original_method_owner.send(:define_method, method_name) do |*args, &block|
-            original_method_in_scope.call(*args, &block)
-          end
+          original_method_body = proc { |*args, &block| original_method_in_scope.call(*args, &block) }
         else
-          original_method_owner.send(:define_method, method_name, original_method)
+          original_method_body = original_method
         end
+        original_method_owner.send(:define_method, method_name, original_method_body)
       end
       return unless original_visibility
       Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -28,11 +28,11 @@ module Mocha
     end
 
     def mock
-      stubbee.mocha
+      mock_owner.mocha
     end
 
     def reset_mocha
-      stubbee.reset_mocha
+      mock_owner.reset_mocha
     end
 
     def hide_original_method
@@ -90,6 +90,10 @@ module Mocha
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
+
+    def mock_owner
+      stubbee
+    end
 
     def retain_original_visibility(method_owner)
       return unless original_visibility

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -55,7 +55,7 @@ module Mocha
     end
 
     def define_new_method
-      stub_method_owner.class_eval(*stub_method_definition)
+      stub_method_owner.send(:define_method, method_name, stub_method_body(method_name))
       return unless original_visibility
       Module.instance_method(original_visibility).bind(stub_method_owner).call(method_name)
     end
@@ -129,13 +129,8 @@ module Mocha
       original_method_owner.__send__ :prepend, @stub_method_owner
     end
 
-    def stub_method_definition
-      method_implementation = <<-CODE
-      def #{method_name}(*args, &block)
-        mocha.method_missing(:#{method_name}, *args, &block)
-      end
-      CODE
-      [method_implementation, __FILE__, __LINE__ - 4]
+    def stub_method_body(method_name)
+      proc { |*args, &block| mocha.method_missing(method_name, *args, &block) }
     end
 
     def stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -67,12 +67,6 @@ module Mocha
     def restore_original_method
       return if use_prepended_module_for_stub_method?
       if stub_method_overwrites_original_method?
-        if PRE_RUBY_V19
-          original_method_in_scope = original_method
-          original_method_body = proc { |*args, &block| original_method_in_scope.call(*args, &block) }
-        else
-          original_method_body = original_method
-        end
         original_method_owner.send(:define_method, method_name, original_method_body)
       end
       return unless original_visibility
@@ -98,6 +92,15 @@ module Mocha
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
+
+    def original_method_body
+      if PRE_RUBY_V19
+        original_method_in_scope = original_method
+        proc { |*args, &block| original_method_in_scope.call(*args, &block) }
+      else
+        original_method
+      end
+    end
 
     attr_reader :original_method, :original_visibility
 

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 29
+    expected_line_number = 21
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 30
+    expected_line_number = 32
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 21
+    expected_line_number = 22
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 27
+    expected_line_number = 25
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 141
+    expected_line_number = 61
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 36
+    expected_line_number = 27
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 32
+    expected_line_number = 36
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 25
+    expected_line_number = 29
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -55,8 +55,8 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.hide_original_method
     method.define_new_method
 
-    expected_filename = 'any_instance_method.rb'
-    expected_line_number = 22
+    expected_filename = 'class_method.rb'
+    expected_line_number = 141
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 133
+    expected_line_number = 132
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 136
+    expected_line_number = 140
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 135
+    expected_line_number = 133
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 141
+    expected_line_number = 61
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 140
+    expected_line_number = 141
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 133
+    expected_line_number = 136
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 132
+    expected_line_number = 135
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|


### PR DESCRIPTION
As suggested in #359.

Also addresses #332

Build is currently failing due to minitest latest version not supporting ruby 1.8.6 as described [here](https://github.com/freerange/mocha/pull/370#issuecomment-537675002)