### PR TITLE
fix macos version extraction

### DIFF
--- a/lib/mocha/macos_version.rb
+++ b/lib/mocha/macos_version.rb
@@ -1,5 +1,5 @@
 module Mocha
   MACOS = /darwin/.match(RUBY_PLATFORM)
-  MACOS_VERSION = MACOS && /darwin(\d+)$/.match(RUBY_PLATFORM)[1].to_i
+  MACOS_VERSION = MACOS && /darwin(\d+)/.match(RUBY_PLATFORM)[1].to_i
   MACOS_MOJAVE_VERSION = 18
 end


### PR DESCRIPTION
RUBY_PLATFORM doesn't necessarily end with $, as it may include a minor version
number (e.g. x86_64-darwin18.7.0)