### PR TITLE
Move development dependencies from gemspec to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,34 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# rubocop:disable Bundler/DuplicatedGem
+if RUBY_VERSION < '1.9.3'
+  gem 'rake', '~> 10.0'
+elsif RUBY_VERSION < '2'
+  gem 'rake', '~> 12.2.1'
+elsif RUBY_VERSION < '2.2'
+  gem 'rake', '~> 12.3.3'
+else
+  gem 'rake'
+end
+# rubocop:enable Bundler/DuplicatedGem
+
+gem 'introspection', '~> 0.0.1'
+
+# Avoid breaking change in psych v4 (https://bugs.ruby-lang.org/issues/17866)
+if RUBY_VERSION >= '3.1.0'
+  gem 'psych', '< 4'
+end
+
+if RUBY_VERSION >= '2.2.0'
+  # No test libraries in standard library
+  gem 'minitest'
+end
+if RUBY_VERSION >= '2.2.0'
+  gem 'rubocop', '<= 0.58.2'
+end
+if ENV['MOCHA_GENERATE_DOCS']
+  gem 'redcarpet'
+  gem 'yard'
+end

--- a/gemfiles/Gemfile.minitest.latest
+++ b/gemfiles/Gemfile.minitest.latest
@@ -4,4 +4,5 @@ gemspec :path=>"../"
 
 group :development do
   gem "minitest"
+  gem "rake"
 end

--- a/gemfiles/Gemfile.test-unit.latest
+++ b/gemfiles/Gemfile.test-unit.latest
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec :path=>"../"
 
 group :development do
+  gem "rake"
   if RUBY_VERSION < '1.9'
     gem "test-unit", "~> 2"
   else

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -2,7 +2,7 @@ lib = File.expand_path('../lib/', __FILE__)
 $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require 'mocha/version'
 
-Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s|
   s.name = 'mocha'
   s.version = Mocha::VERSION
   s.licenses = ['MIT', 'BSD-2-Clause']
@@ -21,41 +21,4 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.homepage = 'https://mocha.jamesmead.org'
   s.require_paths = ['lib']
   s.summary = 'Mocking and stubbing library'
-
-  unless s.respond_to?(:add_development_dependency)
-    class << s
-      def add_development_dependency(*args)
-        add_dependency(*args)
-      end
-    end
-  end
-
-  if RUBY_VERSION < '1.9.3'
-    s.add_development_dependency 'rake', '~> 10.0'
-  elsif RUBY_VERSION < '2'
-    s.add_development_dependency 'rake', '~> 12.2.1'
-  elsif RUBY_VERSION < '2.2'
-    s.add_development_dependency 'rake', '~> 12.3.3'
-  else
-    s.add_development_dependency 'rake'
-  end
-
-  s.add_development_dependency('introspection', '~> 0.0.1')
-
-  # Avoid breaking change in psych v4 (https://bugs.ruby-lang.org/issues/17866)
-  if RUBY_VERSION >= '3.1.0'
-    s.add_development_dependency('psych', '< 4')
-  end
-
-  if RUBY_VERSION >= '2.2.0'
-    # No test libraries in standard library
-    s.add_development_dependency('minitest')
-  end
-  if RUBY_VERSION >= '2.2.0'
-    s.add_development_dependency('rubocop', '<= 0.58.2')
-  end
-  if ENV['MOCHA_GENERATE_DOCS']
-    s.add_development_dependency('redcarpet')
-    s.add_development_dependency('yard')
-  end
 end


### PR DESCRIPTION
Gemspec should not contain `RUBY_VERSION` as a condition to switch dependencies,
because it is meaningless.
Please see the following for details:
- https://github.com/rubocop/rubocop/issues/7137
- https://github.com/rubocop/ruby-style-guide/issues/763

In addition, Bundler no longer uses `add_development_dependency` when genererating new gems.
- https://github.com/rubygems/bundler/pull/7222

For these reason, this PR moves development dependencies from gemspec to Gemfile.

 The CI status can be seen here: https://app.circleci.com/pipelines/github/mishina2228/mocha/9/workflows/2c6bbae9-c2c8-44f7-bf86-2f0fb487b83d