### PR TITLE
don't prepend if already prepended PrependedModule

### DIFF
--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -123,8 +123,10 @@ module Mocha
     end
 
     def use_prepended_module_for_stub_method
-      @stub_method_owner = PrependedModule.new
-      original_method_owner.__send__ :prepend, @stub_method_owner
+      unless original_method_owner.ancestors.first.is_a?(PrependedModule)
+        original_method_owner.__send__ :prepend, PrependedModule.new
+      end
+      @stub_method_owner = original_method_owner.ancestors.first
     end
 
     def stub_method_owner

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -6,7 +6,21 @@ require 'mocha/any_instance_method'
 class AnyInstanceMethodTest < Mocha::TestCase
   include Mocha
 
-  unless RUBY_V2_PLUS
+  if RUBY_V2_PLUS
+    def test_should_reuse_existing_prepended_module_when_stubbing_multiple_existing_methods
+      klass = Class.new do
+        def method_x; end
+
+        def method_y; end
+      end
+
+      [:method_x, :method_y].each do |method_name|
+        method = AnyInstanceMethod.new(klass, method_name)
+        method.hide_original_method
+      end
+      assert_equal 1, klass.ancestors.grep(AnyInstanceMethod::PrependedModule).size
+    end
+  else
     def test_should_hide_original_method
       klass = Class.new { def method_x; end }
       method = AnyInstanceMethod.new(klass, :method_x)

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -7,7 +7,21 @@ require 'mocha/instance_method'
 class InstanceMethodTest < Mocha::TestCase
   include Mocha
 
-  unless RUBY_V2_PLUS
+  if RUBY_V2_PLUS
+    def test_should_reuse_existing_prepended_module_when_stubbing_multiple_existing_methods
+      klass = Class.new do
+        def self.method_x; end
+
+        def self.method_y; end
+      end
+
+      [:method_x, :method_y].each do |method_name|
+        method = InstanceMethod.new(klass, method_name)
+        method.hide_original_method
+      end
+      assert_equal 1, klass.singleton_class.ancestors.grep(InstanceMethod::PrependedModule).size
+    end
+  else
     def test_should_hide_original_method
       klass = Class.new { def self.method_x; end }
       klass.singleton_class.send(:alias_method, :_method, :method)


### PR DESCRIPTION
We used to always prepend an instance of PrependedModule even if an instance has
already been prepended. While this wasn't causing a problem, it felt messy and
could be confusing when debugging.

As suggested in #278 