### PR TITLE
Pin minitest to v5.11.3 for Ruby v1.8.7 to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
       gemfile: Gemfile
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 1.8.7-p371
-      gemfile: gemfiles/Gemfile.minitest.latest
+      gemfile: gemfiles/Gemfile.minitest.5.11.3
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: 1.8.7-p371
       gemfile: gemfiles/Gemfile.minitest.2.11.2

--- a/gemfiles/Gemfile.minitest.5.11.3
+++ b/gemfiles/Gemfile.minitest.5.11.3
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec :path=>"../"
+
+group :development do
+  gem "minitest", "5.11.3"
+end


### PR DESCRIPTION
This is because minitest > v5.11.3 uses look-behind assertions in regular expressions which are [not supported in the regular expression engine for Ruby < v1.9][1]. This has been causing build errors like [this one][2].

As suggested by @nitishr in [this comment][3], this commit pins minitest to v5.11.3 in the integration test build for Ruby v1.8.7 which should hopefully fix the build.

It's worth noting that minitest has also [officially dropped support for Ruby < v2.2][4], but currently this doesn't appear to be affecting the build. I'm happy to address this only if/when it actually becomes a problem.

[1]: https://github.com/seattlerb/minitest/issues/803#issuecomment-534326499
[2]: https://travis-ci.org/floehopper/metaclass/jobs/588418080
[3]: https://github.com/freerange/mocha/pull/370#issuecomment-537675002
[4]: https://github.com/seattlerb/minitest/blob/15ed8e4ce504c8313058a1d6fc4918299be34328/History.rdoc#5122--2019-09-28