### PR TITLE
Add Ruby 2.7 to Travis-CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
   - ruby-head
   - jruby-9.2.9.0
   - jruby-head


### PR DESCRIPTION
Ruby 2.7 got released some time ago. Linux distributions start to ship
it so I think it makes sense to test against this version as well.