### PR TITLE
Reduce duplication in any instance method class

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -15,8 +15,9 @@ module Mocha
       return if use_prepended_module_for_stub_method?
       if stub_method_overwrites_original_method?
         original_method_owner.send(:define_method, method_name, original_method)
-        Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
       end
+      return unless original_visibility
+      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
     private

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -3,14 +3,6 @@ require 'mocha/class_method'
 
 module Mocha
   class AnyInstanceMethod < ClassMethod
-    def mock
-      mock_owner.mocha
-    end
-
-    def reset_mocha
-      mock_owner.reset_mocha
-    end
-
     private
 
     def mock_owner

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -11,15 +11,6 @@ module Mocha
       stubbee.any_instance.reset_mocha
     end
 
-    def restore_original_method
-      return if use_prepended_module_for_stub_method?
-      if stub_method_overwrites_original_method?
-        original_method_owner.send(:define_method, method_name, original_method_body)
-      end
-      return unless original_visibility
-      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
-    end
-
     private
 
     def original_method_body

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -4,14 +4,18 @@ require 'mocha/class_method'
 module Mocha
   class AnyInstanceMethod < ClassMethod
     def mock
-      stubbee.any_instance.mocha
+      mock_owner.mocha
     end
 
     def reset_mocha
-      stubbee.any_instance.reset_mocha
+      mock_owner.reset_mocha
     end
 
     private
+
+    def mock_owner
+      stubbee.any_instance
+    end
 
     def original_method_body
       original_method

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -14,13 +14,17 @@ module Mocha
     def restore_original_method
       return if use_prepended_module_for_stub_method?
       if stub_method_overwrites_original_method?
-        original_method_owner.send(:define_method, method_name, original_method)
+        original_method_owner.send(:define_method, method_name, original_method_body)
       end
       return unless original_visibility
       Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
     private
+
+    def original_method_body
+      original_method
+    end
 
     def store_original_method
       @original_method = original_method_owner.instance_method(method_name)

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -18,7 +18,8 @@ module Mocha
     end
 
     def stub_method_body(method_name)
-      proc { |*args, &block| self.class.any_instance.mocha.method_missing(method_name, *args, &block) }
+      self_in_scope = self
+      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
     end
 
     def original_method_owner

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -17,11 +17,6 @@ module Mocha
       @original_method = original_method_owner.instance_method(method_name)
     end
 
-    def stub_method_body(method_name)
-      self_in_scope = self
-      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
-    end
-
     def original_method_owner
       stubbee
     end

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -13,9 +13,10 @@ module Mocha
 
     def restore_original_method
       return if use_prepended_module_for_stub_method?
-      return unless stub_method_overwrites_original_method?
-      original_method_owner.send(:define_method, method_name, original_method)
-      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
+      if stub_method_overwrites_original_method?
+        original_method_owner.send(:define_method, method_name, original_method)
+        Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
+      end
     end
 
     private

--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -21,13 +21,8 @@ module Mocha
       @original_method = original_method_owner.instance_method(method_name)
     end
 
-    def stub_method_definition
-      method_implementation = <<-CODE
-      def #{method_name}(*args, &block)
-        self.class.any_instance.mocha.method_missing(:#{method_name}, *args, &block)
-      end
-      CODE
-      [method_implementation, __FILE__, __LINE__ - 4]
+    def stub_method_body(method_name)
+      proc { |*args, &block| self.class.any_instance.mocha.method_missing(method_name, *args, &block) }
     end
 
     def original_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -77,7 +77,7 @@ module Mocha
         end
       end
       return unless original_visibility
-      Module.instance_method(original_visibility).bind(stubbee.singleton_class).call(method_name)
+      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
     end
 
     def matches?(other)

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -55,7 +55,11 @@ module Mocha
     end
 
     def define_new_method
-      stub_method_owner.send(:define_method, method_name, stub_method_body(method_name))
+      self_in_scope = self
+      method_name_in_scope = method_name
+      stub_method_owner.send(:define_method, method_name) do |*args, &block|
+        self_in_scope.mock.method_missing(method_name_in_scope, *args, &block)
+      end
       retain_original_visibility(stub_method_owner)
     end
 
@@ -134,11 +138,6 @@ module Mocha
     def use_prepended_module_for_stub_method
       @stub_method_owner = PrependedModule.new
       original_method_owner.__send__ :prepend, @stub_method_owner
-    end
-
-    def stub_method_body(method_name)
-      self_in_scope = self
-      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
     end
 
     def stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -137,7 +137,8 @@ module Mocha
     end
 
     def stub_method_body(method_name)
-      proc { |*args, &block| mocha.method_missing(method_name, *args, &block) }
+      self_in_scope = self
+      proc { |*args, &block| self_in_scope.mock.method_missing(method_name, *args, &block) }
     end
 
     def stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -95,29 +95,12 @@ module Mocha
 
     private
 
-    def mock_owner
-      stubbee
-    end
-
     def retain_original_visibility(method_owner)
       return unless original_visibility
       Module.instance_method(original_visibility).bind(method_owner).call(method_name)
     end
 
-    def original_method_body
-      if PRE_RUBY_V19
-        original_method_in_scope = original_method
-        proc { |*args, &block| original_method_in_scope.call(*args, &block) }
-      else
-        original_method
-      end
-    end
-
     attr_reader :original_method, :original_visibility
-
-    def store_original_method
-      @original_method = stubbee._method(method_name)
-    end
 
     def store_original_method_visibility
       @original_visibility = method_visibility
@@ -142,6 +125,23 @@ module Mocha
 
     def stub_method_owner
       @stub_method_owner ||= original_method_owner
+    end
+
+    def mock_owner
+      stubbee
+    end
+
+    def original_method_body
+      if PRE_RUBY_V19
+        original_method_in_scope = original_method
+        proc { |*args, &block| original_method_in_scope.call(*args, &block) }
+      else
+        original_method
+      end
+    end
+
+    def store_original_method
+      @original_method = stubbee._method(method_name)
     end
 
     def original_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -56,8 +56,7 @@ module Mocha
 
     def define_new_method
       stub_method_owner.send(:define_method, method_name, stub_method_body(method_name))
-      return unless original_visibility
-      Module.instance_method(original_visibility).bind(stub_method_owner).call(method_name)
+      retain_original_visibility(stub_method_owner)
     end
 
     def remove_new_method
@@ -69,8 +68,7 @@ module Mocha
       if stub_method_overwrites_original_method?
         original_method_owner.send(:define_method, method_name, original_method_body)
       end
-      return unless original_visibility
-      Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)
+      retain_original_visibility(original_method_owner)
     end
 
     def matches?(other)
@@ -92,6 +90,11 @@ module Mocha
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
+
+    def retain_original_visibility(method_owner)
+      return unless original_visibility
+      Module.instance_method(original_visibility).bind(method_owner).call(method_name)
+    end
 
     def original_method_body
       if PRE_RUBY_V19

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -69,12 +69,11 @@ module Mocha
       if stub_method_overwrites_original_method?
         if PRE_RUBY_V19
           original_method_in_scope = original_method
-          original_method_owner.send(:define_method, method_name) do |*args, &block|
-            original_method_in_scope.call(*args, &block)
-          end
+          original_method_body = proc { |*args, &block| original_method_in_scope.call(*args, &block) }
         else
-          original_method_owner.send(:define_method, method_name, original_method)
+          original_method_body = original_method
         end
+        original_method_owner.send(:define_method, method_name, original_method_body)
       end
       return unless original_visibility
       Module.instance_method(original_visibility).bind(original_method_owner).call(method_name)

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -28,11 +28,11 @@ module Mocha
     end
 
     def mock
-      stubbee.mocha
+      mock_owner.mocha
     end
 
     def reset_mocha
-      stubbee.reset_mocha
+      mock_owner.reset_mocha
     end
 
     def hide_original_method
@@ -90,6 +90,10 @@ module Mocha
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
+
+    def mock_owner
+      stubbee
+    end
 
     def retain_original_visibility(method_owner)
       return unless original_visibility

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -55,7 +55,7 @@ module Mocha
     end
 
     def define_new_method
-      stub_method_owner.class_eval(*stub_method_definition)
+      stub_method_owner.send(:define_method, method_name, stub_method_body(method_name))
       return unless original_visibility
       Module.instance_method(original_visibility).bind(stub_method_owner).call(method_name)
     end
@@ -129,13 +129,8 @@ module Mocha
       original_method_owner.__send__ :prepend, @stub_method_owner
     end
 
-    def stub_method_definition
-      method_implementation = <<-CODE
-      def #{method_name}(*args, &block)
-        mocha.method_missing(:#{method_name}, *args, &block)
-      end
-      CODE
-      [method_implementation, __FILE__, __LINE__ - 4]
+    def stub_method_body(method_name)
+      proc { |*args, &block| mocha.method_missing(method_name, *args, &block) }
     end
 
     def stub_method_owner

--- a/lib/mocha/class_method.rb
+++ b/lib/mocha/class_method.rb
@@ -67,12 +67,6 @@ module Mocha
     def restore_original_method
       return if use_prepended_module_for_stub_method?
       if stub_method_overwrites_original_method?
-        if PRE_RUBY_V19
-          original_method_in_scope = original_method
-          original_method_body = proc { |*args, &block| original_method_in_scope.call(*args, &block) }
-        else
-          original_method_body = original_method
-        end
         original_method_owner.send(:define_method, method_name, original_method_body)
       end
       return unless original_visibility
@@ -98,6 +92,15 @@ module Mocha
     alias_method :method_defined_in_stubbee_or_in_ancestor_chain?, :method_visibility
 
     private
+
+    def original_method_body
+      if PRE_RUBY_V19
+        original_method_in_scope = original_method
+        proc { |*args, &block| original_method_in_scope.call(*args, &block) }
+      else
+        original_method
+      end
+    end
 
     attr_reader :original_method, :original_visibility
 

--- a/test/acceptance/stub_any_instance_method_test.rb
+++ b/test/acceptance/stub_any_instance_method_test.rb
@@ -43,6 +43,26 @@ class StubAnyInstanceMethodTest < Mocha::TestCase
     assert_equal :original_return_value, instance.my_instance_method
   end
 
+  def test_should_leave_stubbed_public_method_unchanged_after_test_when_it_was_originally_private_in_owning_module
+    module_with_private_method = Module.new do
+      def my_included_method
+        :original_return_value
+      end
+      private :my_included_method
+    end
+    klass = Class.new do
+      include module_with_private_method
+      public :my_included_method
+    end
+    instance = klass.new
+    test_result = run_as_test do
+      klass.any_instance.stubs(:my_included_method).returns(:new_return_value)
+      assert_equal :new_return_value, instance.my_included_method
+    end
+    assert_passed(test_result)
+    assert_equal :original_return_value, instance.my_included_method
+  end
+
   def test_should_leave_stubbed_protected_method_unchanged_after_test
     klass = Class.new do
       def my_instance_method

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 29
+    expected_line_number = 21
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 21
+    expected_line_number = 22
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 27
+    expected_line_number = 25
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 30
+    expected_line_number = 31
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 141
+    expected_line_number = 61
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 36
+    expected_line_number = 27
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 31
+    expected_line_number = 32
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 32
+    expected_line_number = 36
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -56,7 +56,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'any_instance_method.rb'
-    expected_line_number = 25
+    expected_line_number = 29
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -55,8 +55,8 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.hide_original_method
     method.define_new_method
 
-    expected_filename = 'any_instance_method.rb'
-    expected_line_number = 22
+    expected_filename = 'class_method.rb'
+    expected_line_number = 141
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 133
+    expected_line_number = 132
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 136
+    expected_line_number = 140
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 135
+    expected_line_number = 133
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 141
+    expected_line_number = 61
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 140
+    expected_line_number = 141
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 133
+    expected_line_number = 136
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/class_method_test.rb
+++ b/test/unit/class_method_test.rb
@@ -60,7 +60,7 @@ class ClassMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'class_method.rb'
-    expected_line_number = 132
+    expected_line_number = 135
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|


### PR DESCRIPTION
Identical to https://github.com/freerange/mocha/tree/reduce-duplication-in-any-instance-method-class, except that it fixes the (newly added) hanging test by not snapshotting.

The test seemed to be hanging inside Snapshot constructor (`unbound_method = receiver.instance_method(method)`). Most other tests in the file don't check the snapshot, either. The test should be good enough without a snapshot.

This has removed the co-authoring because of a fixup & rebase. I'll try to fix that if I can figure out how to.