### PR TITLE
Make signatures of {Mock,ObjectMethods}#unstub consistent

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -167,8 +167,10 @@ module Mocha
     #   object.stubbed_method # => :result_one
     #   object.unstub(:stubbed_method)
     #   object.stubbed_method # => unexpected invocation: #<Mock:mock>.stubbed_method()
-    def unstub(method_name)
-      @expectations.remove_all_matching_method(method_name)
+    def unstub(*method_names)
+      method_names.each do |method_name|
+        @expectations.remove_all_matching_method(method_name)
+      end
     end
 
     # Constrains the {Mock} instance so that it can only expect or stub methods to which +responder+ responds. The constraint is only applied at method invocation time.

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -339,11 +339,14 @@ class MockTest < Mocha::TestCase
     assert mock.respond_to?(:xyz)
   end
 
-  def test_should_remove_expectation_for_unstubbed_method
+  def test_should_remove_expectations_for_unstubbed_methods
     mock = build_mock
     mock.expects(:method1)
-    mock.unstub(:method1)
+    mock.expects(:method2)
+    mock.unstub(:method1, :method2)
     e = assert_raises(ExpectationErrorFactory.exception_class) { mock.method1 }
+    assert_match(/unexpected invocation/, e.message)
+    e = assert_raises(ExpectationErrorFactory.exception_class) { mock.method2 }
     assert_match(/unexpected invocation/, e.message)
   end
 


### PR DESCRIPTION
As suggested in #72 