### PR TITLE
Remove docs/ and test/ from gemspec.files to reduce .gem file size over 50%

### DIFF
--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.description = 'Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.'
   s.email = 'mocha-developer@googlegroups.com'
 
-  s.files = `git ls-files`.split("\n")
+  s.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(docs|test)/}) }
+  end
   s.files.delete('.travis.yml')
   s.files.delete('.gitignore')
 


### PR DESCRIPTION
I was looking through https://rubygems.org/gems/mocha/versions and noticed the .gem's file size increased from 94kb in v1.7.0 to 219kb in v1.8.0 - an increase of 125kb.

The culprit seems to be the addition of generated docs to the repo in 4a85555831c55961a5100be18b0fe0b555b51945. I don't think there reasonable value in including the generated docs in the compiled .gem, especially for the byte size increase. It was primarily added for Github pages. Gem users still can locally still produce documentation with rdoc/ri. I've also removed the test directory, since they are not useful to gem users.

I'm using the syntax from the gemspec used in `bundle gem`.