### PR TITLE
Optionally reinstate v1.9 behaviour of Expectation#yields & Expectation#multiple_yields when no block given

### DIFF
--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -250,6 +250,9 @@ module Mocha
 
     # Retain undocumented behaviour from v1.9
     #
+    # Previously if {Expectation#yields} or {Expectation#multiple_yields} was called on an expectation, but no block was given when the method was invoked, the instruction to yield was ignored.
+    # Now a LocalJumpError is raised.
+    #
     # Enabling this configuration option retains the previous behaviour, but displays a deprecation warning.
     #
     # @param [Boolean] value +true+ to retain undocumented behaviour; disabled by default.

--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -42,7 +42,8 @@ module Mocha
       :stubbing_non_existent_method => :allow,
       :stubbing_non_public_method => :allow,
       :stubbing_method_on_nil => :prevent,
-      :display_matching_invocations_on_failure => false
+      :display_matching_invocations_on_failure => false,
+      :retain_undocumented_behaviour_from_v1_9 => false
     }.freeze
 
     attr_reader :options
@@ -245,6 +246,20 @@ module Mocha
     # @private
     def display_matching_invocations_on_failure?
       @options[:display_matching_invocations_on_failure]
+    end
+
+    # Retain undocumented behaviour from v1.9
+    #
+    # Enabling this configuration option retains the previous behaviour, but displays a deprecation warning.
+    #
+    # @param [Boolean] value +true+ to retain undocumented behaviour; disabled by default.
+    def retain_undocumented_behaviour_from_v1_9=(value)
+      @options[:retain_undocumented_behaviour_from_v1_9] = value
+    end
+
+    # @private
+    def retain_undocumented_behaviour_from_v1_9?
+      @options[:retain_undocumented_behaviour_from_v1_9]
     end
 
     class << self

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -568,7 +568,7 @@ module Mocha
     def invoke(invocation)
       perform_side_effects
       @cardinality << invocation
-      invocation.call(@yield_parameters, @return_values) { |*yield_args| yield(*yield_args) }
+      invocation.call(@yield_parameters, @return_values)
     end
 
     # @private

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -3,6 +3,7 @@ require 'mocha/raised_exception'
 require 'mocha/return_values'
 require 'mocha/thrown_object'
 require 'mocha/yield_parameters'
+require 'mocha/deprecation'
 
 module Mocha
   class Invocation
@@ -20,8 +21,16 @@ module Mocha
     def call(yield_parameters = YieldParameters.new, return_values = ReturnValues.new)
       yield_parameters.next_invocation.each do |yield_args|
         @yields << ParametersMatcher.new(yield_args)
-        raise LocalJumpError unless @block
-        @block.call(*yield_args)
+        if @block
+          @block.call(*yield_args)
+        else
+          raise LocalJumpError unless Mocha.configuration.retain_undocumented_behaviour_from_v1_9?
+          yield_args_description = ParametersMatcher.new(yield_args).mocha_inspect
+          Deprecation.warning([
+            "Stubbed method was instructed to yield #{yield_args_description}, but no block was given by invocation: #{call_description}.",
+            'This will raise a LocalJumpError in the future.'
+          ].join(' '))
+        end
       end
       return_values.next(self)
     end

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -8,10 +8,11 @@ module Mocha
   class Invocation
     attr_reader :method_name
 
-    def initialize(mock, method_name, *arguments)
+    def initialize(mock, method_name, *arguments, &block)
       @mock = mock
       @method_name = method_name
       @arguments = arguments
+      @block = block
       @yields = []
       @result = nil
     end
@@ -19,7 +20,8 @@ module Mocha
     def call(yield_parameters = YieldParameters.new, return_values = ReturnValues.new)
       yield_parameters.next_invocation.each do |yield_args|
         @yields << ParametersMatcher.new(yield_args)
-        yield(*yield_args)
+        raise LocalJumpError unless @block
+        @block.call(*yield_args)
       end
       return_values.next(self)
     end

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -310,13 +310,13 @@ module Mocha
       if @responder && !@responder.respond_to?(symbol)
         raise NoMethodError, "undefined method `#{symbol}' for #{mocha_inspect} which responds like #{@responder.mocha_inspect}"
       end
-      invocation = Invocation.new(self, symbol, *arguments)
+      invocation = Invocation.new(self, symbol, *arguments, &block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
-        matching_expectation_allowing_invocation.invoke(invocation, &block)
+        matching_expectation_allowing_invocation.invoke(invocation)
       elsif (matching_expectation = all_expectations.match(invocation)) || (!matching_expectation && !@everything_stubbed)
         if @unexpected_invocation.nil?
           @unexpected_invocation = invocation
-          matching_expectation.invoke(invocation, &block) if matching_expectation
+          matching_expectation.invoke(invocation) if matching_expectation
           message = "#{@unexpected_invocation.call_description}\n#{@mockery.mocha_inspect}"
         else
           message = @unexpected_invocation.short_call_description

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -13,7 +13,7 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def invoke(expectation, &block)
-    expectation.invoke(Invocation.new(:irrelevant, :expected_method), &block)
+    expectation.invoke(Invocation.new(:irrelevant, :expected_method, &block))
   end
 
   def test_should_match_calls_to_same_method_with_any_parameters


### PR DESCRIPTION
This is in relation to #436.

In v1.9 if `Expectation#yields` or `Expectation#multiple_yields` was called on an expectation, but no block was given when the method was invoked, the instruction to yield was ignored. Since v1.10, a `LocalJumpError` is raised.

The old undocumented behaviour is now available via the new `retain_undocumented_behaviour_from_v1_9` configuration option, albeit with a deprecation warning. So you'll need to do something like the following to make use of it:

```ruby
Mocha.configure do |c|
  c.retain_undocumented_behaviour_from_v1_9 = true
end
```
