### PR TITLE
Hide ClassMethods#method_visibility & #method_exists? methods to avoid clash with Rails

### DIFF
--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -51,12 +51,12 @@ module Mocha
 
     # @private
     # rubocop:disable Metrics/CyclomaticComplexity
-    def method_visibility(method, include_public_methods = true)
+    def __method_visibility__(method, include_public_methods = true)
       (include_public_methods && public_method_defined?(method) && :public) ||
         (protected_method_defined?(method) && :protected) ||
         (private_method_defined?(method) && :private)
     end
     # rubocop:enable Metrics/CyclomaticComplexity
-    alias_method :method_exists?, :method_visibility
+    alias_method :method_exists?, :__method_visibility__
   end
 end

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -49,6 +49,7 @@ module Mocha
       @any_instance ||= AnyInstance.new(self)
     end
 
+    # @private
     # rubocop:disable Metrics/CyclomaticComplexity
     def method_visibility(method, include_public_methods = true)
       (include_public_methods && public_method_defined?(method) && :public) ||

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -57,6 +57,6 @@ module Mocha
         (private_method_defined?(method) && :private)
     end
     # rubocop:enable Metrics/CyclomaticComplexity
-    alias_method :method_exists?, :__method_visibility__
+    alias_method :__method_exists__?, :__method_visibility__
   end
 end

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -129,10 +129,10 @@ module Mocha
       method = PRE_RUBY_V19 ? method.to_s : method.to_sym
       method_signature = "#{object.mocha_inspect}.#{method}"
       check(:stubbing_non_existent_method, 'non-existent method', method_signature) do
-        !(object.stubba_class.method_exists?(method, true) || object.respond_to?(method.to_sym))
+        !(object.stubba_class.__method_exists__?(method, true) || object.respond_to?(method.to_sym))
       end
       check(:stubbing_non_public_method, 'non-public method', method_signature) do
-        object.stubba_class.method_exists?(method, false)
+        object.stubba_class.__method_exists__?(method, false)
       end
       check(:stubbing_method_on_nil, 'method on nil', method_signature) { object.nil? }
       check(:stubbing_method_on_non_mock_object, 'method on non-mock object', method_signature)

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -100,7 +100,7 @@ module Mocha
     attr_reader :original_method, :original_visibility
 
     def store_original_method_visibility
-      @original_visibility = original_method_owner.method_visibility(method_name)
+      @original_visibility = original_method_owner.__method_visibility__(method_name)
     end
 
     def stub_method_overwrites_original_method?

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -36,7 +36,7 @@ module Mocha
     end
 
     def hide_original_method
-      return unless original_method_owner.method_exists?(method_name)
+      return unless original_method_owner.__method_exists__?(method_name)
       store_original_method_visibility
       if use_prepended_module_for_stub_method?
         use_prepended_module_for_stub_method


### PR DESCRIPTION
These methods are not part of the public API and yet they are included into every class via `API.included`.

I think I've run into a clash with this method in a Rails v6.0.0 project in `activesupport/lib/active_support/core_ext/module/redefine_method.rb` which [defines `Module#method_visibility`][1].

`ClassMethods#method_visibility` was introduced in [this commit][2] which was added after the previous release (v0.9.0). I assume this is why we haven't seen the problem before.

We might want to consider doing something similar for methods on `ObjectMethods`. In particular, `ObjectMethods#stubba_class` has been added since the last release. However, the `stubba_` prefix is probably sufficiently obscure to make this less of a concern.

Note that we'll need to re-generate the docs before releasing this change, because I've also marked `ClassMethods#method_visibility` as not part of the documented API.

c.f. #70

It looks as if `Module#method_visiblity` has been [defined in Rails since v5.0.0.beta1][3], albeit in a different file.

[1]: https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/module/redefine_method.rb#L30-L39
[2]: https://github.com/freerange/mocha/commit/6e50d3818607066d2158a8a6d8313d49dd875f97
[3]: https://github.com/rails/rails/commit/7189e5554e44928698b01c59e833edfbebf0c6be#diff-73a5bed1e1ed94647c0a2c3a00902bf5
