### PR TITLE
Optionally reinstate undocumented behaviour from v1.9

### DIFF
--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -70,15 +70,15 @@ module Mocha
       if Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
         if arguments.first.is_a?(Symbol)
           method_name = arguments[0]
-          Deprecation.warning([
+          Deprecation.warning(
             "Explicitly include `#{method_name}` in Hash of expected methods vs return values,",
-            "e.g. `mock(:#{method_name} => nil)`."
-          ].join(' '))
+            " e.g. `mock(:#{method_name} => nil)`."
+          )
           if arguments[1]
-            Deprecation.warning([
+            Deprecation.warning(
               "In this case the 2nd argument for `mock(:##{method_name}, ...)` is ignored,",
-              'but in the future a Hash of expected methods vs return values will be respected.'
-            ].join(' '))
+              ' but in the future a Hash of expected methods vs return values will be respected.'
+            )
           end
         elsif arguments.first.is_a?(String)
           name = arguments.shift
@@ -117,15 +117,15 @@ module Mocha
       if Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
         if arguments.first.is_a?(Symbol)
           method_name = arguments[0]
-          Deprecation.warning([
+          Deprecation.warning(
             "Explicitly include `#{method_name}` in Hash of stubbed methods vs return values,",
-            "e.g. `stub(:#{method_name} => nil)`."
-          ].join(' '))
+            " e.g. `stub(:#{method_name} => nil)`."
+          )
           if arguments[1]
-            Deprecation.warning([
+            Deprecation.warning(
               "In this case the 2nd argument for `stub(:##{method_name}, ...)` is ignored,",
-              'but in the future a Hash of stubbed methods vs return values will be respected.'
-            ].join(' '))
+              ' but in the future a Hash of stubbed methods vs return values will be respected.'
+            )
           end
         elsif arguments.first.is_a?(String)
           name = arguments.shift
@@ -160,20 +160,20 @@ module Mocha
     #     assert_nil motor.irrelevant_method_2 # => no error raised
     #     assert motor.stop
     #   end
-    # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     def stub_everything(*arguments)
       if Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
         if arguments.first.is_a?(Symbol)
           method_name = arguments[0]
-          Deprecation.warning([
+          Deprecation.warning(
             "Explicitly include `#{method_name}` in Hash of stubbed methods vs return values,",
-            "e.g. `stub_everything(:#{method_name} => nil)`."
-          ].join(' '))
+            " e.g. `stub_everything(:#{method_name} => nil)`."
+          )
           if arguments[1]
-            Deprecation.warning([
+            Deprecation.warning(
               "In this case the 2nd argument for `stub_everything(:##{method_name}, ...)` is ignored,",
-              'but in the future a Hash of stubbed methods vs return values will be respected.'
-            ].join(' '))
+              ' but in the future a Hash of stubbed methods vs return values will be respected.'
+            )
           end
         elsif arguments.first.is_a?(String)
           name = arguments.shift
@@ -187,7 +187,7 @@ module Mocha
       stub.stubs(expectations)
       stub
     end
-    # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
 
     # Builds a new sequence which can be used to constrain the order in which expectations can occur.
     #

--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -51,7 +51,7 @@ module Mocha
     #
     # @overload def mock(name)
     #   @param [String, Symbol] name identifies mock object in error messages.
-    #   @note Prior to v1.10.0 when +name+ was a +Symbol+, this method returned an unnamed +Mock+ that stubbed the method identified by +name+. This was undocumented behaviour and it no longer exists.
+    #   @note Prior to v1.10.0 when +name+ was a +Symbol+, this method returned an unnamed +Mock+ that expected the method identified by +name+. This was undocumented behaviour and it will be removed in the future, but for the moment it can be reinstated using {Configuration#reinstate_undocumented_behaviour_from_v1_9=}.
     # @overload def mock(expected_methods_vs_return_values = {})
     #   @param [Hash] expected_methods_vs_return_values expected method name symbols as keys and corresponding return values as values - these expectations are setup as if {Mock#expects} were called multiple times.
     # @overload def mock(name, expected_methods_vs_return_values = {})
@@ -65,13 +65,33 @@ module Mocha
     #     assert motor.stop
     #     # an error will be raised unless both Motor#start and Motor#stop have been called
     #   end
+    # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     def mock(*arguments)
-      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+      if Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
+        if arguments.first.is_a?(Symbol)
+          method_name = arguments[0]
+          Deprecation.warning([
+            "Explicitly include `#{method_name}` in Hash of expected methods vs return values,",
+            "e.g. `mock(:#{method_name} => nil)`."
+          ].join(' '))
+          if arguments[1]
+            Deprecation.warning([
+              "In this case the 2nd argument for `mock(:##{method_name}, ...)` is ignored,",
+              'but in the future a Hash of expected methods vs return values will be respected.'
+            ].join(' '))
+          end
+        elsif arguments.first.is_a?(String)
+          name = arguments.shift
+        end
+      elsif arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+        name = arguments.shift
+      end
       expectations = arguments.shift || {}
       mock = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
       mock.expects(expectations)
       mock
     end
+    # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
 
     # Builds a new mock object
     #
@@ -79,7 +99,7 @@ module Mocha
     #
     # @overload def stub(name)
     #   @param [String, Symbol] name identifies mock object in error messages.
-    #   @note Prior to v1.10.0 when +name+ was a +Symbol+, this method returned an unnamed +Mock+ that stubbed the method identified by +name+. This was undocumented behaviour and it no longer exists.
+    #   @note Prior to v1.10.0 when +name+ was a +Symbol+, this method returned an unnamed +Mock+ that stubbed the method identified by +name+. This was undocumented behaviour and it will be removed in the future, but for the moment it can be reinstated using {Configuration#reinstate_undocumented_behaviour_from_v1_9=}.
     # @overload def stub(stubbed_methods_vs_return_values = {})
     #   @param [Hash] stubbed_methods_vs_return_values stubbed method name symbols as keys and corresponding return values as values - these stubbed methods are setup as if {Mock#stubs} were called multiple times.
     # @overload def stub(name, stubbed_methods_vs_return_values = {})
@@ -92,13 +112,33 @@ module Mocha
     #     assert motor.stop
     #     # an error will not be raised even if either Motor#start or Motor#stop has not been called
     #   end
+    # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
     def stub(*arguments)
-      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+      if Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
+        if arguments.first.is_a?(Symbol)
+          method_name = arguments[0]
+          Deprecation.warning([
+            "Explicitly include `#{method_name}` in Hash of stubbed methods vs return values,",
+            "e.g. `stub(:#{method_name} => nil)`."
+          ].join(' '))
+          if arguments[1]
+            Deprecation.warning([
+              "In this case the 2nd argument for `stub(:##{method_name}, ...)` is ignored,",
+              'but in the future a Hash of stubbed methods vs return values will be respected.'
+            ].join(' '))
+          end
+        elsif arguments.first.is_a?(String)
+          name = arguments.shift
+        end
+      elsif arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+        name = arguments.shift
+      end
       expectations = arguments.shift || {}
       stub = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
       stub.stubs(expectations)
       stub
     end
+    # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
 
     # Builds a mock object that accepts calls to any method. By default it will return +nil+ for any method call.
     #
@@ -106,7 +146,7 @@ module Mocha
     #
     # @overload def stub_everything(name)
     #   @param [String, Symbol] name identifies mock object in error messages.
-    #   @note Prior to v1.10.0 when +name+ was a +Symbol+, this method returned an unnamed +Mock+ that stubbed everything. This was undocumented behaviour and it no longer exists.
+    #   @note Prior to v1.10.0 when +name+ was a +Symbol+, this method returned an unnamed +Mock+ that stubbed the method identified by +name+. This was undocumented behaviour and it will be removed in the future, but for the moment it can be reinstated using {Configuration#reinstate_undocumented_behaviour_from_v1_9=}.
     # @overload def stub_everything(stubbed_methods_vs_return_values = {})
     #   @param [Hash] stubbed_methods_vs_return_values stubbed method name symbols as keys and corresponding return values as values - these stubbed methods are setup as if {Mock#stubs} were called multiple times.
     # @overload def stub_everything(name, stubbed_methods_vs_return_values = {})
@@ -120,14 +160,34 @@ module Mocha
     #     assert_nil motor.irrelevant_method_2 # => no error raised
     #     assert motor.stop
     #   end
+    # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/AbcSize
     def stub_everything(*arguments)
-      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+      if Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
+        if arguments.first.is_a?(Symbol)
+          method_name = arguments[0]
+          Deprecation.warning([
+            "Explicitly include `#{method_name}` in Hash of stubbed methods vs return values,",
+            "e.g. `stub_everything(:#{method_name} => nil)`."
+          ].join(' '))
+          if arguments[1]
+            Deprecation.warning([
+              "In this case the 2nd argument for `stub_everything(:##{method_name}, ...)` is ignored,",
+              'but in the future a Hash of stubbed methods vs return values will be respected.'
+            ].join(' '))
+          end
+        elsif arguments.first.is_a?(String)
+          name = arguments.shift
+        end
+      elsif arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+        name = arguments.shift
+      end
       expectations = arguments.shift || {}
       stub = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
       stub.stub_everything
       stub.stubs(expectations)
       stub
     end
+    # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/AbcSize
 
     # Builds a new sequence which can be used to constrain the order in which expectations can occur.
     #

--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -66,7 +66,11 @@ module Mocha
     #     # an error will be raised unless both Motor#start and Motor#stop have been called
     #   end
     def mock(*arguments)
-      create_mock(arguments) { |mock, expectations| mock.expects(expectations) }
+      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+      expectations = arguments.shift || {}
+      mock = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
+      mock.expects(expectations)
+      mock
     end
 
     # Builds a new mock object
@@ -89,7 +93,11 @@ module Mocha
     #     # an error will not be raised even if either Motor#start or Motor#stop has not been called
     #   end
     def stub(*arguments)
-      create_mock(arguments) { |stub, expectations| stub.stubs(expectations) }
+      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+      expectations = arguments.shift || {}
+      stub = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
+      stub.stubs(expectations)
+      stub
     end
 
     # Builds a mock object that accepts calls to any method. By default it will return +nil+ for any method call.
@@ -113,10 +121,12 @@ module Mocha
     #     assert motor.stop
     #   end
     def stub_everything(*arguments)
-      create_mock(arguments) do |stub, expectations|
-        stub.stub_everything
-        stub.stubs(expectations)
-      end
+      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
+      expectations = arguments.shift || {}
+      stub = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
+      stub.stub_everything
+      stub.stubs(expectations)
+      stub
     end
 
     # Builds a new sequence which can be used to constrain the order in which expectations can occur.
@@ -167,16 +177,6 @@ module Mocha
     #   end
     def states(name)
       Mockery.instance.new_state_machine(name)
-    end
-
-    private
-
-    def create_mock(arguments)
-      name = arguments.shift.to_s if arguments.first.is_a?(String) || arguments.first.is_a?(Symbol)
-      expectations = arguments.shift || {}
-      mock = name ? Mockery.instance.named_mock(name) : Mockery.instance.unnamed_mock
-      yield mock, expectations
-      mock
     end
   end
 end

--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -250,9 +250,33 @@ module Mocha
 
     # Reinstate undocumented behaviour from v1.9
     #
+    # Previously when {API#mock}, {API#stub}, or {API#stub_everything} were called with the first argument being a symbol, they built an *unnamed* mock object *and* expected or stubbed the method identified by the symbol argument; subsequent arguments were ignored.
+    # Now these methods build a *named* mock with the name specified by the symbol argument; *no* methods are expected or stubbed and subsequent arguments *are* taken into account.
+    #
     # Enabling this configuration option reinstates the previous behaviour, but displays a deprecation warning.
     #
     # @param [Boolean] value +true+ to reinstate undocumented behaviour; disabled by default.
+    #
+    # @example Reinstate undocumented behaviour for {API#mock}
+    #   Mocha.configure do |c|
+    #     c.reinstate_undocumented_behaviour_from_v1_9 = true
+    #   end
+    #
+    #   foo = mock(:bar)
+    #   foo.inspect # => #<Mock>
+    #
+    #   not all expectations were satisfied
+    #   unsatisfied expectations:
+    #   - expected exactly once, invoked never: #<Mock>.foo
+    #
+    # @example Reinstate undocumented behaviour for {API#stub}
+    #   Mocha.configure do |c|
+    #     c.reinstate_undocumented_behaviour_from_v1_9 = true
+    #   end
+    #
+    #   foo = stub(:bar)
+    #   foo.inspect # => #<Mock>
+    #   foo.bar # => nil
     def reinstate_undocumented_behaviour_from_v1_9=(value)
       @options[:reinstate_undocumented_behaviour_from_v1_9] = value
     end

--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -42,7 +42,8 @@ module Mocha
       :stubbing_non_existent_method => :allow,
       :stubbing_non_public_method => :allow,
       :stubbing_method_on_nil => :prevent,
-      :display_matching_invocations_on_failure => false
+      :display_matching_invocations_on_failure => false,
+      :reinstate_undocumented_behaviour_from_v1_9 => false
     }.freeze
 
     attr_reader :options
@@ -245,6 +246,20 @@ module Mocha
     # @private
     def display_matching_invocations_on_failure?
       @options[:display_matching_invocations_on_failure]
+    end
+
+    # Reinstate undocumented behaviour from v1.9
+    #
+    # Enabling this configuration option reinstates the previous behaviour, but displays a deprecation warning.
+    #
+    # @param [Boolean] value +true+ to reinstate undocumented behaviour; disabled by default.
+    def reinstate_undocumented_behaviour_from_v1_9=(value)
+      @options[:reinstate_undocumented_behaviour_from_v1_9] = value
+    end
+
+    # @private
+    def reinstate_undocumented_behaviour_from_v1_9?
+      @options[:reinstate_undocumented_behaviour_from_v1_9]
     end
 
     class << self

--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -253,6 +253,9 @@ module Mocha
     # Previously when {API#mock}, {API#stub}, or {API#stub_everything} were called with the first argument being a symbol, they built an *unnamed* mock object *and* expected or stubbed the method identified by the symbol argument; subsequent arguments were ignored.
     # Now these methods build a *named* mock with the name specified by the symbol argument; *no* methods are expected or stubbed and subsequent arguments *are* taken into account.
     #
+    # Previously if {Expectation#yields} or {Expectation#multiple_yields} was called on an expectation, but no block was given when the method was invoked, the instruction to yield was ignored.
+    # Now a +LocalJumpError+ is raised.
+    #
     # Enabling this configuration option reinstates the previous behaviour, but displays a deprecation warning.
     #
     # @param [Boolean] value +true+ to reinstate undocumented behaviour; disabled by default.
@@ -277,6 +280,20 @@ module Mocha
     #   foo = stub(:bar)
     #   foo.inspect # => #<Mock>
     #   foo.bar # => nil
+    #
+    # @example Reinstate undocumented behaviour for {Expectation#yields}
+    #   foo = mock('foo')
+    #   foo.stubs(:my_method).yields(1, 2)
+    #   foo.my_method # => raises LocalJumpError when no block is supplied
+    #
+    #   Mocha.configure do |c|
+    #     c.reinstate_undocumented_behaviour_from_v1_9 = true
+    #   end
+    #
+    #   foo = mock('foo')
+    #   foo.stubs(:my_method).yields(1, 2)
+    #   foo.my_method # => does *not* raise LocalJumpError when no block is supplied
+    #
     def reinstate_undocumented_behaviour_from_v1_9=(value)
       @options[:reinstate_undocumented_behaviour_from_v1_9] = value
     end

--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -5,7 +5,8 @@ module Mocha
     class << self
       attr_accessor :mode, :messages
 
-      def warning(message)
+      def warning(*messages)
+        message = messages.join
         @messages << message
         return if mode == :disabled
         filter = BacktraceFilter.new

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -568,7 +568,7 @@ module Mocha
     def invoke(invocation)
       perform_side_effects
       @cardinality << invocation
-      invocation.call(@yield_parameters, @return_values) { |*yield_args| yield(*yield_args) }
+      invocation.call(@yield_parameters, @return_values)
     end
 
     # @private

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -3,6 +3,8 @@ require 'mocha/raised_exception'
 require 'mocha/return_values'
 require 'mocha/thrown_object'
 require 'mocha/yield_parameters'
+require 'mocha/configuration'
+require 'mocha/deprecation'
 
 module Mocha
   class Invocation
@@ -20,8 +22,16 @@ module Mocha
     def call(yield_parameters = YieldParameters.new, return_values = ReturnValues.new)
       yield_parameters.next_invocation.each do |yield_args|
         @yields << ParametersMatcher.new(yield_args)
-        raise LocalJumpError unless @block
-        @block.call(*yield_args)
+        if @block
+          @block.call(*yield_args)
+        else
+          raise LocalJumpError unless Mocha.configuration.reinstate_undocumented_behaviour_from_v1_9?
+          yield_args_description = ParametersMatcher.new(yield_args).mocha_inspect
+          Deprecation.warning([
+            "Stubbed method was instructed to yield #{yield_args_description}, but no block was given by invocation: #{call_description}.",
+            'This will raise a LocalJumpError in the future.'
+          ].join(' '))
+        end
       end
       return_values.next(self)
     end

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -8,10 +8,11 @@ module Mocha
   class Invocation
     attr_reader :method_name
 
-    def initialize(mock, method_name, *arguments)
+    def initialize(mock, method_name, *arguments, &block)
       @mock = mock
       @method_name = method_name
       @arguments = arguments
+      @block = block
       @yields = []
       @result = nil
     end
@@ -19,7 +20,8 @@ module Mocha
     def call(yield_parameters = YieldParameters.new, return_values = ReturnValues.new)
       yield_parameters.next_invocation.each do |yield_args|
         @yields << ParametersMatcher.new(yield_args)
-        yield(*yield_args)
+        raise LocalJumpError unless @block
+        @block.call(*yield_args)
       end
       return_values.next(self)
     end

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -310,13 +310,13 @@ module Mocha
       if @responder && !@responder.respond_to?(symbol)
         raise NoMethodError, "undefined method `#{symbol}' for #{mocha_inspect} which responds like #{@responder.mocha_inspect}"
       end
-      invocation = Invocation.new(self, symbol, *arguments)
+      invocation = Invocation.new(self, symbol, *arguments, &block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
-        matching_expectation_allowing_invocation.invoke(invocation, &block)
+        matching_expectation_allowing_invocation.invoke(invocation)
       elsif (matching_expectation = all_expectations.match(invocation)) || (!matching_expectation && !@everything_stubbed)
         if @unexpected_invocation.nil?
           @unexpected_invocation = invocation
-          matching_expectation.invoke(invocation, &block) if matching_expectation
+          matching_expectation.invoke(invocation) if matching_expectation
           message = "#{@unexpected_invocation.call_description}\n#{@mockery.mocha_inspect}"
         else
           message = @unexpected_invocation.short_call_description

--- a/test/acceptance/mock_built_with_first_argument_type_being_string_test.rb
+++ b/test/acceptance/mock_built_with_first_argument_type_being_string_test.rb
@@ -1,0 +1,99 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+require 'deprecation_disabler'
+
+class MockBuiltWithFirstArgumentTypeBeingStringTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+    Mocha.configure { |c| c.reinstate_undocumented_behaviour_from_v1_9 = true }
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_mock_built_with_single_symbol_argument_with_satisfied_expectation
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        m = mock(:my_method)
+        assert_nil m.my_method
+      end
+      expected_warning = 'Explicitly include `my_method` in Hash of expected methods vs return values, e.g. `mock(:my_method => nil)`.'
+      assert_equal expected_warning, Mocha::Deprecation.messages.last
+    end
+    assert_passed(test_result)
+  end
+
+  def test_mock_built_with_single_symbol_argument_with_unsatisfied_expectation
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        mock(:my_method)
+      end
+    end
+    assert_failed(test_result)
+    assert(test_result.failure_message_lines.any? do |line|
+      line[/expected exactly once, invoked never\: #<Mock\:0x[0-9a-f]+>\.my_method\(any_parameters\)/]
+    end)
+  end
+
+  def test_stub_built_with_single_symbol_argument
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        s = stub(:my_method)
+        assert_nil s.my_method
+      end
+      expected_warning = 'Explicitly include `my_method` in Hash of stubbed methods vs return values, e.g. `stub(:my_method => nil)`.'
+      assert_equal expected_warning, Mocha::Deprecation.messages.last
+    end
+    assert_passed(test_result)
+  end
+
+  def test_mock_built_with_first_argument_a_symbol_and_second_argument_a_hash
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        s = mock(:my_method, :another_method => 123)
+        assert_nil s.my_method
+      end
+      expected_warning = 'In this case the 2nd argument for `mock(:#my_method, ...)` is ignored, but in the future a Hash of expected methods vs return values will be respected.'
+      assert Mocha::Deprecation.messages.last(2).include?(expected_warning)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_stub_built_with_first_argument_a_symbol_and_second_argument_a_hash
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        s = stub(:my_method, :another_method => 123)
+        assert_nil s.my_method
+      end
+      expected_warning = 'In this case the 2nd argument for `stub(:#my_method, ...)` is ignored, but in the future a Hash of stubbed methods vs return values will be respected.'
+      assert Mocha::Deprecation.messages.last(2).include?(expected_warning)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_stub_everything_built_with_single_symbol_argument
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        s = stub_everything(:my_method)
+        assert_nil s.my_method
+      end
+      expected_warning = 'Explicitly include `my_method` in Hash of stubbed methods vs return values, e.g. `stub_everything(:my_method => nil)`.'
+      assert_equal expected_warning, Mocha::Deprecation.messages.last
+    end
+    assert_passed(test_result)
+  end
+
+  def test_stub_everything_built_with_first_argument_a_symbol_and_second_argument_a_hash
+    test_result = run_as_test do
+      DeprecationDisabler.disable_deprecations do
+        s = stub_everything(:my_method, :another_method => 123)
+        assert_nil s.my_method
+      end
+      expected_warning = 'In this case the 2nd argument for `stub_everything(:#my_method, ...)` is ignored, but in the future a Hash of stubbed methods vs return values will be respected.' # rubocop:disable Metrics/LineLength
+      assert Mocha::Deprecation.messages.last(2).include?(expected_warning)
+    end
+    assert_passed(test_result)
+  end
+end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -13,7 +13,7 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def invoke(expectation, &block)
-    expectation.invoke(Invocation.new(:irrelevant, :expected_method), &block)
+    expectation.invoke(Invocation.new(:irrelevant, :expected_method, &block))
   end
 
   def test_should_match_calls_to_same_method_with_any_parameters

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -2,8 +2,11 @@ require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/expectation'
 require 'mocha/invocation'
 require 'mocha/sequence'
+require 'mocha/configuration'
+require 'mocha/deprecation'
 require 'execution_point'
 require 'simple_counter'
+require 'deprecation_disabler'
 
 class ExpectationTest < Mocha::TestCase
   include Mocha
@@ -114,6 +117,18 @@ class ExpectationTest < Mocha::TestCase
 
   def test_yield_should_fail_when_the_caller_does_not_provide_a_block
     assert_raises(LocalJumpError) { invoke(new_expectation.yields(:foo)) }
+  end
+
+  def test_yield_should_display_warning_when_caller_does_not_provide_block_and_behaviour_from_v1_9_retained
+    Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => true) do
+      DeprecationDisabler.disable_deprecations do
+        invoke(new_expectation.yields(:foo, 1, [2, 3]))
+      end
+    end
+    assert message = Deprecation.messages.last
+    assert message.include?('Stubbed method was instructed to yield (:foo, 1, [2, 3])')
+    assert message.include?('but no block was given by invocation: :irrelevant.expected_method()')
+    assert message.include?('This will raise a LocalJumpError in the future.')
   end
 
   def test_should_yield_with_specified_parameters


### PR DESCRIPTION
This introduces a new configuration option (`reinstate_undocumented_behaviour_from_v1_9`) to reinstate a couple of bits of undocumented behaviour from v1.9 which were changed in v1.10 without any prior deprecation warning. It turns out that a number of projects were depending on this behaviour and I'm keen to provide them with a way to upgrade to the latest version of Mocha, but see deprecation warnings for the behaviour which has changed.

* The behaviour of `API#mock`, `API#stub` and `API#stub_everything` when called with a symbol as the first argument.

* The behaviour of `Expectation#yields` and `Expectation#multiple_yields` when the stubbed method is called without a block.

This supersedes #437, because it includes the same functionality albeit with a different configuration option name. It should therefore address #436.

It also includes work I did in [this branch][1] in response to a private email regarding the behaviour of `API#mock`, `API#stub` and `API#stub_everything`.

[1]: https://github.com/freerange/mocha/compare/reinstate-undocumented-behaviour-changed-in-v1.10
