### PR TITLE
Simplify mockery and add check to include state in failure message

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -80,10 +80,8 @@ module Mocha
         backtrace = unsatisfied_expectations.empty? ? caller : unsatisfied_expectations[0].backtrace
         raise ExpectationErrorFactory.build("not all expectations were satisfied\n#{mocha_inspect}", backtrace)
       end
-      unless Mocha.configuration.stubbing_method_unnecessarily == :allow
-        expectations.reject(&:used?).each do |e|
-          check(:stubbing_method_unnecessarily, 'method unnecessarily', e.method_signature, e.backtrace)
-        end
+      expectations.reject(&:used?).each do |e|
+        check(:stubbing_method_unnecessarily, 'method unnecessarily', e.method_signature, e.backtrace)
       end
     end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -80,8 +80,8 @@ module Mocha
         backtrace = unsatisfied_expectations.empty? ? caller : unsatisfied_expectations[0].backtrace
         raise ExpectationErrorFactory.build("not all expectations were satisfied\n#{mocha_inspect}", backtrace)
       end
-      expectations.each do |e|
-        unless Mocha.configuration.stubbing_method_unnecessarily == :allow
+      unless Mocha.configuration.stubbing_method_unnecessarily == :allow
+        expectations.each do |e|
           next if e.used?
           on_stubbing_method_unnecessarily(e)
         end

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -81,10 +81,7 @@ module Mocha
         raise ExpectationErrorFactory.build("not all expectations were satisfied\n#{mocha_inspect}", backtrace)
       end
       unless Mocha.configuration.stubbing_method_unnecessarily == :allow
-        expectations.each do |e|
-          next if e.used?
-          on_stubbing_method_unnecessarily(e)
-        end
+        expectations.reject(&:used?).each { |e| on_stubbing_method_unnecessarily(e) }
       end
     end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -105,9 +105,12 @@ module Mocha
 
     def mocha_inspect
       message = ''
-      message << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" unless unsatisfied_expectations.empty?
-      message << "satisfied expectations:\n- #{satisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" unless satisfied_expectations.empty?
-      message << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}\n" unless state_machines.empty?
+      [
+        ['unsatisfied expectations', unsatisfied_expectations], ['satisfied expectations', satisfied_expectations],
+        ['states', state_machines]
+      ].each do |label, list|
+        message << "#{label}:\n- #{list.map(&:mocha_inspect).join("\n- ")}\n" unless list.empty?
+      end
       message
     end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -107,7 +107,7 @@ module Mocha
       message = ''
       message << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" unless unsatisfied_expectations.empty?
       message << "satisfied expectations:\n- #{satisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" unless satisfied_expectations.empty?
-      message << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}" unless state_machines.empty?
+      message << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}\n" unless state_machines.empty?
       message
     end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -51,7 +51,6 @@ module Mocha
         instance.teardown
       ensure
         @instances.pop
-        @instances = nil if instances.empty?
       end
 
       private

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -77,11 +77,7 @@ module Mocha
 
     def verify(assertion_counter = nil)
       unless mocks.all? { |mock| mock.__verified__?(assertion_counter) }
-        backtrace = if unsatisfied_expectations.empty?
-                      caller
-                    else
-                      unsatisfied_expectations[0].backtrace
-                    end
+        backtrace = unsatisfied_expectations.empty? ? caller : unsatisfied_expectations[0].backtrace
         raise ExpectationErrorFactory.build("not all expectations were satisfied\n#{mocha_inspect}", backtrace)
       end
       expectations.each do |e|

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -104,14 +104,10 @@ module Mocha
     end
 
     def mocha_inspect
-      message = ''
       [
         ['unsatisfied expectations', unsatisfied_expectations], ['satisfied expectations', satisfied_expectations],
         ['states', state_machines]
-      ].each do |label, list|
-        message << "#{label}:\n- #{list.map(&:mocha_inspect).join("\n- ")}\n" unless list.empty?
-      end
-      message
+      ].map { |label, list| "#{label}:\n- #{list.map(&:mocha_inspect).join("\n- ")}\n" unless list.empty? }.join
     end
 
     def on_stubbing(object, method)

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -34,12 +34,13 @@ module Mocha
 
     class << self
       def instance
-        instances.last || Null.new
+        @instances.last || Null.new
       end
 
       def setup
+        @instances ||= []
         mockery = new
-        mockery.logger = instance.logger unless instances.empty?
+        mockery.logger = instance.logger unless @instances.empty?
         @instances.push(mockery)
       end
 
@@ -51,12 +52,6 @@ module Mocha
         instance.teardown
       ensure
         @instances.pop
-      end
-
-      private
-
-      def instances
-        @instances ||= []
       end
     end
 

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -81,7 +81,9 @@ module Mocha
         raise ExpectationErrorFactory.build("not all expectations were satisfied\n#{mocha_inspect}", backtrace)
       end
       unless Mocha.configuration.stubbing_method_unnecessarily == :allow
-        expectations.reject(&:used?).each { |e| on_stubbing_method_unnecessarily(e) }
+        expectations.reject(&:used?).each do |e|
+          check(:stubbing_method_unnecessarily, 'method unnecessarily', e.method_signature, e.backtrace)
+        end
       end
     end
 
@@ -121,10 +123,6 @@ module Mocha
       end
       check(:stubbing_method_on_nil, 'method on nil', method_signature) { object.nil? }
       check(:stubbing_method_on_non_mock_object, 'method on non-mock object', method_signature)
-    end
-
-    def on_stubbing_method_unnecessarily(expectation)
-      check(:stubbing_method_unnecessarily, 'method unnecessarily', expectation.method_signature, expectation.backtrace)
     end
 
     attr_writer :logger

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -107,7 +107,7 @@ module Mocha
       [
         ['unsatisfied expectations', unsatisfied_expectations], ['satisfied expectations', satisfied_expectations],
         ['states', state_machines]
-      ].map { |label, list| "#{label}:\n- #{list.map(&:mocha_inspect).join("\n- ")}\n" unless list.empty? }.join
+      ].map { |label, list| "#{label}:\n- #{list.map(&:mocha_inspect).join("\n- ")}\n" if list.any? }.join
     end
 
     def on_stubbing(object, method)

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -28,8 +28,7 @@ module Mocha
       private
 
       def raise_not_initialized_error
-        message = 'Mocha methods cannot be used outside the context of a test'
-        raise NotInitializedError.new(message, caller)
+        raise NotInitializedError.new('Mocha methods cannot be used outside the context of a test', caller)
       end
     end
 
@@ -84,13 +83,12 @@ module Mocha
 
     def verify(assertion_counter = nil)
       unless mocks.all? { |mock| mock.__verified__?(assertion_counter) }
-        message = "not all expectations were satisfied\n#{mocha_inspect}"
         backtrace = if unsatisfied_expectations.empty?
                       caller
                     else
                       unsatisfied_expectations[0].backtrace
                     end
-        raise ExpectationErrorFactory.build(message, backtrace)
+        raise ExpectationErrorFactory.build("not all expectations were satisfied\n#{mocha_inspect}", backtrace)
       end
       expectations.each do |e|
         unless Mocha.configuration.stubbing_method_unnecessarily == :allow

--- a/test/acceptance/multiple_expectations_failure_message_test.rb
+++ b/test/acceptance/multiple_expectations_failure_message_test.rb
@@ -63,4 +63,20 @@ class FailureMessageTest < Mocha::TestCase
       '- expected exactly once, invoked once: #<Mock:mock>.method_one(any_parameters)'
     ], test_result.failure_message_lines
   end
+
+  def test_should_include_state_in_unsatisfied_expectation_message
+    test_result = run_as_test do
+      mock = mock('mock')
+      readiness = states('readiness')
+      mock.expects(:method_one).once.then(readiness.is('ready'))
+    end
+    assert_failed(test_result)
+    assert_equal [
+      'not all expectations were satisfied',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method_one(any_parameters)',
+      'states:',
+      '- readiness has no current state'
+    ], test_result.failure_message_lines
+  end
 end


### PR DESCRIPTION
While most of the changes here are refactorings, there're 2 things in particular that go beyond and I think are useful irrespective of the other changes:

- consistently terminate Mockery#mocha_inspect with \n here https://github.com/freerange/mocha/pull/449/commits/2a5ecdc5cd933ae4f2178b9613acefe4f6dbd819, since the old code would terminate the mocha_inspect output in all cases _except_ when there's `states` to be output.
- a ~test~ check for including `states` in the mocha_inspect output here: https://github.com/freerange/mocha/pull/449/commits/031309f7f7639a4601b4d5021fe90020452febfa

Some of the refactorings like inlining temps might be considered merely stylistic preference, although I did them based on my (admittedly limited) understanding of cognition, and I'd happily revert those if need be. Others like the ones to do with @instances are, to my mind, genuine simplifications.