### PR TITLE
Add Expectation#with_block_given & Expectation#with_no_block_given

### DIFF
--- a/lib/mocha/block_matcher.rb
+++ b/lib/mocha/block_matcher.rb
@@ -1,0 +1,31 @@
+module Mocha
+  module BlockMatchers
+    class OptionalBlock
+      def match?(_actual_block)
+        true
+      end
+
+      def mocha_inspect; end
+    end
+
+    class BlockGiven
+      def match?(actual_block)
+        !actual_block.nil?
+      end
+
+      def mocha_inspect
+        'with block given'
+      end
+    end
+
+    class NoBlockGiven
+      def match?(actual_block)
+        actual_block.nil?
+      end
+
+      def mocha_inspect
+        'with no block given'
+      end
+    end
+  end
+end

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -8,7 +8,7 @@ require 'mocha/deprecation'
 
 module Mocha
   class Invocation
-    attr_reader :method_name
+    attr_reader :method_name, :block
 
     def initialize(mock, method_name, *arguments, &block)
       @mock = mock

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -53,7 +53,9 @@ module Mocha
     end
 
     def call_description
-      "#{@mock.mocha_inspect}.#{@method_name}#{ParametersMatcher.new(@arguments).mocha_inspect}"
+      description = "#{@mock.mocha_inspect}.#{@method_name}#{ParametersMatcher.new(@arguments).mocha_inspect}"
+      description << ' { ... }' unless @block.nil?
+      description
     end
 
     def short_call_description

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -29,7 +29,9 @@ module Mocha
           yield_args_description = ParametersMatcher.new(yield_args).mocha_inspect
           Deprecation.warning(
             "Stubbed method was instructed to yield #{yield_args_description}, but no block was given by invocation: #{call_description}.",
-            ' This will raise a LocalJumpError in the future.'
+            ' This will raise a LocalJumpError in the future.',
+            ' Use Expectation#with_block_given to constrain this expectation to match invocations supplying a block.',
+            ' And, if necessary, add another expectation to match invocations not supplying a block.'
           )
         end
       end

--- a/test/acceptance/display_matching_invocations_alongside_expectations_test.rb
+++ b/test/acceptance/display_matching_invocations_alongside_expectations_test.rb
@@ -40,9 +40,9 @@ class DisplayMatchingInvocationsAlongsideExpectationsTest < Mocha::TestCase
     assert_invocations(
       test_result,
       '- allowed any number of times, invoked 3 times: #<Mock:foo>.bar(any_parameters)',
-      '  - #<Mock:foo>.bar(1, 2) # => "f" after yielding ("bc"), then ("d", "e")',
-      '  - #<Mock:foo>.bar(3, 4) # => raised StandardError after yielding ("bc"), then ("d", "e")',
-      '  - #<Mock:foo>.bar(5, 6) # => threw (:tag, "value") after yielding ("bc"), then ("d", "e")'
+      '  - #<Mock:foo>.bar(1, 2) { ... } # => "f" after yielding ("bc"), then ("d", "e")',
+      '  - #<Mock:foo>.bar(3, 4) { ... } # => raised StandardError after yielding ("bc"), then ("d", "e")',
+      '  - #<Mock:foo>.bar(5, 6) { ... } # => threw (:tag, "value") after yielding ("bc"), then ("d", "e")'
     )
   end
 
@@ -57,7 +57,7 @@ class DisplayMatchingInvocationsAlongsideExpectationsTest < Mocha::TestCase
     assert_invocations(
       test_result,
       '- allowed any number of times, invoked once: #<Mock:foo>.bar(any_parameters)',
-      '  - #<Mock:foo>.bar(1, 2) # => nil after yielding ()'
+      '  - #<Mock:foo>.bar(1, 2) { ... } # => nil after yielding ()'
     )
   end
 

--- a/test/acceptance/failure_messages_test.rb
+++ b/test/acceptance/failure_messages_test.rb
@@ -58,4 +58,20 @@ class FailureMessagesTest < Mocha::TestCase
     end
     assert_match Regexp.new(%("Foo")), test_result.failures[0].message
   end
+
+  def test_should_display_that_block_was_expected
+    test_result = run_as_test do
+      foo = mock
+      foo.expects(:bar).with_block_given
+    end
+    assert_match Regexp.new(' with block given$'), test_result.failures[0].message
+  end
+
+  def test_should_display_that_block_was_not_expected
+    test_result = run_as_test do
+      foo = mock
+      foo.expects(:bar).with_no_block_given
+    end
+    assert_match Regexp.new(' with no block given$'), test_result.failures[0].message
+  end
 end

--- a/test/acceptance/yielding_test.rb
+++ b/test/acceptance/yielding_test.rb
@@ -31,6 +31,28 @@ class YieldingTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  def test_yields_when_block_expected_and_block_given
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).with_block_given.yields
+      m.stubs(:foo).with_no_block_given.returns(:bar)
+      yielded = false
+      m.foo { yielded = true }
+      assert yielded
+    end
+    assert_passed(test_result)
+  end
+
+  def test_returns_when_no_block_expected_and_no_block_given
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).with_block_given.yields
+      m.stubs(:foo).with_no_block_given.returns(:bar)
+      assert_equal :bar, m.foo
+    end
+    assert_passed(test_result)
+  end
+
   def test_yields_values_when_stubbed_method_is_invoked
     test_result = run_as_test do
       m = mock('m')


### PR DESCRIPTION
This relates to #436 & #382.

Since #382, a `LocalJumpError` is raised if an invocation does not supply a block, but the matching expectation includes an instruction to yield. Until now there has been no way to constrain an expectation to match based on whether the invocation supplies a block or not. This PR makes this possible.

These changes have allowed me to improve the deprecation warning in `Invocation#call` to give a concrete suggestion on how to avoid the deprecated functionality.

@nitishr I've included a change `Invocation#call_description` to append " { ... }" to give an indication that the invocation supplied a block. I'm not 100% sure this is the best string representation - so I'm open to ideas on this front. I'm also not sure whether I should add something similar to `Invocation#short_call_description` too...?
