### PR TITLE
Add Ruby 3.0 to the CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ workflows:
                 - ruby:2.5
                 - ruby:2.6
                 - ruby:2.7
+                - ruby:3.0
                 - ruby:latest
                 - jruby:latest
               gemfile:


### PR DESCRIPTION
This PR adds Ruby 3.0 to the CI matrix.
`ruby:latest` is Ruby 3.1, so only Ruby 3.0 is missing now.

EDIT: The CI status can be seen here: https://app.circleci.com/pipelines/github/mishina2228/mocha?branch=ci-on-ruby30&filter=all