### PR TITLE
Mock#expects & #stubs should return last expectation

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -109,6 +109,7 @@ module Mocha
     #   object.expects(:expected_method_one).returns(:result_one)
     #   object.expects(:expected_method_two).returns(:result_two)
     def expects(method_name_or_hash, backtrace = nil)
+      expectation = nil
       iterator = ArgumentIterator.new(method_name_or_hash)
       iterator.each do |*args|
         method_name = args.shift
@@ -117,6 +118,7 @@ module Mocha
         expectation.returns(args.shift) unless args.empty?
         @expectations.add(expectation)
       end
+      expectation
     end
 
     # Adds an expectation that the specified method may be called any number of times with any parameters.
@@ -145,6 +147,7 @@ module Mocha
     #   object.stubs(:stubbed_method_one).returns(:result_one)
     #   object.stubs(:stubbed_method_two).returns(:result_two)
     def stubs(method_name_or_hash, backtrace = nil)
+      expectation = nil
       iterator = ArgumentIterator.new(method_name_or_hash)
       iterator.each do |*args|
         method_name = args.shift
@@ -154,6 +157,7 @@ module Mocha
         expectation.returns(args.shift) unless args.empty?
         @expectations.add(expectation)
       end
+      expectation
     end
 
     # Removes the specified stubbed methods (added by calls to {#expects} or {#stubs}) and all expectations associated with them.

--- a/test/acceptance/issue_524_test.rb
+++ b/test/acceptance/issue_524_test.rb
@@ -1,0 +1,35 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class Issue524Test < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_expects_returns_last_expectation
+    test_result = run_as_test do
+      object = mock
+      object.expects(:method_1 => 1, :method_2 => 2).twice
+      object.method_1
+      object.method_2
+      object.method_2
+    end
+    assert_passed(test_result)
+  end
+
+  def test_stubs_returns_last_expectation
+    test_result = run_as_test do
+      object = mock
+      object.stubs(:method_1 => 1, :method_2 => 2).twice
+      object.method_1
+      object.method_2
+      object.method_2
+    end
+    assert_passed(test_result)
+  end
+end


### PR DESCRIPTION
Even when passed a hash of method names vs return values. This is the same behaviour as for `ObjectMethods#expects` & `#stubs` and the behaviour described by the documentation for `Mock#expects` & `#stubs`.

Fixes #524.