### PR TITLE
Ruby3 keyword argument matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Style/Alias:
 Style/Documentation:
   Enabled: false
 
+# Useful for distinuishing between positional & keyword arguments
+Style/BracesAroundHashParameters:
+  Enabled: false
+
 # Enumerable#each_with_object only available since Ruby v1.9
 Style/EachWithObject:
   Enabled: false

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -222,6 +222,7 @@ module Mocha
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end
+    ruby2_keywords(:with) if Module.respond_to?(:ruby2_keywords, true)
 
     # Modifies expectation so that the expected method must be called with a block.
     #

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -1,3 +1,4 @@
+require 'mocha/ruby_version'
 require 'mocha/method_matcher'
 require 'mocha/parameters_matcher'
 require 'mocha/expectation_error'
@@ -222,7 +223,7 @@ module Mocha
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end
-    ruby2_keywords(:with) if Module.respond_to?(:ruby2_keywords, true)
+    ruby2_keywords(:with) if RUBY_V3_PLUS
 
     # Modifies expectation so that the expected method must be called with a block.
     #

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -318,6 +318,7 @@ module Mocha
         raise_unexpected_invocation_error(invocation, matching_expectation)
       end
     end
+    ruby2_keywords(:method_missing) if Module.respond_to?(:ruby2_keywords, true)
 
     # @private
     def respond_to_missing?(symbol, include_all)

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -1,3 +1,4 @@
+require 'mocha/ruby_version'
 require 'mocha/expectation'
 require 'mocha/expectation_list'
 require 'mocha/invocation'
@@ -318,7 +319,7 @@ module Mocha
         raise_unexpected_invocation_error(invocation, matching_expectation)
       end
     end
-    ruby2_keywords(:method_missing) if Module.respond_to?(:ruby2_keywords, true)
+    ruby2_keywords(:method_missing) if RUBY_V3_PLUS
 
     # @private
     def respond_to_missing?(symbol, include_all)

--- a/lib/mocha/parameter_matchers/last_positional_hash.rb
+++ b/lib/mocha/parameter_matchers/last_positional_hash.rb
@@ -1,0 +1,26 @@
+require 'mocha/parameter_matchers/base'
+
+module Mocha
+  module ParameterMatchers
+    # Parameter matcher which matches when actual parameter equals expected value.
+    class LastPositionalHash < Base
+      # @private
+      def initialize(value)
+        @value = value
+      end
+
+      # @private
+      def matches?(available_parameters)
+        parameter = available_parameters.shift
+        return false unless Hash.ruby2_keywords_hash?(parameter) && Hash.ruby2_keywords_hash?(@value)
+
+        parameter == @value
+      end
+
+      # @private
+      def mocha_inspect
+        @value.mocha_inspect
+      end
+    end
+  end
+end

--- a/lib/mocha/parameter_matchers/last_positional_hash.rb
+++ b/lib/mocha/parameter_matchers/last_positional_hash.rb
@@ -2,14 +2,12 @@ require 'mocha/parameter_matchers/base'
 
 module Mocha
   module ParameterMatchers
-    # Parameter matcher which matches when actual parameter equals expected value.
+    # @private
     class LastPositionalHash < Base
-      # @private
       def initialize(value)
         @value = value
       end
 
-      # @private
       def matches?(available_parameters)
         parameter = available_parameters.shift
         if Hash.respond_to?(:ruby2_keywords_hash?)
@@ -19,7 +17,6 @@ module Mocha
         parameter == @value
       end
 
-      # @private
       def mocha_inspect
         @value.mocha_inspect
       end

--- a/lib/mocha/parameter_matchers/last_positional_hash.rb
+++ b/lib/mocha/parameter_matchers/last_positional_hash.rb
@@ -12,7 +12,7 @@ module Mocha
       # @private
       def matches?(available_parameters)
         parameter = available_parameters.shift
-        return false unless Hash.ruby2_keywords_hash?(parameter) && Hash.ruby2_keywords_hash?(@value)
+        return false if Hash.ruby2_keywords_hash?(@value) && !Hash.ruby2_keywords_hash?(parameter)
 
         parameter == @value
       end

--- a/lib/mocha/parameter_matchers/last_positional_hash.rb
+++ b/lib/mocha/parameter_matchers/last_positional_hash.rb
@@ -12,7 +12,9 @@ module Mocha
       # @private
       def matches?(available_parameters)
         parameter = available_parameters.shift
-        return false if Hash.ruby2_keywords_hash?(@value) && !Hash.ruby2_keywords_hash?(parameter)
+        if Hash.respond_to?(:ruby2_keywords_hash?)
+          return false if Hash.ruby2_keywords_hash?(@value) && !Hash.ruby2_keywords_hash?(parameter)
+        end
 
         parameter == @value
       end

--- a/lib/mocha/parameter_matchers/last_positional_hash.rb
+++ b/lib/mocha/parameter_matchers/last_positional_hash.rb
@@ -1,4 +1,5 @@
 require 'mocha/parameter_matchers/base'
+require 'mocha/ruby_version'
 
 module Mocha
   module ParameterMatchers
@@ -10,7 +11,7 @@ module Mocha
 
       def matches?(available_parameters)
         parameter = available_parameters.shift
-        if Hash.respond_to?(:ruby2_keywords_hash?)
+        if RUBY_V3_PLUS
           return false if Hash.ruby2_keywords_hash?(@value) && !Hash.ruby2_keywords_hash?(parameter)
         end
 

--- a/lib/mocha/parameters_matcher.rb
+++ b/lib/mocha/parameters_matcher.rb
@@ -1,5 +1,6 @@
 require 'mocha/inspect'
 require 'mocha/parameter_matchers'
+require 'mocha/parameter_matchers/last_positional_hash'
 
 module Mocha
   class ParametersMatcher
@@ -28,7 +29,11 @@ module Mocha
     end
 
     def matchers
-      @expected_parameters.map(&:to_matcher)
+      if (last_parameter = @expected_parameters.last).is_a?(Hash)
+        @expected_parameters[0...-1].map(&:to_matcher) + [ParameterMatchers::LastPositionalHash.new(last_parameter)]
+      else
+        @expected_parameters.map(&:to_matcher)
+      end
     end
   end
 end

--- a/lib/mocha/ruby_version.rb
+++ b/lib/mocha/ruby_version.rb
@@ -1,3 +1,4 @@
 module Mocha
   RUBY_V2_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2')
+  RUBY_V3_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('3')
 end

--- a/test/acceptance/stubba_example_test.rb
+++ b/test/acceptance/stubba_example_test.rb
@@ -88,9 +88,9 @@ class StubbaExampleTest < Mocha::TestCase
     found_widgets = [Widget.new]
     created_widget = Widget.new
     Widget.expects(:find).with(:all).returns(found_widgets)
-    Widget.expects(:create).with({:model => 'wombat'}).returns(created_widget)
+    Widget.expects(:create).with({ :model => 'wombat' }).returns(created_widget)
     assert_equal found_widgets, Widget.find(:all)
-    assert_equal created_widget, Widget.create({:model => 'wombat'})
+    assert_equal created_widget, Widget.create({ :model => 'wombat' })
   end
 
   def should_stub_instance_method_on_any_instance_of_a_class

--- a/test/acceptance/stubba_example_test.rb
+++ b/test/acceptance/stubba_example_test.rb
@@ -88,9 +88,9 @@ class StubbaExampleTest < Mocha::TestCase
     found_widgets = [Widget.new]
     created_widget = Widget.new
     Widget.expects(:find).with(:all).returns(found_widgets)
-    Widget.expects(:create).with(:model => 'wombat').returns(created_widget)
+    Widget.expects(:create).with({:model => 'wombat'}).returns(created_widget)
     assert_equal found_widgets, Widget.find(:all)
-    assert_equal created_widget, Widget.create(:model => 'wombat')
+    assert_equal created_widget, Widget.create({:model => 'wombat'})
   end
 
   def should_stub_instance_method_on_any_instance_of_a_class

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -72,14 +72,18 @@ class ExpectationTest < Mocha::TestCase
     assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
   end
 
-  def test_should_match_keyword_args
-    expectation = new_expectation.with(1, a: 1)
-    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
+  if Hash.respond_to?(:ruby2_keywords_hash)
+    def test_should_match_keyword_args
+      expectation = new_expectation.with(1, a: 1)
+      assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
+    end
   end
 
-  def test_should_not_match_keyword_args_with_last_positional_hashes
-    expectation = new_expectation.with(1, a: 1)
-    assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
+  if Module.respond_to?(:ruby2_keywords, true)
+    def test_should_not_match_keyword_args_with_last_positional_hashes
+      expectation = new_expectation.with(1, a: 1)
+      assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
+    end
   end
 
   def test_should_allow_invocations_until_expected_invocation_count_is_one_and_actual_invocation_count_would_be_two

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -67,16 +67,19 @@ class ExpectationTest < Mocha::TestCase
     assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, 0, 3))
   end
 
+  def test_should_match_last_positional_hash
+    expectation = new_expectation.with(1, { a: 1 })
+    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
+  end
+
   def test_should_match_keyword_args
     expectation = new_expectation.with(1, a: 1)
     assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
   end
 
-  if RUBY_VERSION >= '3.0.0'
-    def test_should_not_match_keyword_args_with_last_positional_hashes
-      expectation = new_expectation.with(1, { a: 1 })
-      assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
-    end
+  def test_should_not_match_keyword_args_with_last_positional_hashes
+    expectation = new_expectation.with(1, a: 1)
+    assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
   end
 
   def test_should_allow_invocations_until_expected_invocation_count_is_one_and_actual_invocation_count_would_be_two

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -67,6 +67,18 @@ class ExpectationTest < Mocha::TestCase
     assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, 0, 3))
   end
 
+  def test_should_match_keyword_args
+    expectation = new_expectation.with(1, a: 1)
+    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
+  end
+
+  if RUBY_VERSION >= '3.0.0'
+    def test_should_not_match_keyword_args_with_last_positional_hashes
+      expectation = new_expectation.with(1, { a: 1 })
+      assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
+    end
+  end
+
   def test_should_allow_invocations_until_expected_invocation_count_is_one_and_actual_invocation_count_would_be_two
     expectation = new_expectation.times(1)
     assert expectation.invocations_allowed?

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../test_helper', __FILE__)
+require 'mocha/ruby_version'
 require 'mocha/expectation'
 require 'mocha/invocation'
 require 'mocha/sequence'
@@ -72,14 +73,12 @@ class ExpectationTest < Mocha::TestCase
     assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { :a => 1 }))
   end
 
-  if Hash.respond_to?(:ruby2_keywords_hash)
+  if RUBY_V3_PLUS
     def test_should_match_keyword_args
       expectation = new_expectation.with(1, Hash.ruby2_keywords_hash({ :a => 1 }))
       assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ :a => 1 })))
     end
-  end
 
-  if Module.respond_to?(:ruby2_keywords, true)
     def test_should_not_match_keyword_args_with_last_positional_hashes
       expectation = new_expectation.with(1, Hash.ruby2_keywords_hash({ :a => 1 }))
       assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { :a => 1 }))

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -68,21 +68,21 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_match_last_positional_hash
-    expectation = new_expectation.with(1, { a: 1 })
-    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
+    expectation = new_expectation.with(1, { :a => 1 })
+    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { :a => 1 }))
   end
 
   if Hash.respond_to?(:ruby2_keywords_hash)
     def test_should_match_keyword_args
-      expectation = new_expectation.with(1, a: 1)
-      assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ a: 1 })))
+      expectation = new_expectation.with(1, Hash.ruby2_keywords_hash({ :a => 1 }))
+      assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, Hash.ruby2_keywords_hash({ :a => 1 })))
     end
   end
 
   if Module.respond_to?(:ruby2_keywords, true)
     def test_should_not_match_keyword_args_with_last_positional_hashes
-      expectation = new_expectation.with(1, a: 1)
-      assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { a: 1 }))
+      expectation = new_expectation.with(1, Hash.ruby2_keywords_hash({ :a => 1 }))
+      assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, { :a => 1 }))
     end
   end
 


### PR DESCRIPTION
TODO:

* [ ] Is there a missing unit test scenario in `ExpectationTest`?
* [ ] Add acceptance tests, c.f. [`ParameterMatcherTest`](https://github.com/freerange/mocha/blob/b7a7d23321e409c9ad77229f80033a55eb0d8a90/test/acceptance/parameter_matcher_test.rb) and/or [`OptionalParameterMatcherTest`](https://github.com/freerange/mocha/blob/b7a7d23321e409c9ad77229f80033a55eb0d8a90/test/acceptance/optional_parameters_test.rb).
* [ ] Work out whether [the two test failures in `StubbaExampleTest`](https://app.circleci.com/pipelines/github/freerange/mocha/128/workflows/59b1abe9-2659-4abf-b42f-797c62aeee07/jobs/1795) is a sign that this change might break a lot of existing tests. Do we need to put this change behind a configuration option?
* [x] ~Simplify/centralize Ruby version checking for ruby2 keywords functionality.~ Fixed by using `RUBY_V3_PLUS`.
* [x] ~Work out what to do with Ruby v1.8 - there is a problem *parsing* `expectation_test.rb` with keyword arguments.~ Resolved in #536
* [x] ~Resolve Rubocop issues in unit tests.~ Resolved by disabling `Style/BracesAroundHashParameters` cop and using hash rocket syntax in combination with `Hash.ruby2_keywords_hash` to designate keyword arguments. Now that we've dropped support for Ruby v1.8, we could probably change the configuration of the `Style/HashSyntax` cop, but that feels like a bigger change (see #537).
* [x] ~Fix Yardoc for `LastPositionalHash`.~ Fixed by marking the whole class as private from a documentation point of view. 
* [ ] Find someone with a large Rails codebase using Mocha to test a pre-release version
