### PR TITLE
accept symbol as mock/stub name

### DIFF
--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -21,7 +21,7 @@ module Mocha
 
     # Builds a new mock object
     #
-    # @param [String] name identifies mock object in error messages.
+    # @param [String, Symbol] name identifies mock object in error messages.
     # @param [Hash] expected_methods_vs_return_values expected method name symbols as keys and corresponding return values as values - these expectations are setup as if {Mock#expects} were called multiple times.
     # @yield optional block to be evaluated in the context of the mock object instance, giving an alternative way to setup stubbed methods.
     # @yield note that the block is evaulated by calling Mock#instance_eval and so things like instance variables declared in the test will not be available within the block.
@@ -50,7 +50,7 @@ module Mocha
     #     # an error will only be raised if Motor#start(100.rpm) has not been called
     #   end
     def mock(*arguments, &block)
-      name = arguments.shift if arguments.first.is_a?(String)
+      name = arguments.shift if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
       expectations = arguments.shift || {}
       mock = name ? Mockery.instance.named_mock(name, &block) : Mockery.instance.unnamed_mock(&block)
       mock.expects(expectations)
@@ -59,7 +59,7 @@ module Mocha
 
     # Builds a new mock object
     #
-    # @param [String] name identifies mock object in error messages.
+    # @param [String, Symbol] name identifies mock object in error messages.
     # @param [Hash] stubbed_methods_vs_return_values stubbed method name symbols as keys and corresponding return values as values - these stubbed methods are setup as if {Mock#stubs} were called multiple times.
     # @yield optional block to be evaluated in the context of the mock object instance, giving an alternative way to setup stubbed methods.
     # @yield note that the block is evaulated by calling Mock#instance_eval and so things like instance variables declared in the test will not be available within the block.
@@ -89,7 +89,7 @@ module Mocha
     #     # an error will only be raised if Motor#start(100.rpm) has not been called
     #   end
     def stub(*arguments, &block)
-      name = arguments.shift if arguments.first.is_a?(String)
+      name = arguments.shift if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
       expectations = arguments.shift || {}
       stub = name ? Mockery.instance.named_mock(name, &block) : Mockery.instance.unnamed_mock(&block)
       stub.stubs(expectations)
@@ -98,7 +98,7 @@ module Mocha
 
     # Builds a mock object that accepts calls to any method. By default it will return +nil+ for any method call.
     #
-    # @param [String] name identifies mock object in error messages.
+    # @param [String, Symbol] name identifies mock object in error messages.
     # @param [Hash] stubbed_methods_vs_return_values stubbed method name symbols as keys and corresponding return values as values - these stubbed methods are setup as if {Mock#stubs} were called multiple times.
     # @yield optional block to be evaluated in the context of the mock object instance, giving an alternative way to setup stubbed methods.
     # @yield note that the block is evaulated by calling Mock#instance_eval and so things like instance variables declared in the test will not be available within the block.
@@ -117,7 +117,7 @@ module Mocha
     #     assert motor.stop
     #   end
     def stub_everything(*arguments, &block)
-      name = arguments.shift if arguments.first.is_a?(String)
+      name = arguments.shift if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
       expectations = arguments.shift || {}
       stub = name ? Mockery.instance.named_mock(name, &block) : Mockery.instance.unnamed_mock(&block)
       stub.stub_everything

--- a/lib/mocha/names.rb
+++ b/lib/mocha/names.rb
@@ -21,7 +21,7 @@ module Mocha
 
   class Name
     def initialize(name)
-      @name = name
+      @name = name.to_s
     end
 
     def mocha_inspect

--- a/test/acceptance/mock_test.rb
+++ b/test/acceptance/mock_test.rb
@@ -29,7 +29,7 @@ class MockTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
-  def test_should_build_named_mock_and_explicitly_add_an_expectation_which_is_satisfied
+  def test_should_build_string_named_mock_and_explicitly_add_an_expectation_which_is_satisfied
     test_result = run_as_test do
       foo = mock('foo')
       foo.expects(:bar)
@@ -38,9 +38,26 @@ class MockTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
-  def test_should_build_named_mock_and_explicitly_add_an_expectation_which_is_not_satisfied
+  def test_should_build_symbol_named_mock_and_explicitly_add_an_expectation_which_is_satisfied
+    test_result = run_as_test do
+      foo = mock(:foo)
+      foo.expects(:bar)
+      foo.bar
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_build_string_named_mock_and_explicitly_add_an_expectation_which_is_not_satisfied
     test_result = run_as_test do
       foo = mock('foo')
+      foo.expects(:bar)
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_build_symbol_named_mock_and_explicitly_add_an_expectation_which_is_not_satisfied
+    test_result = run_as_test do
+      foo = mock(:foo)
       foo.expects(:bar)
     end
     assert_failed(test_result)
@@ -71,7 +88,7 @@ class MockTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
-  def test_should_build_named_mock_incorporating_two_expectations_which_are_satisifed
+  def test_should_build_string_named_mock_incorporating_two_expectations_which_are_satisifed
     test_result = run_as_test do
       foo = mock('foo', :bar => 'bar', :baz => 'baz')
       foo.bar
@@ -80,7 +97,16 @@ class MockTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
-  def test_should_build_named_mock_incorporating_two_expectations_the_first_of_which_is_not_satisifed
+  def test_should_build_symbol_named_mock_incorporating_two_expectations_which_are_satisifed
+    test_result = run_as_test do
+      foo = mock(:foo, :bar => 'bar', :baz => 'baz')
+      foo.bar
+      foo.baz
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_build_string_named_mock_incorporating_two_expectations_the_first_of_which_is_not_satisifed
     test_result = run_as_test do
       foo = mock('foo', :bar => 'bar', :baz => 'baz')
       foo.baz
@@ -88,9 +114,25 @@ class MockTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
-  def test_should_build_named_mock_incorporating_two_expectations_the_second_of_which_is_not_satisifed
+  def test_should_build_symbol_named_mock_incorporating_two_expectations_the_first_of_which_is_not_satisifed
+    test_result = run_as_test do
+      foo = mock(:foo, :bar => 'bar', :baz => 'baz')
+      foo.baz
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_build_string_named_mock_incorporating_two_expectations_the_second_of_which_is_not_satisifed
     test_result = run_as_test do
       foo = mock('foo', :bar => 'bar', :baz => 'baz')
+      foo.bar
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_build_symbol_named_mock_incorporating_two_expectations_the_second_of_which_is_not_satisifed
+    test_result = run_as_test do
+      foo = mock(:foo, :bar => 'bar', :baz => 'baz')
       foo.bar
     end
     assert_failed(test_result)


### PR DESCRIPTION
Looking at #353 and #347 , I thought instead of deprecating / preventing calling Mocha::API#mock or #stub with single symbol, we could treat the first symbol as the test double name, i.e. accept strings as well as symbols for test double names.

There's a bit of duplication I'd like to remove, but only if the basic idea is acceptable.