### PR TITLE
deprecate current method dispatch behavior(jmock1)

### DIFF
--- a/lib/mocha/expectation_list.rb
+++ b/lib/mocha/expectation_list.rb
@@ -1,3 +1,5 @@
+require 'mocha/deprecation'
+
 module Mocha
   class ExpectationList
     def initialize(expectations = [])
@@ -5,6 +7,13 @@ module Mocha
     end
 
     def add(expectation)
+      if @expectations.any?
+        Deprecation.warning(
+          'Expectations are currently searched from newest to oldest to find one that matches the invocation.',
+          ' This search order will be reversed in the future, such that expectations are searched from oldest to newest to find one that matches the invocation.',
+          ' This means you will have to reverse the order of `expects` and `stubs` calls on the same object if you want to retain the current behavior.'
+        )
+      end
       @expectations.unshift(expectation)
       expectation
     end

--- a/test/unit/expectation_list_test.rb
+++ b/test/unit/expectation_list_test.rb
@@ -79,4 +79,18 @@ class ExpectationListTest < Mocha::TestCase
     expectation_list = expectation_list1 + expectation_list2
     assert_equal [expectation1, expectation2], expectation_list.to_a
   end
+
+  def test_should_display_deprecation_warning_when_multiple_expectations_are_added
+    DeprecationDisabler.disable_deprecations do
+      expectation_list = ExpectationList.new
+      expectation1 = Expectation.new(nil, :my_method).with(:argument1, :argument2)
+      expectation2 = Expectation.new(nil, :my_method).with(:argument3, :argument4)
+      expectation_list.add(expectation1)
+      expectation_list.add(expectation2)
+    end
+    assert message = Deprecation.messages.last
+    assert message.include?('Expectations are currently searched from newest to oldest to find one that matches the invocation.')
+    assert message.include?('This search order will be reversed in the future, such that expectations are searched from oldest to newest to find one that matches the invocation.')
+    assert message.include?('This means you will have to reverse the order of `expects` and `stubs` calls on the same object if you want to retain the current behavior.')
+  end
 end


### PR DESCRIPTION
Display deprecation warning when adding an expectation if the expectation list
already contains any expectations. The intent is to change method dispatch
behavior to that of jMock v2 as suggested in #173 in a major version release.