### PR TITLE
Reintroduce allow check removed in 948a0c2

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -151,14 +151,11 @@ module Mocha
     private
 
     def check(action, description, method_signature, backtrace = caller)
-      return if block_given? && !yield
+      treatment = Mocha.configuration.send(action)
+      return if (treatment == :allow) || (block_given? && !yield)
       message = "stubbing #{description}: #{method_signature}"
-      case Mocha.configuration.send(action)
-      when :warn
-        logger.warn(message)
-      when :prevent
-        raise StubbingError.new(message, backtrace)
-      end
+      raise StubbingError.new(message, backtrace) if treatment == :prevent
+      logger.warn(message) if treatment == :warn
     end
 
     def expectations

--- a/test/acceptance/stubbing_non_existent_any_instance_method_test.rb
+++ b/test/acceptance/stubbing_non_existent_any_instance_method_test.rb
@@ -76,6 +76,22 @@ class StubbingNonExistentAnyInstanceMethodTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  def test_should_default_to_allowing_stubbing_method_if_responds_to_depends_on_calling_initialize
+    klass = Class.new do
+      def initialize(attrs = {})
+        @attributes = attrs
+      end
+
+      def respond_to?(method, _include_private = false)
+        @attributes.key?(method) ? @attributes[method] : super
+      end
+    end
+    test_result = run_as_test do
+      klass.any_instance.stubs(:foo)
+    end
+    assert_passed(test_result)
+  end
+
   def test_should_allow_stubbing_existing_protected_any_instance_method
     Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
     klass = Class.new do


### PR DESCRIPTION
Fixes #432 by short-circuiting the method_exists? check in case the treatment of
the action is to allow it.