### PR TITLE
require 'method_definer' mistakenly deleted

### DIFF
--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../test_helper', __FILE__)
+require 'method_definer'
 require 'mocha/mock'
 require 'mocha/singleton_class'
 


### PR DESCRIPTION
Noticed this while trying to run tests individually.