### PR TITLE
Fix misleading exception in `has_entry`

### DIFF
--- a/lib/mocha/parameter_matchers/has_entry.rb
+++ b/lib/mocha/parameter_matchers/has_entry.rb
@@ -42,6 +42,8 @@ module Mocha
     #
     def has_entry(*options) # rubocop:disable Naming/PredicateName
       case options.length
+      when 0
+        raise ArgumentError, 'Argument has no entries.'
       when 1
         case options[0]
         when Hash

--- a/test/unit/parameter_matchers/has_entry_test.rb
+++ b/test/unit/parameter_matchers/has_entry_test.rb
@@ -92,6 +92,11 @@ class HasEntryTest < Mocha::TestCase
     assert_equal 'Argument has no entries.', e.message
   end
 
+  def test_should_raise_argument_error_if_no_arguments_are_supplied
+    e = assert_raises(ArgumentError) { has_entry }
+    assert_equal 'Argument has no entries.', e.message
+  end
+
   def test_should_raise_argument_error_if_multiple_entries_are_supplied
     e = assert_raises(ArgumentError) do
       has_entry(:key_1 => 'value_1', :key_2 => 'value_2')


### PR DESCRIPTION
If `has_entry` is called without any arguments, it will raise an
exception like the following:

```
ArgumentError: Too many arguments; use either a single argument (must be a Hash) or two arguments (a key and a value).
```

This is because we don't check if the `options.length` is zero so when
it is, the `else` branch executes and prints the above error. We can fix
this by simply adding another branch to cover the case when
`options.length` is zero.

---

Unfortunately, this change introduces a new RuboCop violation:

```
$ bundle exec rake test
Running RuboCop...
Inspecting 234 files
................................................................................................................................................................................
............................................C.............

Offenses:

lib/mocha/parameter_matchers/has_entry.rb:43:5: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for has_entry is too high. [7/6]
    def has_entry(*options) # rubocop:disable Naming/PredicateName ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

234 files inspected, 1 offense detected
RuboCop failed!
```

We could disable the cop but I didn't feel like it was my call to make. I'll leave that up to y'all.