### PR TITLE
Deprecate requiring 'mocha/setup'

### DIFF
--- a/lib/mocha/setup.rb
+++ b/lib/mocha/setup.rb
@@ -1,4 +1,9 @@
 require 'mocha/integration'
+require 'mocha/deprecation'
+
+Mocha::Deprecation.warning(
+  "Use `require 'mocha/test_unit'` or `require 'mocha/minitest'` instead."
+)
 
 module Mocha
   def self.activate


### PR DESCRIPTION
By forcing people to require the explicit integrations for Test::Unit or Minitest, we will be able to provide more useful feedback if the integration fails for some reason.

Note that requiring 'mocha/setup' was [removed from the README in the v1.0.0 release][1].

This addresses #398. 

[1]: https://github.com/freerange/mocha/commit/1d6b08f0c802a64f20464a4f2fa2ef6861deb9c8