### PR TITLE
Make yields fail when the caller does not provide a block

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -223,7 +223,7 @@ module Mocha
       self
     end
 
-    # Modifies expectation so that when the expected method is called, it yields with the specified +parameters+.
+    # Modifies expectation so that when the expected method is called, it yields with the specified +parameters+ (even if no block is provided, in which case yielding will result in a +LocalJumpError+).
     #
     # May be called multiple times on the same expectation for consecutive invocations.
     #
@@ -252,7 +252,7 @@ module Mocha
       self
     end
 
-    # Modifies expectation so that when the expected method is called, it yields multiple times per invocation with the specified +parameter_groups+.
+    # Modifies expectation so that when the expected method is called, it yields multiple times per invocation with the specified +parameter_groups+ (even if no block is provided, in which case yielding will result in a +LocalJumpError+).
     #
     # @param [*Array<Array>] parameter_groups each element of +parameter_groups+ should iself be an +Array+ representing the parameters to be passed to the block for a single yield.
     # @return [Expectation] the same expectation, thereby allowing invocations of other {Expectation} methods to be chained.
@@ -560,10 +560,8 @@ module Mocha
     def invoke
       @invocation_count += 1
       perform_side_effects
-      if block_given?
-        @yield_parameters.next_invocation.each do |yield_parameters|
-          yield(*yield_parameters)
-        end
+      @yield_parameters.next_invocation.each do |yield_parameters|
+        yield(*yield_parameters)
       end
       @return_values.next
     end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -112,6 +112,11 @@ class ExpectationTest < Mocha::TestCase
     assert_equal [], yielded_parameters
   end
 
+  def test_yield_should_fail_when_the_caller_does_not_provide_a_block
+    expectation = new_expectation.yields(:foo)
+    assert_raise(LocalJumpError) { expectation.invoke }
+  end
+
   def test_should_yield_with_specified_parameters
     expectation = new_expectation.yields(1, 2, 3)
     yielded_parameters = nil

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -17,18 +17,15 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_match_calls_to_same_method_with_exactly_zero_parameters
-    expectation = new_expectation.with
-    assert expectation.match?(:expected_method)
+    assert new_expectation.with.match?(:expected_method)
   end
 
   def test_should_not_match_calls_to_same_method_with_more_than_zero_parameters
-    expectation = new_expectation.with
-    assert !expectation.match?(:expected_method, 1, 2, 3)
+    assert !new_expectation.with.match?(:expected_method, 1, 2, 3)
   end
 
   def test_should_match_calls_to_same_method_with_expected_parameter_values
-    expectation = new_expectation.with(1, 2, 3)
-    assert expectation.match?(:expected_method, 1, 2, 3)
+    assert new_expectation.with(1, 2, 3).match?(:expected_method, 1, 2, 3)
   end
 
   def test_should_match_calls_to_same_method_with_parameters_constrained_as_expected
@@ -46,18 +43,15 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_not_match_calls_to_same_method_with_too_few_parameters
-    expectation = new_expectation.with(1, 2, 3)
-    assert !expectation.match?(:unexpected_method, 1, 2)
+    assert !new_expectation.with(1, 2, 3).match?(:unexpected_method, 1, 2)
   end
 
   def test_should_not_match_calls_to_same_method_with_too_many_parameters
-    expectation = new_expectation.with(1, 2)
-    assert !expectation.match?(:unexpected_method, 1, 2, 3)
+    assert !new_expectation.with(1, 2).match?(:unexpected_method, 1, 2, 3)
   end
 
   def test_should_not_match_calls_to_same_method_with_unexpected_parameter_values
-    expectation = new_expectation.with(1, 2, 3)
-    assert !expectation.match?(:unexpected_method, 1, 0, 3)
+    assert !new_expectation.with(1, 2, 3).match?(:unexpected_method, 1, 0, 3)
   end
 
   def test_should_not_match_calls_to_same_method_with_parameters_not_constrained_as_expected


### PR DESCRIPTION
This is more reasonable and realistic than yielding only if a block is given. A stub that's set up to yield must unconditionally yield, just like it would unconditionally raise or return when set up to do so. The block_given? check should be the responsibility of the original method implementation if it so chooses. A stub set up to yield is presumably set up to simulate the code path that actually yields.

In rspec-mocks as well, [It fails when the caller does not provide a block]( https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/configuring-responses/yielding#it-fails-when-the-caller-does-not-provide-a-block). (Note: Unlike rspec-mocks, I did not choose that [It fails when the caller's block does not accept the provided arguments](https://relishapp.com/rspec/rspec-mocks/v/3-9/docs/configuring-responses/yielding#it-fails-when-the-caller's-block-does-not-accept-the-provided-arguments) because that's not how yielding from a real method would behave.)

P.S. This change was prompted by looking at rspec-mocks docs to get ideas for #352. 