### PR TITLE
Improve documentation for responds_like{,_instance_of}

### DIFF
--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -8,6 +8,29 @@ require 'mocha/class_methods'
 
 module Mocha
   # Methods added to +Test::Unit::TestCase+, +MiniTest::Unit::TestCase+ or equivalent.
+  # The mock creation methods are {#mock}, {#stub} and {#stub_everything}, all of which return a #{Mock}
+  # which can be further modified by {Mock#responds_like} and {Mock#responds_like_instance_of} methods,
+  # both of which return a {Mock}, too, and can therefore, be chained to the original creation methods.
+  #
+  # {Mock#responds_like} and {Mock#responds_like_instance_of} force the mock to indicate what it is
+  # supposed to be mocking, thus making it a safer verifying mock. They check that the underlying +responder+
+  # will actually respond to the methods being stubbed, throwing a +NoMethodError+ upon invocation otherwise.
+  #
+  # @example Verifying mock using {Mock#responds_like_instance_of}
+  #   class Sheep
+  #     def initialize
+  #       raise "some awkward code we don't want to call"
+  #     end
+  #     def chew(grass); end
+  #   end
+  #
+  #   sheep = mock('sheep').responds_like_instance_of(Sheep)
+  #   sheep.expects(:chew)
+  #   sheep.expects(:foo)
+  #   sheep.respond_to?(:chew) # => true
+  #   sheep.respond_to?(:foo) # => false
+  #   sheep.chew
+  #   sheep.foo # => raises NoMethodError exception
   module API
     include ParameterMatchers
     include Hooks

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -14,8 +14,15 @@ require 'mocha/ruby_version'
 module Mocha
   # Traditional mock object.
   #
-  # All methods return an {Expectation} which can be further modified by
-  # methods on {Expectation}.
+  # {expects} and {stubs} return an {Expectation} which can be further modified
+  # by methods on {Expectation}.
+  #
+  # {responds_like} and {responds_like_instance_of} both return a {Mock}, and
+  # can therefore, be chained to the original creation methods in {API}.
+  # They force the mock to indicate what it is supposed to be mocking, thus
+  # making it a safer verifying mock. They check that the underlying +responder+
+  # will actually respond to the methods being stubbed, throwing a
+  # +NoMethodError+ upon invocation otherwise.
   #
   # Stubs and expectations are basically the same thing. A stub is just an
   # expectation of zero or more invocations. The {#stubs} method is syntactic


### PR DESCRIPTION
Make the chainability to #mock and #stub clearer, as suggested in #337 