### PR TITLE
Upgrade JRuby to v9.2.8.0 in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - 2.4.4
   - 2.5.1
   - ruby-head
-  - jruby-9.1.17.0
+  - jruby-9.2.8.0
   - jruby-head
   - truffleruby
 gemfile:
@@ -27,7 +27,7 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.8.0
       gemfile: gemfiles/Gemfile.minitest.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=minitest
     - rvm: ruby-head
@@ -102,7 +102,7 @@ matrix:
     - rvm: truffleruby
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.8.0
       gemfile: gemfiles/Gemfile.test-unit.latest
       env: MOCHA_OPTIONS=debug MOCHA_RUN_INTEGRATION_TESTS=test-unit
     - rvm: jruby-head


### PR DESCRIPTION
Release: https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html

Note that there was a problem with JRuby v9.2.8.0 (see #364), so I'm
skipping that version in the hope that the problem is now resolved.