### PR TITLE
Fix issue with non-Array arguments passed to Expectation#multiple_yields

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -261,7 +261,7 @@ module Mocha
 
     # Modifies expectation so that when the expected method is called, it yields multiple times per invocation with the specified +parameter_groups+ (even if no block is provided, in which case yielding will result in a +LocalJumpError+).
     #
-    # @param [*Array<Array>] parameter_groups each element of +parameter_groups+ should iself be an +Array+ representing the parameters to be passed to the block for a single yield.
+    # @param [*Array<Array>] parameter_groups each element of +parameter_groups+ should iself be an +Array+ representing the parameters to be passed to the block for a single yield. Any element of +parameter_groups+ that is not an +Array+ is wrapped in an +Array+.
     # @return [Expectation] the same expectation, thereby allowing invocations of other {Expectation} methods to be chained.
     # @see #then
     #

--- a/lib/mocha/yield_parameters.rb
+++ b/lib/mocha/yield_parameters.rb
@@ -13,7 +13,9 @@ module Mocha
     end
 
     def add(*parameter_groups)
-      @parameter_groups << parameter_groups
+      @parameter_groups << parameter_groups.map do |pg|
+        pg.is_a?(Array) ? pg : [pg]
+      end
     end
   end
 end

--- a/test/acceptance/display_matching_invocations_alongside_expectations_test.rb
+++ b/test/acceptance/display_matching_invocations_alongside_expectations_test.rb
@@ -31,7 +31,7 @@ class DisplayMatchingInvocationsAlongsideExpectationsTest < Mocha::TestCase
     test_result = run_as_test do
       foo = mock('foo')
       foo.expects(:bar).with(1).returns('a')
-      foo.stubs(:bar).with(any_parameters).multiple_yields(%w[b c], %w[d e]).returns('f').raises(StandardError).throws(:tag, 'value')
+      foo.stubs(:bar).with(any_parameters).multiple_yields('bc', %w[d e]).returns('f').raises(StandardError).throws(:tag, 'value')
 
       foo.bar(1, 2) { |_ignored| }
       assert_raises(StandardError) { foo.bar(3, 4) { |_ignored| } }
@@ -40,9 +40,9 @@ class DisplayMatchingInvocationsAlongsideExpectationsTest < Mocha::TestCase
     assert_invocations(
       test_result,
       '- allowed any number of times, invoked 3 times: #<Mock:foo>.bar(any_parameters)',
-      '  - #<Mock:foo>.bar(1, 2) # => "f" after yielding ("b", "c"), then ("d", "e")',
-      '  - #<Mock:foo>.bar(3, 4) # => raised StandardError after yielding ("b", "c"), then ("d", "e")',
-      '  - #<Mock:foo>.bar(5, 6) # => threw (:tag, "value") after yielding ("b", "c"), then ("d", "e")'
+      '  - #<Mock:foo>.bar(1, 2) # => "f" after yielding ("bc"), then ("d", "e")',
+      '  - #<Mock:foo>.bar(3, 4) # => raised StandardError after yielding ("bc"), then ("d", "e")',
+      '  - #<Mock:foo>.bar(5, 6) # => threw (:tag, "value") after yielding ("bc"), then ("d", "e")'
     )
   end
 

--- a/test/acceptance/multiple_yielding_test.rb
+++ b/test/acceptance/multiple_yielding_test.rb
@@ -22,6 +22,17 @@ class MultipleYieldingTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  def test_yields_values_multiple_times_when_multiple_yields_arguments_are_not_arrays
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).multiple_yields(1, { :b => 2 }, '3')
+      yielded = []
+      m.foo { |*args| yielded << args }
+      assert_equal [[1], [{ :b => 2 }], ['3']], yielded
+    end
+    assert_passed(test_result)
+  end
+
   def test_raises_local_jump_error_if_instructed_to_multiple_yield_but_no_block_given
     test_result = run_as_test do
       m = mock('m')

--- a/test/acceptance/multiple_yielding_test.rb
+++ b/test/acceptance/multiple_yielding_test.rb
@@ -1,0 +1,45 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class MultipleYieldingTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_yields_values_multiple_times_when_stubbed_method_is_invoked
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).multiple_yields([1], [2, 3])
+      yielded = []
+      m.foo { |*args| yielded << args }
+      assert_equal [[1], [2, 3]], yielded
+    end
+    assert_passed(test_result)
+  end
+
+  def test_raises_local_jump_error_if_instructed_to_multiple_yield_but_no_block_given
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).multiple_yields([])
+      assert_raises(LocalJumpError) { m.foo }
+    end
+    assert_passed(test_result)
+  end
+
+  def test_yields_different_values_on_consecutive_invocations
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).multiple_yields([0], [1, 2]).then.multiple_yields([3], [4, 5])
+      yielded = []
+      m.foo { |*args| yielded << args }
+      m.foo { |*args| yielded << args }
+      assert_equal [[0], [1, 2], [3], [4, 5]], yielded
+    end
+    assert_passed(test_result)
+  end
+end

--- a/test/acceptance/yielding_test.rb
+++ b/test/acceptance/yielding_test.rb
@@ -1,0 +1,56 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class YieldingTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_yields_when_stubbed_method_is_invoked
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).yields
+      yielded = false
+      m.foo { yielded = true }
+      assert yielded
+    end
+    assert_passed(test_result)
+  end
+
+  def test_raises_local_jump_error_if_instructed_to_yield_but_no_block_given
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).yields
+      assert_raises(LocalJumpError) { m.foo }
+    end
+    assert_passed(test_result)
+  end
+
+  def test_yields_values_when_stubbed_method_is_invoked
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).yields(0, 1)
+      yielded = []
+      m.foo { |*args| yielded << args }
+      assert_equal [[0, 1]], yielded
+    end
+    assert_passed(test_result)
+  end
+
+  def test_yields_different_values_on_consecutive_invocations
+    test_result = run_as_test do
+      m = mock('m')
+      m.stubs(:foo).yields(0, 1).then.yields(2, 3)
+      yielded = []
+      m.foo { |*args| yielded << args }
+      m.foo { |*args| yielded << args }
+      assert_equal [[0, 1], [2, 3]], yielded
+    end
+    assert_passed(test_result)
+  end
+end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -8,6 +8,7 @@ require 'execution_point'
 require 'simple_counter'
 require 'deprecation_disabler'
 
+# rubocop:disable  Metrics/ClassLength
 class ExpectationTest < Mocha::TestCase
   include Mocha
 
@@ -119,7 +120,7 @@ class ExpectationTest < Mocha::TestCase
     assert_raises(LocalJumpError) { invoke(new_expectation.yields(:foo)) }
   end
 
-  def test_yield_should_display_warning_when_caller_does_not_provide_block_and_behaviour_from_v1_9_retained
+  def test_yields_should_display_warning_when_caller_does_not_provide_block_and_behaviour_from_v1_9_retained
     Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => true) do
       DeprecationDisabler.disable_deprecations do
         invoke(new_expectation.yields(:foo, 1, [2, 3]))
@@ -127,6 +128,18 @@ class ExpectationTest < Mocha::TestCase
     end
     assert message = Deprecation.messages.last
     assert message.include?('Stubbed method was instructed to yield (:foo, 1, [2, 3])')
+    assert message.include?('but no block was given by invocation: :irrelevant.expected_method()')
+    assert message.include?('This will raise a LocalJumpError in the future.')
+  end
+
+  def test_multiple_yields_should_display_warning_when_caller_does_not_provide_block_and_behaviour_from_v1_9_retained
+    Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => true) do
+      DeprecationDisabler.disable_deprecations do
+        invoke(new_expectation.multiple_yields(:foo, 1, [2, 3]))
+      end
+    end
+    assert message = Deprecation.messages.last
+    assert message.include?('Stubbed method was instructed to yield (2, 3)')
     assert message.include?('but no block was given by invocation: :irrelevant.expected_method()')
     assert message.include?('This will raise a LocalJumpError in the future.')
   end
@@ -490,3 +503,4 @@ class ExpectationTest < Mocha::TestCase
     assert expectation.inspect.include?(expectation.mocha_inspect)
   end
 end
+# rubocop:enable  Metrics/ClassLength

--- a/test/unit/yield_parameters_test.rb
+++ b/test/unit/yield_parameters_test.rb
@@ -36,6 +36,12 @@ class YieldParametersTest < Mocha::TestCase
     assert_next_invocation_yields(yield_parameters, [[1, 2, 3], [4, 5]])
   end
 
+  def test_should_return_multiple_yield_parameter_group_when_arguments_are_not_arrays
+    yield_parameters = YieldParameters.new
+    yield_parameters.add(1, { :b => 2 }, 3)
+    assert_next_invocation_yields(yield_parameters, [[1], [{ :b => 2 }], [3]])
+  end
+
   def test_should_keep_returning_multiple_yield_parameter_group
     yield_parameters = YieldParameters.new
     yield_parameters.add([1, 2, 3], [4, 5])


### PR DESCRIPTION
This was highlighted when investigating [this issue][1]. It turned out that this project was calling `Expectation#multiple_yields` with non-Array arguments, mostly/all Strings. See #443 for details.

While the documentation said that each argument should be an `Array`, it turned out that in most cases the functionality still worked with non-`Array` arguments, but I suspect this was by accident rather than
design. One exception to this was if an argument was a `Hash`, then it  ended up being passed to the block as an `Array` of two-element Arrays.

[This code][2] which is used to optionally displays invocations was assuming that `yield_args` was always an `Array`, but this was not true. Similarly [this code][3] which is used to display a deprecation warning was also assuming that `yield_args` was always an `Array`. And it was the latter which was causing [the `NoMethodError` in the apiology/quality project][4].

I've hopefully fixed the underlying problem by wrapping any non-`Array` argument in an `Array`. Note that using `Kernel#Array` was not an option,  because this didn't give the correct behaviour for `Hash` arguments.

There is an argument to say that this was undocumented behaviour, but I think that seems unnecessarily strict in this case.

[1]: https://github.com/apiology/quality/issues/121
[2]: https://github.com/freerange/mocha/blob/1070fc02015a8ea36ad50782f80b557813595c02/lib/mocha/invocation.rb#L24
[3]: https://github.com/freerange/mocha/blob/1070fc02015a8ea36ad50782f80b557813595c02/lib/mocha/invocation.rb#L29
[4]: https://circleci.com/gh/apiology/quality/351