### PR TITLE
Allow hiding satisfied expectations in test output

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -541,6 +541,18 @@ module Mocha
       self
     end
 
+    # Modifies expectation so that it will not be reported in test output, if it is satisfied.
+    #
+    # @return [Expectation] the same expectation, thereby allowing invocations of other {Expectation} methods to be chained.
+    #
+    # @example Satisfied expectation will not be reported in test output.
+    #   object = mock()
+    #   object.stubs(:expected_method).quietly
+    def quietly
+      @quiet = true
+      self
+    end
+
     # @private
     attr_reader :backtrace
 
@@ -556,6 +568,7 @@ module Mocha
       @return_values = ReturnValues.new
       @yield_parameters = YieldParameters.new
       @backtrace = backtrace || caller
+      @quiet = false
     end
 
     # @private
@@ -643,6 +656,11 @@ module Mocha
       signature = "#{@mock.mocha_inspect}.#{@method_matcher.mocha_inspect}#{@parameters_matcher.mocha_inspect}"
       signature << " #{@block_matcher.mocha_inspect}" if @block_matcher.mocha_inspect
       signature
+    end
+
+    # @private
+    def quiet?
+      @quiet
     end
   end
 end

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -157,7 +157,7 @@ module Mocha
     end
 
     def satisfied_expectations
-      expectations.select(&:verified?)
+      expectations.select(&:verified?).reject(&:quiet?)
     end
 
     def add_mock(mock)

--- a/test/acceptance/multiple_expectations_failure_message_test.rb
+++ b/test/acceptance/multiple_expectations_failure_message_test.rb
@@ -64,6 +64,26 @@ class FailureMessageTest < Mocha::TestCase
     ], test_result.failure_message_lines
   end
 
+  def test_should_not_report_quietly_satisfied_expectations
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.stubs(:method_one).quietly
+      mock.expects(:method_two).twice
+      mock.expects(:method_three).times(3)
+      1.times { mock.method_one }
+      2.times { mock.method_two }
+      2.times { mock.method_three }
+    end
+    assert_failed(test_result)
+    assert_equal [
+      'not all expectations were satisfied',
+      'unsatisfied expectations:',
+      '- expected exactly 3 times, invoked twice: #<Mock:mock>.method_three(any_parameters)',
+      'satisfied expectations:',
+      '- expected exactly twice, invoked twice: #<Mock:mock>.method_two(any_parameters)',
+    ], test_result.failure_message_lines
+  end
+
   def test_should_include_state_in_unsatisfied_expectation_message
     test_result = run_as_test do
       mock = mock('mock')


### PR DESCRIPTION
It's often not important to see satisfied stubs in test output, and in some test suites the noise can be difficult to parse. This commit introduces an `Expectation#quietly` method which allows the suppression of test output for satisfied expectations on a case-by-case basis.

### Example

```rb
setup do
  SomeGlobal.stubs(:foo).with(any_of(*SomeGlobal::THINGS)).quietly
  AnotherGlobal.stubs(:connection).quietly
end

test "foo" do
  Foo.stubs(:bar)
  Bar.expects(:baz)
end
```

| Without `#quietly` | With `#quietly` |
| - | - |
| <img width="937" alt="Screenshot 2021-11-11 at 15 35 17" src="https://user-images.githubusercontent.com/770763/141325641-74d88f82-80f4-47c2-a553-b7462017b585.png"> | <img width="953" alt="Screenshot 2021-11-11 at 17 46 29" src="https://user-images.githubusercontent.com/770763/141344841-dc3bddf6-e331-4c10-a752-4910a49b1d6f.png"> |

### Alternatives

One alternative might be to treat stubs and expectations differently, such that satisfied stubs are never reported. Or maybe satisfied expectations with a cardinality of 0 needn't be reported. Or maybe it's already possible to hook into `Mockery` somehow to override the reporting behaviour?

At the moment, we're monkey patching to achieve something similar but thought others might be interested in this change – no worries if not!