### PR TITLE
Fix test failures on Mac OSX Catalina

### DIFF
--- a/lib/mocha/macos_version.rb
+++ b/lib/mocha/macos_version.rb
@@ -1,0 +1,5 @@
+module Mocha
+  MACOS = /darwin/.match(RUBY_PLATFORM)
+  MACOS_VERSION = MACOS && /darwin(\d+)$/.match(RUBY_PLATFORM)[1].to_i
+  MACOS_MOJAVE_VERSION = 18
+end

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/ruby_version'
+require 'mocha/macos_version'
 require 'mocha/mock'
 require 'mocha/expectation_error_factory'
 require 'set'
@@ -50,13 +51,17 @@ class MockTest < Mocha::TestCase
     initialize
   ].freeze
 
+  MACOS_EXCLUDED_METHODS =
+    MACOS && MACOS_VERSION >= MACOS_MOJAVE_VERSION ? [:syscall] : []
+
   RUBY_V19_AND_LATER_EXCLUDED_METHODS = [
     :object_id,
     :method_missing,
     :singleton_method_undefined,
     :initialize,
     :String,
-    :singleton_method_added
+    :singleton_method_added,
+    *MACOS_EXCLUDED_METHODS
   ].freeze
 
   OBJECT_METHODS = STANDARD_OBJECT_PUBLIC_INSTANCE_METHODS.reject do |m|

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -44,20 +44,24 @@ class MockTest < Mocha::TestCase
     assert_equal true, mock.eql?(mock)
   end
 
+  PRE_RUBY_V19_EXCLUDED_METHODS = %w[
+    method_missing
+    singleton_method_undefined
+    initialize
+  ].freeze
+
+  RUBY_V19_AND_LATER_EXCLUDED_METHODS = [
+    :object_id,
+    :method_missing,
+    :singleton_method_undefined,
+    :initialize,
+    :String,
+    :singleton_method_added
+  ].freeze
+
   EXCLUDED_METHODS = {
-    true => %w[
-      method_missing
-      singleton_method_undefined
-      initialize
-    ],
-    false => [
-      :object_id,
-      :method_missing,
-      :singleton_method_undefined,
-      :initialize,
-      :String,
-      :singleton_method_added
-    ]
+    true => PRE_RUBY_V19_EXCLUDED_METHODS,
+    false => RUBY_V19_AND_LATER_EXCLUDED_METHODS
   }.freeze
 
   OBJECT_METHODS = STANDARD_OBJECT_PUBLIC_INSTANCE_METHODS.reject do |m|

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -59,13 +59,10 @@ class MockTest < Mocha::TestCase
     :singleton_method_added
   ].freeze
 
-  EXCLUDED_METHODS = {
-    true => PRE_RUBY_V19_EXCLUDED_METHODS,
-    false => RUBY_V19_AND_LATER_EXCLUDED_METHODS
-  }.freeze
-
   OBJECT_METHODS = STANDARD_OBJECT_PUBLIC_INSTANCE_METHODS.reject do |m|
-    m =~ /^__.*__$/ || EXCLUDED_METHODS[PRE_RUBY_V19].include?(m)
+    (m =~ /^__.*__$/) ||
+      (PRE_RUBY_V19 && PRE_RUBY_V19_EXCLUDED_METHODS.include?(m)) ||
+      (!PRE_RUBY_V19 && RUBY_V19_AND_LATER_EXCLUDED_METHODS.include?(m))
   end
 
   def test_should_be_able_to_mock_standard_object_methods


### PR DESCRIPTION
This fixes the failures in #413, but I haven't investigated whether the test failures mean there is actually a problem stubbing `Kernel#syscall` on recent versions of Mac OSX. I've opened # 416 to capture the latter.