### PR TITLE
Spike refactoring of arguments for Ruby 3

### DIFF
--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -219,6 +219,8 @@ module Mocha
     #   object.expected_method(17)
     #   # => verify fails
     def with(*expected_parameters, &matching_block)
+      # FUTURE: parse expected_parameters into positional and keyword args
+      # Depends a little on how we want to handle https://github.com/freerange/mocha/issues/446#issuecomment-1232952693
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -224,6 +224,7 @@ module Mocha
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end
+    ruby2_keywords(:with)
 
     # Modifies expectation so that the expected method must be called with a block.
     #

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -220,7 +220,7 @@ module Mocha
     #   # => verify fails
     def with(*expected_parameters, &matching_block)
       # FUTURE: parse expected_parameters into positional and keyword args
-      # Depends a little on how we want to handle https://github.com/freerange/mocha/issues/446#issuecomment-1232952693
+      # Depends a little on how we want to handle https://github.com/freerange/mocha/pull/534#discussion_r959743155
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -590,7 +590,7 @@ module Mocha
 
     # @private
     def match?(invocation)
-      @method_matcher.match?(invocation.method_name) && @parameters_matcher.match?(invocation.arguments) && @block_matcher.match?(invocation.block) && in_correct_order?
+      @method_matcher.match?(invocation.method_name) && @parameters_matcher.match?(invocation) && @block_matcher.match?(invocation.block) && in_correct_order?
     end
 
     # @private

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -219,8 +219,6 @@ module Mocha
     #   object.expected_method(17)
     #   # => verify fails
     def with(*expected_parameters, &matching_block)
-      # FUTURE: parse expected_parameters into positional and keyword args
-      # Depends a little on how we want to handle https://github.com/freerange/mocha/pull/534#discussion_r959743155
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -10,6 +10,7 @@ module Mocha
   class Invocation
     attr_reader :method_name, :block
 
+    # FUTURE: def initialize(mock, method_name, positional_arguments, keyword_arguments, block)
     def initialize(mock, method_name, arguments, block)
       @mock = mock
       @method_name = method_name
@@ -21,6 +22,8 @@ module Mocha
 
     def call(yield_parameters = YieldParameters.new, return_values = ReturnValues.new)
       yield_parameters.next_invocation.each do |yield_args|
+        # FUTURE: depending on future API for matching kwargs,
+        # may need to tweak the call here. See Expectation#with.
         @yields << ParametersMatcher.new(yield_args)
         if @block
           @block.call(*yield_args)

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -10,7 +10,6 @@ module Mocha
   class Invocation
     attr_reader :method_name, :block
 
-    # FUTURE: def initialize(mock, method_name, positional_arguments, keyword_arguments, block)
     def initialize(mock, method_name, arguments, block)
       @mock = mock
       @method_name = method_name
@@ -22,8 +21,7 @@ module Mocha
 
     def call(yield_parameters = YieldParameters.new, return_values = ReturnValues.new)
       yield_parameters.next_invocation.each do |yield_args|
-        # FUTURE: depending on future API for matching kwargs,
-        # may need to tweak the call here. See Expectation#with.
+        # need to check how keyword args factors into this
         @yields << ParametersMatcher.new(yield_args)
         if @block
           @block.call(*yield_args)

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -10,7 +10,7 @@ module Mocha
   class Invocation
     attr_reader :method_name, :block
 
-    def initialize(mock, method_name, *arguments, &block)
+    def initialize(mock, method_name, arguments, block)
       @mock = mock
       @method_name = method_name
       @arguments = arguments

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -309,9 +309,13 @@ module Mocha
 
     # @private
     def method_missing(symbol, *arguments, &block) # rubocop:disable Style/MethodMissingSuper
+      handle_method_call(symbol, arguments, block)
+    end
+
+    def handle_method_call(symbol, arguments, block)
       check_expiry
       check_responder_responds_to(symbol)
-      invocation = Invocation.new(self, symbol, *arguments, &block)
+      invocation = Invocation.new(self, symbol, arguments, block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
         matching_expectation_allowing_invocation.invoke(invocation)
       elsif (matching_expectation = all_expectations.match(invocation)) || (!matching_expectation && !@everything_stubbed)

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -311,10 +311,14 @@ module Mocha
     def method_missing(symbol, *arguments, &block) # rubocop:disable Style/MethodMissingSuper
       handle_method_call(symbol, arguments, block)
     end
+    # FUTURE: ruby2_keywords(:method_missing)
 
     def handle_method_call(symbol, arguments, block)
       check_expiry
       check_responder_responds_to(symbol)
+      # FUTURE: split arguments into args and kwargs e.g.:
+      # args, kwargs = split_ruby2_args(arguments)
+      # invocation = Invocation.new(self, symbol, args, kwargs, block)
       invocation = Invocation.new(self, symbol, arguments, block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
         matching_expectation_allowing_invocation.invoke(invocation)

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -311,14 +311,11 @@ module Mocha
     def method_missing(symbol, *arguments, &block) # rubocop:disable Style/MethodMissingSuper
       handle_method_call(symbol, arguments, block)
     end
-    # FUTURE: ruby2_keywords(:method_missing)
+    ruby2_keywords(:method_missing)
 
     def handle_method_call(symbol, arguments, block)
       check_expiry
       check_responder_responds_to(symbol)
-      # FUTURE: split arguments into args and kwargs e.g.:
-      # args, kwargs = split_ruby2_args(arguments)
-      # invocation = Invocation.new(self, symbol, args, kwargs, block)
       invocation = Invocation.new(self, symbol, arguments, block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
         matching_expectation_allowing_invocation.invoke(invocation)

--- a/lib/mocha/parameter_matchers/hash.rb
+++ b/lib/mocha/parameter_matchers/hash.rb
@@ -11,6 +11,7 @@ module Mocha
       # @private
       def matches?(available_parameters)
         parameter = available_parameters.shift
+        # we can insert a check for a configuration here
         if available_parameters.empty? # last parameter
           return false unless ::Hash.ruby2_keywords_hash?(parameter) == ::Hash.ruby2_keywords_hash?(@value)
         end

--- a/lib/mocha/parameter_matchers/hash.rb
+++ b/lib/mocha/parameter_matchers/hash.rb
@@ -1,0 +1,26 @@
+require 'mocha/parameter_matchers/base'
+
+module Mocha
+  module ParameterMatchers
+    class Hash < Base
+      # @private
+      def initialize(value)
+        @value = value
+      end
+
+      # @private
+      def matches?(available_parameters)
+        parameter = available_parameters.shift
+        if available_parameters.empty? # last parameter
+          return false unless ::Hash.ruby2_keywords_hash?(parameter) == ::Hash.ruby2_keywords_hash?(@value)
+        end
+        parameter == @value
+      end
+
+      # @private
+      def mocha_inspect
+        @value.mocha_inspect
+      end
+    end
+  end
+end

--- a/lib/mocha/parameter_matchers/instance_methods.rb
+++ b/lib/mocha/parameter_matchers/instance_methods.rb
@@ -1,4 +1,5 @@
 require 'mocha/parameter_matchers/equals'
+require 'mocha/parameter_matchers/hash'
 
 module Mocha
   module ParameterMatchers
@@ -15,4 +16,10 @@ end
 # @private
 class Object
   include Mocha::ParameterMatchers::InstanceMethods
+end
+
+class Hash
+  def to_matcher
+    Mocha::ParameterMatchers::Hash.new(self)
+  end
 end

--- a/lib/mocha/parameters_matcher.rb
+++ b/lib/mocha/parameters_matcher.rb
@@ -11,8 +11,10 @@ module Mocha
     def match?(invocation)
       actual_parameters = invocation.arguments
       if @matching_block
+        # FUTURE: @matching_block.call(*invocation.positional_arguments, **invocation.keyword_arguments)
         @matching_block.call(*actual_parameters)
       else
+        # FUTURE: check against invocation.positional_arguments and invocation.keyword_arguments
         parameters_match?(actual_parameters)
       end
     end

--- a/lib/mocha/parameters_matcher.rb
+++ b/lib/mocha/parameters_matcher.rb
@@ -8,7 +8,8 @@ module Mocha
       @matching_block = matching_block
     end
 
-    def match?(actual_parameters = [])
+    def match?(invocation)
+      actual_parameters = invocation.arguments
       if @matching_block
         @matching_block.call(*actual_parameters)
       else

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -59,7 +59,7 @@ module Mocha
       stub_method_owner.send(:define_method, method_name) do |*args, &block|
         self_in_scope.mock.handle_method_call(method_name_in_scope, args, block)
       end
-      # FUTURE: stub_method_owner.send(:ruby2_keywords, method_name)
+      stub_method_owner.send(:ruby2_keywords, method_name)
       retain_original_visibility(stub_method_owner)
     end
 

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -57,7 +57,7 @@ module Mocha
       self_in_scope = self
       method_name_in_scope = method_name
       stub_method_owner.send(:define_method, method_name) do |*args, &block|
-        self_in_scope.mock.method_missing(method_name_in_scope, *args, &block)
+        self_in_scope.mock.handle_method_call(method_name_in_scope, args, block)
       end
       retain_original_visibility(stub_method_owner)
     end

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -59,6 +59,7 @@ module Mocha
       stub_method_owner.send(:define_method, method_name) do |*args, &block|
         self_in_scope.mock.handle_method_call(method_name_in_scope, args, block)
       end
+      # FUTURE: stub_method_owner.send(:ruby2_keywords, method_name)
       retain_original_visibility(stub_method_owner)
     end
 

--- a/test/acceptance/ruby3_keyword_arguments_test.rb
+++ b/test/acceptance/ruby3_keyword_arguments_test.rb
@@ -13,7 +13,7 @@ class KeywordArgumentsTest < Mocha::TestCase
 
   # somewhat adapted from https://github.com/ruby/ruby/blob/4643bf5d55af6f79266dd67b69bb6eb4ff82029a/doc/NEWS-2.7.0#the-spec-of-keyword-arguments-is-changed-towards-30-
 
-  # failing
+  # previously failing
   def test_should_not_match_hash_parameter_with_keyword_args
     test_result = run_as_test do
       mock = mock()
@@ -23,7 +23,7 @@ class KeywordArgumentsTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
-  # failing
+  # previously failing
   def test_should_not_match_hash_parameter_with_splatted_keyword_args
     test_result = run_as_test do
       mock = mock()
@@ -51,7 +51,7 @@ class KeywordArgumentsTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
-  # failing
+  # previously failing
   def test_should_not_match_keyword_args_with_positional_hash
     test_result = run_as_test do
       mock = mock()
@@ -61,7 +61,7 @@ class KeywordArgumentsTest < Mocha::TestCase
     assert_failed(test_result)
   end
 
-  # failing
+  # previously failing
   def test_should_not_match_positional_hash_with_keyword_args
     test_result = run_as_test do
       mock = mock()

--- a/test/acceptance/ruby3_keyword_arguments_test.rb
+++ b/test/acceptance/ruby3_keyword_arguments_test.rb
@@ -1,0 +1,82 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class KeywordArgumentsTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  # somewhat adapted from https://github.com/ruby/ruby/blob/4643bf5d55af6f79266dd67b69bb6eb4ff82029a/doc/NEWS-2.7.0#the-spec-of-keyword-arguments-is-changed-towards-30-
+
+  # failing
+  def test_should_not_match_hash_parameter_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(key: 42)
+      mock.method({ key: 42 })
+    end
+    assert_failed(test_result)
+  end
+
+  # failing
+  def test_should_not_match_hash_parameter_with_splatted_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(**{ key: 42 })
+      mock.method({ key: 42 })
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(key: 42)
+      mock.method(**{ key: 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_splatted_hash
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(**{ key: 42 })
+      mock.method(**{ key: 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  # failing
+  def test_should_not_match_keyword_args_with_positional_hash
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, { key: 42 })
+      mock.method(1, key: 42)
+    end
+    assert_failed(test_result)
+  end
+
+  # failing
+  def test_should_not_match_positional_hash_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, key: 42)
+      mock.method(1, { key: 42 })
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_match_keyword_args_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, key: 42)
+      mock.method(1, key: 42)
+    end
+    assert_passed(test_result)
+  end
+end


### PR DESCRIPTION
Proposed changes: 
- parse the invocation arguments / block once and then pass those down, instead of re-splatting/delegating them. In the future, this will let us keep the `ruby2_keywords` logic at the "entry points" (`Mock#method_missing` and `StubbedMethod#define_new_method`) instead of having to do it at multiple layers.
- have ParametersMatcher check against Invocation, so in the future Invocation could expose positional/keyword arguments instead of a single `arguments` array

If this seems reasonable, I'll work on breaking this into smaller PRs with proper tests.