### PR TITLE
method_missing won't throw if ExpectationList empty

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -312,7 +312,7 @@ module Mocha
       invocation = Invocation.new(self, symbol, *arguments, &block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
         matching_expectation_allowing_invocation.invoke(invocation)
-      elsif (matching_expectation = all_expectations.match(invocation)) || (!matching_expectation && !@everything_stubbed)
+      elsif all_expectations.any? && (matching_expectation = all_expectations.match(invocation)) || (!matching_expectation && !@everything_stubbed)
         raise_unexpected_invocation_error(invocation, matching_expectation)
       end
     end


### PR DESCRIPTION
This is my attempt to fix https://github.com/freerange/mocha/issues/461
Although _mocha_ does not claim to be thread-safe; this change slowly
makes it more resilient to race conditions through use of mocha.

A method on an object/class may be stubbed & invoked prior to the
expectation being added to the list. In such a scenario, the
method_missing in `mock.rb` would raise an exception for unknown
invocation.

Smply add a if-guard that checks that the expectation list is not empty.

fixes #461