### PR TITLE
Don't over-write definition of singleton_class

### DIFF
--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -22,12 +22,12 @@ module Mocha
         Mocha::AnyInstanceMethod
       end
 
-      def respond_to?(method)
-        @stubba_object.allocate.respond_to?(method.to_sym)
+      def stubba_class
+        @stubba_object
       end
 
-      def singleton_class
-        @stubba_object
+      def respond_to?(method)
+        @stubba_object.allocate.respond_to?(method.to_sym)
       end
 
       attr_reader :stubba_object

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -129,10 +129,10 @@ module Mocha
       method = PRE_RUBY_V19 ? method.to_s : method.to_sym
       method_signature = "#{object.mocha_inspect}.#{method}"
       check(:stubbing_non_existent_method, 'non-existent method', method_signature) do
-        !(object.singleton_class.method_exists?(method, true) || object.respond_to?(method.to_sym))
+        !(object.stubba_class.method_exists?(method, true) || object.respond_to?(method.to_sym))
       end
       check(:stubbing_non_public_method, 'non-public method', method_signature) do
-        object.singleton_class.method_exists?(method, false)
+        object.stubba_class.method_exists?(method, false)
       end
       check(:stubbing_method_on_nil, 'method on nil', method_signature) { object.nil? }
       check(:stubbing_method_on_non_mock_object, 'method on non-mock object', method_signature)

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -35,6 +35,11 @@ module Mocha
       self
     end
 
+    # @private
+    def stubba_class
+      singleton_class
+    end
+
     # Adds an expectation that the specified method must be called exactly once with any parameters.
     #
     # The original implementation of the method is replaced during the test and then restored at the end of the test. The temporary replacement method has the same visibility as the original method.


### PR DESCRIPTION
Introduce stubba_class method as part of the contract between Mockery and the
object being stubbed.

As suggested in #391