### PR TITLE
Remove ParametersMatcher from Invocation#call_description

### DIFF
--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -55,7 +55,7 @@ module Mocha
     end
 
     def call_description
-      description = "#{@mock.mocha_inspect}.#{@method_name}#{ParametersMatcher.new(@arguments).mocha_inspect}"
+      description = "#{@mock.mocha_inspect}.#{@method_name}#{argument_description}"
       description << ' { ... }' unless @block.nil?
       description
     end
@@ -72,6 +72,15 @@ module Mocha
 
     def full_description
       "\n  - #{call_description} #{result_description}"
+    end
+
+    private
+
+    def argument_description
+      signature = arguments.mocha_inspect
+      signature = signature.gsub(/^\[|\]$/, '')
+      signature = signature.gsub(/^\{|\}$/, '') if arguments.length == 1
+      "(#{signature})"
     end
   end
 end


### PR DESCRIPTION
This is a somewhat odd usage of `ParametersMatcher`, and I think unnecessarily couples it to `Invocation#call_description`.

I've chosen to duplicate the mocha_inspect logic for now because it seemed possible for them to work differently e.g. Invocation should never contain matchers (right?).

Does this look fine to you @floehopper?