### PR TITLE
Use Ruby v1.9 features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,10 +19,6 @@ Style/ExpandPathArguments:
 Style/FormatStringToken:
   EnforcedStyle: unannotated
 
-# ruby19 style has only been supported since Ruby v1.9
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-
 # I'm not keen on this cop, because it's easy to miss the conditional
 # I think the results are particularly unhelpful when Metrics/LineLength is big
 Style/IfUnlessModifier:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,10 +15,6 @@ Style/Documentation:
 Style/ExpandPathArguments:
   Enabled: false
 
-# Kernel#format has only supported named references since Ruby v1.9
-Style/FormatStringToken:
-  EnforcedStyle: unannotated
-
 # I'm not keen on this cop, because it's easy to miss the conditional
 # I think the results are particularly unhelpful when Metrics/LineLength is big
 Style/IfUnlessModifier:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ Style/Alias:
 Style/Documentation:
   Enabled: false
 
-# Enumerable#each_with_object only available since Ruby v1.9
-Style/EachWithObject:
-  Enabled: false
-
 # Kernel#__dir__ has only been available since Ruby v2.0
 Style/ExpandPathArguments:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -106,7 +106,7 @@ def benchmark_test_case(klass, iterations)
     unless @silent_option
       begin
         load 'test/unit/ui/console/outputlevel.rb' unless defined?(Test::Unit::UI::Console::OutputLevel::SILENT)
-        @silent_option = { :output_level => Test::Unit::UI::Console::OutputLevel::SILENT }
+        @silent_option = { output_level: Test::Unit::UI::Console::OutputLevel::SILENT }
       rescue LoadError
         @silent_option = Test::Unit::UI::SILENT
       end

--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -37,13 +37,13 @@ module Mocha
   class Configuration
     # @private
     DEFAULTS = {
-      :stubbing_method_unnecessarily => :allow,
-      :stubbing_method_on_non_mock_object => :allow,
-      :stubbing_non_existent_method => :allow,
-      :stubbing_non_public_method => :allow,
-      :stubbing_method_on_nil => :prevent,
-      :display_matching_invocations_on_failure => false,
-      :reinstate_undocumented_behaviour_from_v1_9 => true
+      stubbing_method_unnecessarily: :allow,
+      stubbing_method_on_non_mock_object: :allow,
+      stubbing_non_existent_method: :allow,
+      stubbing_non_public_method: :allow,
+      stubbing_method_on_nil: :prevent,
+      display_matching_invocations_on_failure: false,
+      reinstate_undocumented_behaviour_from_v1_9: true
     }.freeze
 
     attr_reader :options

--- a/lib/mocha/debug.rb
+++ b/lib/mocha/debug.rb
@@ -1,8 +1,7 @@
 module Mocha
   module Debug
-    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').inject({}) do |hash, key|
+    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').each_with_object({}) do |key, hash|
       hash[key] = true
-      hash
     end.freeze
 
     def self.puts(message)

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -625,7 +625,7 @@ module Mocha
     def inspect
       address = __id__ * 2
       address += 0x100000000 if address < 0
-      "#<Expectation:0x#{format('%x', address)} #{mocha_inspect} >"
+      "#<Expectation:0x#{format('%<address>x', address: address)} #{mocha_inspect} >"
     end
 
     # @private

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -623,9 +623,7 @@ module Mocha
 
     # @private
     def inspect
-      address = __id__ * 2
-      address += 0x100000000 if address < 0
-      "#<Expectation:0x#{format('%<address>x', address: address)} #{mocha_inspect} >"
+      Inspect.describe(self, " #{mocha_inspect} ")
     end
 
     # @private

--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -2,11 +2,15 @@ require 'date'
 
 module Mocha
   module Inspect
+    def self.describe(object, desc = '')
+      address = object.__id__ * 2
+      address += 0x100000000 if address < 0
+      "#<#{object.class.to_s.delete_prefix('Mocha::')}:0x#{format('%<address>x', address: address)}#{desc}>"
+    end
+
     module ObjectMethods
       def mocha_inspect
-        address = __id__ * 2
-        address += 0x100000000 if address < 0
-        inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%<address>x', address: address)}>" : inspect
+        inspect =~ /#</ ? Inspect.describe(self) : inspect
       end
     end
 

--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -6,7 +6,7 @@ module Mocha
       def mocha_inspect
         address = __id__ * 2
         address += 0x100000000 if address < 0
-        inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%x', address)}>" : inspect
+        inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%<address>x', address: address)}>" : inspect
       end
     end
 

--- a/lib/mocha/integration/test_unit/adapter.rb
+++ b/lib/mocha/integration/test_unit/adapter.rb
@@ -23,16 +23,16 @@ module Mocha
 
         # @private
         def self.included(mod)
-          mod.setup :mocha_setup, :before => :prepend
+          mod.setup :mocha_setup, before: :prepend
 
           mod.exception_handler(:handle_mocha_expectation_error)
 
-          mod.cleanup :after => :append do
+          mod.cleanup after: :append do
             assertion_counter = Integration::AssertionCounter.new(self)
             mocha_verify(assertion_counter)
           end
 
-          mod.teardown :mocha_teardown, :after => :append
+          mod.teardown :mocha_teardown, after: :append
         end
 
         private

--- a/lib/mocha/names.rb
+++ b/lib/mocha/names.rb
@@ -35,9 +35,7 @@ module Mocha
     end
 
     def mocha_inspect
-      address = @mock.__id__ * 2
-      address += 0x100000000 if address < 0
-      "#<Mock:0x#{format('%<address>x', address: address)}>"
+      Inspect.describe(@mock)
     end
   end
 end

--- a/lib/mocha/names.rb
+++ b/lib/mocha/names.rb
@@ -37,7 +37,7 @@ module Mocha
     def mocha_inspect
       address = @mock.__id__ * 2
       address += 0x100000000 if address < 0
-      "#<Mock:0x#{format('%x', address)}>"
+      "#<Mock:0x#{format('%<address>x', address: address)}>"
     end
   end
 end

--- a/lib/mocha/parameter_matchers/equivalent_uri.rb
+++ b/lib/mocha/parameter_matchers/equivalent_uri.rb
@@ -51,7 +51,7 @@ module Mocha
       # @private
       def explode(uri)
         query_hash = CGI.parse(uri.query || '')
-        URI::Generic::COMPONENT.inject({}) { |h, k| h.merge(k => uri.__send__(k)) }.merge(:query => query_hash)
+        URI::Generic::COMPONENT.inject({}) { |h, k| h.merge(k => uri.__send__(k)) }.merge(query: query_hash)
       end
     end
   end

--- a/test/acceptance/expectations_on_multiple_methods_test.rb
+++ b/test/acceptance/expectations_on_multiple_methods_test.rb
@@ -23,8 +23,8 @@ class ExpectationsOnMultipleMethodsTest < Mocha::TestCase
     end.new
     test_result = run_as_test do
       instance.expects(
-        :my_instance_method_1 => :new_return_value_1,
-        :my_instance_method_2 => :new_return_value_2
+        my_instance_method_1: :new_return_value_1,
+        my_instance_method_2: :new_return_value_2
       )
       assert_equal :new_return_value_1, instance.my_instance_method_1
       assert_equal :new_return_value_2, instance.my_instance_method_2
@@ -44,8 +44,8 @@ class ExpectationsOnMultipleMethodsTest < Mocha::TestCase
     end.new
     test_result = run_as_test do
       instance.stubs(
-        :my_instance_method_1 => :new_return_value_1,
-        :my_instance_method_2 => :new_return_value_2
+        my_instance_method_1: :new_return_value_1,
+        my_instance_method_2: :new_return_value_2
       )
       assert_equal :new_return_value_1, instance.my_instance_method_1
       assert_equal :new_return_value_2, instance.my_instance_method_2

--- a/test/acceptance/issue_524_test.rb
+++ b/test/acceptance/issue_524_test.rb
@@ -14,7 +14,7 @@ class Issue524Test < Mocha::TestCase
   def test_expects_returns_last_expectation
     test_result = run_as_test do
       object = mock
-      object.expects(:method_1 => 1, :method_2 => 2).twice
+      object.expects(method_1: 1, method_2: 2).twice
       object.method_1
       object.method_2
       object.method_2
@@ -25,7 +25,7 @@ class Issue524Test < Mocha::TestCase
   def test_stubs_returns_last_expectation
     test_result = run_as_test do
       object = mock
-      object.stubs(:method_1 => 1, :method_2 => 2).twice
+      object.stubs(method_1: 1, method_2: 2).twice
       object.method_1
       object.method_2
       object.method_2

--- a/test/acceptance/mock_built_with_first_argument_type_being_string_test.rb
+++ b/test/acceptance/mock_built_with_first_argument_type_being_string_test.rb
@@ -51,7 +51,7 @@ class MockBuiltWithFirstArgumentTypeBeingStringTest < Mocha::TestCase
   def test_mock_built_with_first_argument_a_symbol_and_second_argument_a_hash
     test_result = run_as_test do
       DeprecationDisabler.disable_deprecations do
-        s = mock(:my_method, :another_method => 123)
+        s = mock(:my_method, another_method: 123)
         assert_nil s.my_method
       end
       expected_warning = 'In this case the 2nd argument for `mock(:#my_method, ...)` is ignored, but in the future a Hash of expected methods vs return values will be respected.'
@@ -63,7 +63,7 @@ class MockBuiltWithFirstArgumentTypeBeingStringTest < Mocha::TestCase
   def test_stub_built_with_first_argument_a_symbol_and_second_argument_a_hash
     test_result = run_as_test do
       DeprecationDisabler.disable_deprecations do
-        s = stub(:my_method, :another_method => 123)
+        s = stub(:my_method, another_method: 123)
         assert_nil s.my_method
       end
       expected_warning = 'In this case the 2nd argument for `stub(:#my_method, ...)` is ignored, but in the future a Hash of stubbed methods vs return values will be respected.'
@@ -87,7 +87,7 @@ class MockBuiltWithFirstArgumentTypeBeingStringTest < Mocha::TestCase
   def test_stub_everything_built_with_first_argument_a_symbol_and_second_argument_a_hash
     test_result = run_as_test do
       DeprecationDisabler.disable_deprecations do
-        s = stub_everything(:my_method, :another_method => 123)
+        s = stub_everything(:my_method, another_method: 123)
         assert_nil s.my_method
       end
       expected_warning = 'In this case the 2nd argument for `stub_everything(:#my_method, ...)` is ignored, but in the future a Hash of stubbed methods vs return values will be respected.' # rubocop:disable Metrics/LineLength

--- a/test/acceptance/mock_test.rb
+++ b/test/acceptance/mock_test.rb
@@ -43,7 +43,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_symbol_named_mock_and_explicitly_add_an_expectation_which_is_satisfied
     test_result = run_as_test do
-      Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => false) do
+      Mocha::Configuration.override(reinstate_undocumented_behaviour_from_v1_9: false) do
         DeprecationDisabler.disable_deprecations do
           foo = mock(:foo)
           foo.expects(:bar)
@@ -74,7 +74,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_mock_incorporating_two_expectations_which_are_satisifed
     test_result = run_as_test do
-      foo = mock(:bar => 'bar', :baz => 'baz')
+      foo = mock(bar: 'bar', baz: 'baz')
       foo.bar
       foo.baz
     end
@@ -83,7 +83,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_mock_incorporating_two_expectations_the_first_of_which_is_not_satisifed
     test_result = run_as_test do
-      foo = mock(:bar => 'bar', :baz => 'baz')
+      foo = mock(bar: 'bar', baz: 'baz')
       foo.baz
     end
     assert_failed(test_result)
@@ -91,7 +91,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_mock_incorporating_two_expectations_the_second_of_which_is_not_satisifed
     test_result = run_as_test do
-      foo = mock(:bar => 'bar', :baz => 'baz')
+      foo = mock(bar: 'bar', baz: 'baz')
       foo.bar
     end
     assert_failed(test_result)
@@ -99,7 +99,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_string_named_mock_incorporating_two_expectations_which_are_satisifed
     test_result = run_as_test do
-      foo = mock('foo', :bar => 'bar', :baz => 'baz')
+      foo = mock('foo', bar: 'bar', baz: 'baz')
       foo.bar
       foo.baz
     end
@@ -108,9 +108,9 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_symbol_named_mock_incorporating_two_expectations_which_are_satisifed
     test_result = run_as_test do
-      Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => false) do
+      Mocha::Configuration.override(reinstate_undocumented_behaviour_from_v1_9: false) do
         DeprecationDisabler.disable_deprecations do
-          foo = mock(:foo, :bar => 'bar', :baz => 'baz')
+          foo = mock(:foo, bar: 'bar', baz: 'baz')
           foo.bar
           foo.baz
         end
@@ -121,7 +121,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_string_named_mock_incorporating_two_expectations_the_first_of_which_is_not_satisifed
     test_result = run_as_test do
-      foo = mock('foo', :bar => 'bar', :baz => 'baz')
+      foo = mock('foo', bar: 'bar', baz: 'baz')
       foo.baz
     end
     assert_failed(test_result)
@@ -130,7 +130,7 @@ class MockTest < Mocha::TestCase
   def test_should_build_symbol_named_mock_incorporating_two_expectations_the_first_of_which_is_not_satisifed
     test_result = run_as_test do
       DeprecationDisabler.disable_deprecations do
-        foo = mock(:foo, :bar => 'bar', :baz => 'baz')
+        foo = mock(:foo, bar: 'bar', baz: 'baz')
         foo.baz
       end
     end
@@ -139,7 +139,7 @@ class MockTest < Mocha::TestCase
 
   def test_should_build_string_named_mock_incorporating_two_expectations_the_second_of_which_is_not_satisifed
     test_result = run_as_test do
-      foo = mock('foo', :bar => 'bar', :baz => 'baz')
+      foo = mock('foo', bar: 'bar', baz: 'baz')
       foo.bar
     end
     assert_failed(test_result)
@@ -148,7 +148,7 @@ class MockTest < Mocha::TestCase
   def test_should_build_symbol_named_mock_incorporating_two_expectations_the_second_of_which_is_not_satisifed
     test_result = run_as_test do
       DeprecationDisabler.disable_deprecations do
-        foo = mock(:foo, :bar => 'bar', :baz => 'baz')
+        foo = mock(:foo, bar: 'bar', baz: 'baz')
         foo.bar
       end
     end

--- a/test/acceptance/multiple_yielding_test.rb
+++ b/test/acceptance/multiple_yielding_test.rb
@@ -26,17 +26,17 @@ class MultipleYieldingTest < Mocha::TestCase
   def test_yields_values_multiple_times_when_multiple_yields_arguments_are_not_arrays
     test_result = run_as_test do
       m = mock('m')
-      m.stubs(:foo).multiple_yields(1, { :b => 2 }, '3')
+      m.stubs(:foo).multiple_yields(1, { b: 2 }, '3')
       yielded = []
       m.foo { |*args| yielded << args }
-      assert_equal [[1], [{ :b => 2 }], ['3']], yielded
+      assert_equal [[1], [{ b: 2 }], ['3']], yielded
     end
     assert_passed(test_result)
   end
 
   def test_raises_local_jump_error_if_instructed_to_multiple_yield_but_no_block_given
     test_result = run_as_test do
-      Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => false) do
+      Mocha::Configuration.override(reinstate_undocumented_behaviour_from_v1_9: false) do
         m = mock('m')
         m.stubs(:foo).multiple_yields([])
         assert_raises(LocalJumpError) { m.foo }

--- a/test/acceptance/parameter_matcher_test.rb
+++ b/test/acceptance/parameter_matcher_test.rb
@@ -15,7 +15,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_key(:key_1))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2')
+      mock.method(key_1: 'value_1', key_2: 'value_2')
     end
     assert_passed(test_result)
   end
@@ -24,7 +24,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_key(:key_1))
-      mock.method(:key_2 => 'value_2')
+      mock.method(key_2: 'value_2')
     end
     assert_failed(test_result)
   end
@@ -33,7 +33,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_value('value_1'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2')
+      mock.method(key_1: 'value_1', key_2: 'value_2')
     end
     assert_passed(test_result)
   end
@@ -42,7 +42,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_value('value_1'))
-      mock.method(:key_2 => 'value_2')
+      mock.method(key_2: 'value_2')
     end
     assert_failed(test_result)
   end
@@ -51,7 +51,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_entry(:key_1, 'value_1'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2')
+      mock.method(key_1: 'value_1', key_2: 'value_2')
     end
     assert_passed(test_result)
   end
@@ -60,7 +60,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_entry(:key_1, 'value_2'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2')
+      mock.method(key_1: 'value_1', key_2: 'value_2')
     end
     assert_failed(test_result)
   end
@@ -68,8 +68,8 @@ class ParameterMatcherTest < Mocha::TestCase
   def test_should_match_hash_parameter_with_specified_hash_entry
     test_result = run_as_test do
       mock = mock()
-      mock.expects(:method).with(has_entry(:key_1 => 'value_1'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2')
+      mock.expects(:method).with(has_entry(key_1: 'value_1'))
+      mock.method(key_1: 'value_1', key_2: 'value_2')
     end
     assert_passed(test_result)
   end
@@ -77,8 +77,8 @@ class ParameterMatcherTest < Mocha::TestCase
   def test_should_not_match_hash_parameter_with_specified_hash_entry
     test_result = run_as_test do
       mock = mock()
-      mock.expects(:method).with(has_entry(:key_1 => 'value_2'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2')
+      mock.expects(:method).with(has_entry(key_1: 'value_2'))
+      mock.method(key_1: 'value_1', key_2: 'value_2')
     end
     assert_failed(test_result)
   end
@@ -86,8 +86,8 @@ class ParameterMatcherTest < Mocha::TestCase
   def test_should_match_hash_parameter_with_specified_entries
     test_result = run_as_test do
       mock = mock()
-      mock.expects(:method).with(has_entries(:key_1 => 'value_1', :key_2 => 'value_2'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2', :key_3 => 'value_3')
+      mock.expects(:method).with(has_entries(key_1: 'value_1', key_2: 'value_2'))
+      mock.method(key_1: 'value_1', key_2: 'value_2', key_3: 'value_3')
     end
     assert_passed(test_result)
   end
@@ -95,8 +95,8 @@ class ParameterMatcherTest < Mocha::TestCase
   def test_should_not_match_hash_parameter_with_specified_entries
     test_result = run_as_test do
       mock = mock()
-      mock.expects(:method).with(has_entries(:key_1 => 'value_1', :key_2 => 'value_2'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_3')
+      mock.expects(:method).with(has_entries(key_1: 'value_1', key_2: 'value_2'))
+      mock.method(key_1: 'value_1', key_2: 'value_3')
     end
     assert_failed(test_result)
   end
@@ -123,7 +123,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_entries(:key_1 => regexp_matches(/value_1/), kind_of(Symbol) => 'value_2'))
-      mock.method(:key_1 => 'value_1', :key_2 => 'value_2', :key_3 => 'value_3')
+      mock.method(key_1: 'value_1', key_2: 'value_2', key_3: 'value_3')
     end
     assert_passed(test_result)
   end
@@ -132,7 +132,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_entries(:key_1 => regexp_matches(/value_1/), kind_of(String) => 'value_2'))
-      mock.method(:key_1 => 'value_2', :key_2 => 'value_3')
+      mock.method(key_1: 'value_2', key_2: 'value_3')
     end
     assert_failed(test_result)
   end
@@ -160,8 +160,8 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_key(:foo) | has_key(:bar)).times(2)
-      mock.method(:foo => 'fooval')
-      mock.method(:bar => 'barval')
+      mock.method(foo: 'fooval')
+      mock.method(bar: 'barval')
     end
     assert_passed(test_result)
   end
@@ -170,7 +170,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_key(:foo) | has_key(:bar))
-      mock.method(:baz => 'bazval')
+      mock.method(baz: 'bazval')
     end
     assert_failed(test_result)
   end
@@ -197,7 +197,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_key(:foo) & has_key(:bar))
-      mock.method(:foo => 'fooval', :bar => 'barval')
+      mock.method(foo: 'fooval', bar: 'barval')
     end
     assert_passed(test_result)
   end
@@ -206,7 +206,7 @@ class ParameterMatcherTest < Mocha::TestCase
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(has_key(:foo) & has_key(:bar))
-      mock.method(:foo => 'fooval', :baz => 'bazval')
+      mock.method(foo: 'fooval', baz: 'bazval')
     end
     assert_failed(test_result)
   end

--- a/test/acceptance/return_value_test.rb
+++ b/test/acceptance/return_value_test.rb
@@ -22,7 +22,7 @@ class ReturnValueTest < Mocha::TestCase
 
   def test_should_build_mock_incorporating_two_expectations_with_return_values
     test_result = run_as_test do
-      foo = mock('foo', :bar => 'bar', :baz => 'baz')
+      foo = mock('foo', bar: 'bar', baz: 'baz')
       assert_equal 'bar', foo.bar
       assert_equal 'baz', foo.baz
     end
@@ -40,7 +40,7 @@ class ReturnValueTest < Mocha::TestCase
 
   def test_should_build_stub_incorporating_two_expectations_with_return_values
     test_result = run_as_test do
-      foo = stub('foo', :bar => 'bar', :baz => 'baz')
+      foo = stub('foo', bar: 'bar', baz: 'baz')
       assert_equal 'bar', foo.bar
       assert_equal 'baz', foo.baz
     end

--- a/test/acceptance/stub_any_instance_method_defined_on_superclass_test.rb
+++ b/test/acceptance/stub_any_instance_method_defined_on_superclass_test.rb
@@ -46,11 +46,11 @@ class StubAnyInstanceMethodDefinedOnSuperclassTest < Mocha::TestCase
       def my_instance_method; end
     end
     test_result = run_as_tests(
-      :test_1 => lambda {
+      test_1: lambda {
         klass.any_instance.expects(:my_instance_method)
         klass.new.my_instance_method
       },
-      :test_2 => lambda {
+      test_2: lambda {
         superklass.any_instance.expects(:my_instance_method)
       }
     )

--- a/test/acceptance/stub_class_method_defined_on_superclass_test.rb
+++ b/test/acceptance/stub_class_method_defined_on_superclass_test.rb
@@ -125,11 +125,11 @@ class StubClassMethodDefinedOnSuperclassTest < Mocha::TestCase
       def self.my_class_method; end
     end
     test_result = run_as_tests(
-      :test_1 => lambda {
+      test_1: lambda {
         klass.expects(:my_class_method)
         klass.my_class_method
       },
-      :test_2 => lambda {
+      test_2: lambda {
         superklass.expects(:my_class_method)
       }
     )

--- a/test/acceptance/stub_everything_test.rb
+++ b/test/acceptance/stub_everything_test.rb
@@ -33,7 +33,7 @@ class StubEverythingTest < Mocha::TestCase
 
   def test_should_build_stub_incorporating_two_expectations
     test_result = run_as_test do
-      foo = stub_everything(:bar => 'bar', :baz => 'baz')
+      foo = stub_everything(bar: 'bar', baz: 'baz')
       foo.bar
       foo.baz
       foo.unexpected_invocation
@@ -43,7 +43,7 @@ class StubEverythingTest < Mocha::TestCase
 
   def test_should_build_named_stub_incorporating_two_expectations
     test_result = run_as_test do
-      foo = stub_everything('foo', :bar => 'bar', :baz => 'baz')
+      foo = stub_everything('foo', bar: 'bar', baz: 'baz')
       foo.bar
       foo.baz
       foo.unexpected_invocation

--- a/test/acceptance/stub_test.rb
+++ b/test/acceptance/stub_test.rb
@@ -31,7 +31,7 @@ class StubTest < Mocha::TestCase
 
   def test_should_build_stub_incorporating_two_expectations
     test_result = run_as_test do
-      foo = stub(:bar => 'bar', :baz => 'baz')
+      foo = stub(bar: 'bar', baz: 'baz')
       foo.bar
       foo.baz
     end
@@ -40,7 +40,7 @@ class StubTest < Mocha::TestCase
 
   def test_should_build_named_stub_incorporating_two_expectations
     test_result = run_as_test do
-      foo = stub('foo', :bar => 'bar', :baz => 'baz')
+      foo = stub('foo', bar: 'bar', baz: 'baz')
       foo.bar
       foo.baz
     end

--- a/test/acceptance/stubba_example_test.rb
+++ b/test/acceptance/stubba_example_test.rb
@@ -88,9 +88,9 @@ class StubbaExampleTest < Mocha::TestCase
     found_widgets = [Widget.new]
     created_widget = Widget.new
     Widget.expects(:find).with(:all).returns(found_widgets)
-    Widget.expects(:create).with(:model => 'wombat').returns(created_widget)
+    Widget.expects(:create).with(model: 'wombat').returns(created_widget)
     assert_equal found_widgets, Widget.find(:all)
-    assert_equal created_widget, Widget.create(:model => 'wombat')
+    assert_equal created_widget, Widget.create(model: 'wombat')
   end
 
   def should_stub_instance_method_on_any_instance_of_a_class

--- a/test/acceptance/stubbing_same_class_method_on_parent_and_child_classes_test.rb
+++ b/test/acceptance/stubbing_same_class_method_on_parent_and_child_classes_test.rb
@@ -19,11 +19,11 @@ class StubbingSameClassMethodOnParentAndChildClassTest < Mocha::TestCase
     end
     child_class = Class.new(parent_class)
     test_result = run_as_tests(
-      :test_1 => lambda {
+      test_1: lambda {
         parent_class.stubs(:foo).returns('stubbed Parent.foo')
         child_class.stubs(:foo).returns('stubbed Child.foo')
       },
-      :test_2 => lambda {
+      test_2: lambda {
         parent_class.foo
         child_class.foo
       }

--- a/test/acceptance/yielding_test.rb
+++ b/test/acceptance/yielding_test.rb
@@ -24,7 +24,7 @@ class YieldingTest < Mocha::TestCase
 
   def test_raises_local_jump_error_if_instructed_to_yield_but_no_block_given
     test_result = run_as_test do
-      Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => false) do
+      Mocha::Configuration.override(reinstate_undocumented_behaviour_from_v1_9: false) do
         m = mock('m')
         m.stubs(:foo).yields
         assert_raises(LocalJumpError) { m.foo }

--- a/test/integration/shared_tests.rb
+++ b/test/integration/shared_tests.rb
@@ -71,11 +71,11 @@ module SharedTests
   def test_mock_object_unexpected_invocation_in_setup
     execution_point = nil
     test_result = run_as_tests(
-      :setup => lambda {
+      setup: lambda {
         mock = mock('not expecting invocation')
         execution_point = ExecutionPoint.current; mock.unexpected
       },
-      :test_me => lambda {
+      test_me: lambda {
         assert true
       }
     )
@@ -88,11 +88,11 @@ module SharedTests
   def test_mock_object_unsatisfied_expectation_in_setup
     execution_point = nil
     test_result = run_as_tests(
-      :setup => lambda {
+      setup: lambda {
         mock = mock('expecting invocation')
         execution_point = ExecutionPoint.current; mock.expects(:expected)
       },
-      :test_me => lambda {
+      test_me: lambda {
         assert true
       }
     )
@@ -109,10 +109,10 @@ module SharedTests
   def test_mock_object_unexpected_invocation_in_teardown
     execution_point = nil
     test_result = run_as_tests(
-      :test_me => lambda {
+      test_me: lambda {
         assert true
       },
-      :teardown => lambda {
+      teardown: lambda {
         mock = mock('not expecting invocation')
         execution_point = ExecutionPoint.current; mock.unexpected
       }
@@ -160,11 +160,11 @@ module SharedTests
     execution_point = nil
     klass = Class.new
     test_result = run_as_tests(
-      :test_1 => lambda {
+      test_1: lambda {
         klass.expects(:foo)
         klass.foo
       },
-      :test_2 => lambda {
+      test_2: lambda {
         execution_point = ExecutionPoint.current; klass.foo
       }
     )

--- a/test/mini_test_result.rb
+++ b/test/mini_test_result.rb
@@ -6,11 +6,11 @@ class MiniTestResult
   if Gem::Requirement.new('<= 4.6.1').satisfied_by?(minitest_version)
     FAILURE_PATTERN = /(Failure)\:\n([^\(]+)\(([^\)]+)\) \[([^\]]+)\]\:\n(.*)\n/m
     ERROR_PATTERN   = /(Error)\:\n([^\(]+)\(([^\)]+)\)\:\n(.+?)\n/m
-    PATTERN_INDICES = { :method => 2, :testcase => 3 }.freeze
+    PATTERN_INDICES = { method: 2, testcase: 3 }.freeze
   else
     FAILURE_PATTERN = /(Failure)\:\n.([^#]+)\#([^ ]+) \[([^\]]+)\]\:\n(.*)\n/m
     ERROR_PATTERN   = /(Error)\:\n.([^#]+)\#([^ ]+)\:\n(.+?)\n/m
-    PATTERN_INDICES = { :method => 3, :testcase => 2 }.freeze
+    PATTERN_INDICES = { method: 3, testcase: 2 }.freeze
   end
 
   def self.parse_failure(raw)

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -4,7 +4,7 @@ require 'mocha/detection/mini_test'
 
 module TestRunner
   def run_as_test(&block)
-    run_as_tests(:test_me => block)
+    run_as_tests(test_me: block)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -5,7 +5,7 @@ class ConfigurationTest < Mocha::TestCase
   def test_allow_temporarily_changes_config_when_given_block
     Mocha.configure { |c| c.stubbing_method_unnecessarily = :warn }
     yielded = false
-    Mocha::Configuration.override(:stubbing_method_unnecessarily => :allow) do
+    Mocha::Configuration.override(stubbing_method_unnecessarily: :allow) do
       yielded = true
       assert_equal :allow, Mocha.configuration.stubbing_method_unnecessarily
     end
@@ -16,7 +16,7 @@ class ConfigurationTest < Mocha::TestCase
   def test_prevent_temporarily_changes_config_when_given_block
     Mocha.configure { |c| c.stubbing_method_unnecessarily = :allow }
     yielded = false
-    Mocha::Configuration.override(:stubbing_method_unnecessarily => :prevent) do
+    Mocha::Configuration.override(stubbing_method_unnecessarily: :prevent) do
       yielded = true
       assert_equal :prevent, Mocha.configuration.stubbing_method_unnecessarily
     end
@@ -27,7 +27,7 @@ class ConfigurationTest < Mocha::TestCase
   def test_warn_when_temporarily_changes_config_when_given_block
     Mocha.configure { |c| c.stubbing_method_unnecessarily = :allow }
     yielded = false
-    Mocha::Configuration.override(:stubbing_method_unnecessarily => :warn) do
+    Mocha::Configuration.override(stubbing_method_unnecessarily: :warn) do
       yielded = true
       assert_equal :warn, Mocha.configuration.stubbing_method_unnecessarily
     end

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -117,7 +117,7 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_yield_should_fail_when_the_caller_does_not_provide_a_block_and_behaviour_from_v1_9_not_retained
-    Mocha::Configuration.override(:reinstate_undocumented_behaviour_from_v1_9 => false) do
+    Mocha::Configuration.override(reinstate_undocumented_behaviour_from_v1_9: false) do
       assert_raises(LocalJumpError) { invoke(new_expectation.yields(:foo)) }
     end
   end
@@ -355,7 +355,7 @@ class ExpectationTest < Mocha::TestCase
     mock = FakeMock.new('mock')
     sequence_one = Sequence.new('one')
     sequence_two = Sequence.new('two')
-    expectation = Expectation.new(mock, :expected_method).with(1, 2, { 'a' => true }, { :b => false }, [1, 2, 3]).in_sequence(sequence_one, sequence_two)
+    expectation = Expectation.new(mock, :expected_method).with(1, 2, { 'a' => true }, { b: false }, [1, 2, 3]).in_sequence(sequence_one, sequence_two)
     assert !expectation.verified?
     assert_match %{mock.expected_method(1, 2, {"a" => true}, {:b => false}, [1, 2, 3]); in sequence "one"; in sequence "two"}, expectation.mocha_inspect
   end

--- a/test/unit/hash_inspect_test.rb
+++ b/test/unit/hash_inspect_test.rb
@@ -3,17 +3,17 @@ require 'mocha/inspect'
 
 class HashInspectTest < Mocha::TestCase
   def test_should_keep_spacing_between_key_value
-    hash = { :a => true }
+    hash = { a: true }
     assert_equal '{:a => true}', hash.mocha_inspect
   end
 
   def test_should_return_unwrapped_hash_when_wrapped_is_false
-    hash = { :a => true }
+    hash = { a: true }
     assert_equal ':a => true', hash.mocha_inspect(false)
   end
 
   def test_should_use_mocha_inspect_on_each_item
-    hash = { :a => 'mocha' }
+    hash = { a: 'mocha' }
     assert_equal %({:a => "mocha"}), hash.mocha_inspect
   end
 end

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -165,14 +165,14 @@ class MockTest < Mocha::TestCase
 
   def test_should_set_up_multiple_expectations_with_return_values
     mock = build_mock
-    mock.expects(:method1 => :result1, :method2 => :result2)
+    mock.expects(method1: :result1, method2: :result2)
     assert_equal :result1, mock.method1
     assert_equal :result2, mock.method2
   end
 
   def test_should_set_up_multiple_stubs_with_return_values
     mock = build_mock
-    mock.stubs(:method1 => :result1, :method2 => :result2)
+    mock.stubs(method1: :result1, method2: :result2)
     assert_equal :result1, mock.method1
     assert_equal :result2, mock.method2
   end

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -34,7 +34,6 @@ class ObjectInspectTest < Mocha::TestCase
       calls << :__id__
       return 1
     end
-    replace_instance_method(object, :inspect) { 'object-description' }
 
     object.mocha_inspect
 

--- a/test/unit/parameter_matchers/has_entries_test.rb
+++ b/test/unit/parameter_matchers/has_entries_test.rb
@@ -8,17 +8,17 @@ class HasEntriesTest < Mocha::TestCase
   include Mocha::ParameterMatchers
 
   def test_should_match_hash_including_specified_entries
-    matcher = has_entries(:key_1 => 'value_1', :key_2 => 'value_2')
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2', :key_3 => 'value_3' }])
+    matcher = has_entries(key_1: 'value_1', key_2: 'value_2')
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2', key_3: 'value_3' }])
   end
 
   def test_should_not_match_hash_not_including_specified_entries
-    matcher = has_entries(:key_1 => 'value_2', :key_2 => 'value_2', :key_3 => 'value_3')
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    matcher = has_entries(key_1: 'value_2', key_2: 'value_2', key_3: 'value_3')
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_describe_matcher
-    matcher = has_entries(:key_1 => 'value_1', :key_2 => 'value_2')
+    matcher = has_entries(key_1: 'value_1', key_2: 'value_2')
     description = matcher.mocha_inspect
     matches = /has_entries\((.*)\)/.match(description)
     assert_not_nil matches[0]
@@ -31,21 +31,21 @@ class HasEntriesTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_entries_with_nested_key_matchers
     matcher = has_entries(equals(:key_1) => 'value_1', equals(:key_2) => 'value_2')
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2', :key_3 => 'value_3' }])
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2', key_3: 'value_3' }])
   end
 
   def test_should_not_match_hash_not_including_specified_entries_with_nested_key_matchers
     matcher = has_entries(equals(:key_1) => 'value_2', equals(:key_2) => 'value_2', equals(:key_3) => 'value_3')
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_match_hash_including_specified_entries_with_nested_value_matchers
-    matcher = has_entries(:key_1 => equals('value_1'), :key_2 => equals('value_2'))
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2', :key_3 => 'value_3' }])
+    matcher = has_entries(key_1: equals('value_1'), key_2: equals('value_2'))
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2', key_3: 'value_3' }])
   end
 
   def test_should_not_match_hash_not_including_specified_entries_with_nested_value_matchers
-    matcher = has_entries(:key_1 => equals('value_2'), :key_2 => equals('value_2'), :key_3 => equals('value_3'))
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    matcher = has_entries(key_1: equals('value_2'), key_2: equals('value_2'), key_3: equals('value_3'))
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 end

--- a/test/unit/parameter_matchers/has_entry_test.rb
+++ b/test/unit/parameter_matchers/has_entry_test.rb
@@ -10,22 +10,22 @@ class HasEntryTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_key_value_pair
     matcher = has_entry(:key_1, 'value_1')
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_hash_not_including_specified_key_value_pair
     matcher = has_entry(:key_1, 'value_2')
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_match_hash_including_specified_entry
-    matcher = has_entry(:key_1 => 'value_1')
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    matcher = has_entry(key_1: 'value_1')
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_hash_not_including_specified_entry
-    matcher = has_entry(:key_1 => 'value_2')
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    matcher = has_entry(key_1: 'value_2')
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_describe_matcher_with_key_value_pair
@@ -34,32 +34,32 @@ class HasEntryTest < Mocha::TestCase
   end
 
   def test_should_describe_matcher_with_entry
-    matcher = has_entry(:key_1 => 'value_1')
+    matcher = has_entry(key_1: 'value_1')
     assert_equal %{has_entry(:key_1 => "value_1")}, matcher.mocha_inspect
   end
 
   def test_should_match_hash_including_specified_entry_with_nested_key_matcher
     matcher = has_entry(equals(:key_1) => 'value_1')
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_match_hash_including_specified_entry_with_nested_value_matcher
-    matcher = has_entry(:key_1 => equals('value_1'))
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    matcher = has_entry(key_1: equals('value_1'))
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_hash_not_including_specified_entry_with_nested_key_matcher
     matcher = has_entry(equals(:key_1) => 'value_2')
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_hash_not_including_specified_entry_with_nested_value_matcher
-    matcher = has_entry(:key_1 => equals('value_2'))
-    assert !matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    matcher = has_entry(key_1: equals('value_2'))
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_object_that_doesnt_respond_to_keys
-    matcher = has_entry(:key_1 => equals('value_2'))
+    matcher = has_entry(key_1: equals('value_2'))
     object = Class.new do
       def [](_key)
         'value_2'
@@ -69,7 +69,7 @@ class HasEntryTest < Mocha::TestCase
   end
 
   def test_should_not_match_object_that_doesnt_respond_to_square_bracket
-    matcher = has_entry(:key_1 => equals('value_2'))
+    matcher = has_entry(key_1: equals('value_2'))
     object = Class.new do
       def keys
         [:key_1]
@@ -99,7 +99,7 @@ class HasEntryTest < Mocha::TestCase
 
   def test_should_raise_argument_error_if_multiple_entries_are_supplied
     e = assert_raises(ArgumentError) do
-      has_entry(:key_1 => 'value_1', :key_2 => 'value_2')
+      has_entry(key_1: 'value_1', key_2: 'value_2')
     end
     assert_equal 'Argument has multiple entries. Use Mocha::ParameterMatchers#has_entries instead.', e.message
   end
@@ -117,17 +117,17 @@ class HasEntryTest < Mocha::TestCase
   end
 
   def test_should_match_array_as_value
-    matcher = has_entry(:key_1 => %w[value_1 value_2])
-    assert matcher.matches?([{ :key_1 => %w[value_1 value_2] }])
+    matcher = has_entry(key_1: %w[value_1 value_2])
+    assert matcher.matches?([{ key_1: %w[value_1 value_2] }])
   end
 
   def test_should_match_hash_as_value_and_key
-    matcher = has_entry({ :key_1 => 'value_1', :key_2 => 'value_2' } => { :key_3 => 'value_3', :key_4 => 'value_4' })
-    assert matcher.matches?([{ { :key_1 => 'value_1', :key_2 => 'value_2' } => { :key_3 => 'value_3', :key_4 => 'value_4' }, :key_5 => 'value_5' }])
+    matcher = has_entry({ key_1: 'value_1', key_2: 'value_2' } => { key_3: 'value_3', key_4: 'value_4' })
+    assert matcher.matches?([{ { key_1: 'value_1', key_2: 'value_2' } => { key_3: 'value_3', key_4: 'value_4' }, :key_5 => 'value_5' }])
   end
 
   def test_should_match_matcher_as_value_and_key
-    matcher = has_entry(has_entry(:key_1 => 'value_1') => has_entry(:key_3 => 'value_3'))
-    assert matcher.matches?([{ { :key_1 => 'value_1', :key_2 => 'value_2' } => { :key_3 => 'value_3', :key_4 => 'value_4' }, :key_5 => 'value_5' }])
+    matcher = has_entry(has_entry(key_1: 'value_1') => has_entry(key_3: 'value_3'))
+    assert matcher.matches?([{ { key_1: 'value_1', key_2: 'value_2' } => { key_3: 'value_3', key_4: 'value_4' }, :key_5 => 'value_5' }])
   end
 end

--- a/test/unit/parameter_matchers/has_key_test.rb
+++ b/test/unit/parameter_matchers/has_key_test.rb
@@ -9,12 +9,12 @@ class HasKeyTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_key
     matcher = has_key(:key_1)
-    assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }])
+    assert matcher.matches?([{ key_1: 1, key_2: 2 }])
   end
 
   def test_should_not_match_hash_not_including_specified_key
     matcher = has_key(:key_1)
-    assert !matcher.matches?([{ :key_2 => 2 }])
+    assert !matcher.matches?([{ key_2: 2 }])
   end
 
   def test_should_describe_matcher
@@ -24,12 +24,12 @@ class HasKeyTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_key_with_nested_key_matcher
     matcher = has_key(equals(:key_1))
-    assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }])
+    assert matcher.matches?([{ key_1: 1, key_2: 2 }])
   end
 
   def test_should_not_match_hash_not_including_specified_key_with_nested_key_matcher
     matcher = has_key(equals(:key_1))
-    assert !matcher.matches?([{ :key_2 => 2 }])
+    assert !matcher.matches?([{ key_2: 2 }])
   end
 
   def test_should_not_raise_error_on_empty_arguments

--- a/test/unit/parameter_matchers/has_keys_test.rb
+++ b/test/unit/parameter_matchers/has_keys_test.rb
@@ -9,17 +9,17 @@ class HasKeysTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_keys
     matcher = has_keys(:key_1, :key_2)
-    assert matcher.matches?([{ :key_1 => 1, :key_2 => 2, :key_3 => 3 }])
+    assert matcher.matches?([{ key_1: 1, key_2: 2, key_3: 3 }])
   end
 
   def test_should_not_match_hash_not_including_specified_keys
     matcher = has_keys(:key_1, :key_2)
-    assert !matcher.matches?([{ :key_3 => 3 }])
+    assert !matcher.matches?([{ key_3: 3 }])
   end
 
   def test_should_not_match_hash_not_including_all_keys
     matcher = has_keys(:key_1, :key_2)
-    assert !matcher.matches?([{ :key_1 => 1, :key_3 => 3 }])
+    assert !matcher.matches?([{ key_1: 1, key_3: 3 }])
   end
 
   def test_should_describe_matcher
@@ -29,12 +29,12 @@ class HasKeysTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_key_with_nested_key_matcher
     matcher = has_keys(equals(:key_1), equals(:key_2))
-    assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }])
+    assert matcher.matches?([{ key_1: 1, key_2: 2 }])
   end
 
   def test_should_not_match_hash_not_including_specified_keys_with_nested_key_matchers
     matcher = has_keys(equals(:key_1), equals(:key2))
-    assert !matcher.matches?([{ :key_2 => 2 }])
+    assert !matcher.matches?([{ key_2: 2 }])
   end
 
   def test_should_not_raise_error_on_empty_arguments

--- a/test/unit/parameter_matchers/has_value_test.rb
+++ b/test/unit/parameter_matchers/has_value_test.rb
@@ -10,12 +10,12 @@ class HasValueTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_value
     matcher = has_value('value_1')
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_hash_not_including_specified_value
     matcher = has_value('value_1')
-    assert !matcher.matches?([{ :key_2 => 'value_2' }])
+    assert !matcher.matches?([{ key_2: 'value_2' }])
   end
 
   def test_should_describe_matcher
@@ -25,12 +25,12 @@ class HasValueTest < Mocha::TestCase
 
   def test_should_match_hash_including_specified_value_with_nested_value_matcher
     matcher = has_value(equals('value_1'))
-    assert matcher.matches?([{ :key_1 => 'value_1', :key_2 => 'value_2' }])
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
   def test_should_not_match_hash_not_including_specified_value_with_nested_value_matcher
     matcher = has_value(equals('value_1'))
-    assert !matcher.matches?([{ :key_2 => 'value_2' }])
+    assert !matcher.matches?([{ key_2: 'value_2' }])
   end
 
   def test_should_not_raise_error_on_empty_arguments

--- a/test/unit/parameter_matchers/includes_test.rb
+++ b/test/unit/parameter_matchers/includes_test.rb
@@ -66,12 +66,12 @@ class IncludesTest < Mocha::TestCase
 
   def test_should_match_object_including_value_which_matches_nested_matcher
     matcher = includes(has_key(:key))
-    assert matcher.matches?([[:non_matching_element, { :key => 'value' }]])
+    assert matcher.matches?([[:non_matching_element, { key: 'value' }]])
   end
 
   def test_should_not_match_object_which_doesnt_include_value_that_matches_nested_matcher
     matcher = includes(has_key(:key))
-    assert !matcher.matches?([[:non_matching_element, { :other_key => 'other-value' }]])
+    assert !matcher.matches?([[:non_matching_element, { other_key: 'other-value' }]])
   end
 
   def test_should_match_string_argument_containing_substring
@@ -86,12 +86,12 @@ class IncludesTest < Mocha::TestCase
 
   def test_should_match_hash_argument_containing_given_key
     matcher = includes(:key)
-    assert matcher.matches?([{ :thing => 1, :key => 2 }])
+    assert matcher.matches?([{ thing: 1, key: 2 }])
   end
 
   def test_should_not_match_hash_argument_missing_given_key
     matcher = includes(:key)
-    assert !matcher.matches?([{ :thing => 1, :other => :key }])
+    assert !matcher.matches?([{ thing: 1, other: :key }])
   end
 
   def test_should_match_hash_when_nested_matcher_matches_key

--- a/test/unit/parameters_matcher_test.rb
+++ b/test/unit/parameters_matcher_test.rb
@@ -100,14 +100,14 @@ class ParametersMatcherTest < Mocha::TestCase
   end
 
   def test_should_remove_curly_braces_if_hash_is_only_argument
-    params = [{ :a => 1, :z => 2 }]
+    params = [{ a: 1, z: 2 }]
     parameters_matcher = ParametersMatcher.new(params)
     assert_nil parameters_matcher.mocha_inspect.index('{')
     assert_nil parameters_matcher.mocha_inspect.index('}')
   end
 
   def test_should_not_remove_curly_braces_if_hash_is_not_the_only_argument
-    params = [1, { :a => 1 }]
+    params = [1, { a: 1 }]
     parameters_matcher = ParametersMatcher.new(params)
     assert_equal '(1, {:a => 1})', parameters_matcher.mocha_inspect
   end

--- a/test/unit/yield_parameters_test.rb
+++ b/test/unit/yield_parameters_test.rb
@@ -38,8 +38,8 @@ class YieldParametersTest < Mocha::TestCase
 
   def test_should_return_multiple_yield_parameter_group_when_arguments_are_not_arrays
     yield_parameters = YieldParameters.new
-    yield_parameters.add(1, { :b => 2 }, 3)
-    assert_next_invocation_yields(yield_parameters, [[1], [{ :b => 2 }], [3]])
+    yield_parameters.add(1, { b: 2 }, 3)
+    assert_next_invocation_yields(yield_parameters, [[1], [{ b: 2 }], [3]])
   end
 
   def test_should_keep_returning_multiple_yield_parameter_group


### PR DESCRIPTION
Slightly expanding on #537, now that we've dropped support for Ruby v1.8 in https://github.com/freerange/mocha/pull/536, we should be able to enable the Style/HashSyntax, Style/EachWithObject and Style/FormatStringToken cops across the board.

The first two commits include just the output of rubocop autocorrect.

