### PR TITLE
move static yard options from rake task to .yardopts

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
+--output-dir docs
 --template-path yard-templates
 --no-private
 lib/mocha/api.rb

--- a/Rakefile
+++ b/Rakefile
@@ -138,10 +138,7 @@ if ENV['MOCHA_GENERATE_DOCS']
 
   desc 'Generate documentation'
   YARD::Rake::YardocTask.new('yardoc' => 'docs_environment') do |task|
-    task.options = [
-      '--title', "Mocha #{Mocha::VERSION}",
-      '--output-dir', 'docs'
-    ]
+    task.options = ['--title', "Mocha #{Mocha::VERSION}"]
   end
 
   task 'checkout_docs_cname' do


### PR DESCRIPTION
This allows docs to be generated without using rake using almost the same
options as with rake (except for the dynamic options requiring ruby code - which
at this point is only the title which includes Mocha::VERSION

Addresses #423 but by taking a different (almost opposite) approach. See reasoning above.