### PR TITLE
Remove unnecessary splatting in Invocation

### DIFF
--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -10,7 +10,7 @@ module Mocha
   class Invocation
     attr_reader :method_name, :block
 
-    def initialize(mock, method_name, *arguments, &block)
+    def initialize(mock, method_name, arguments = [], block = nil)
       @mock = mock
       @method_name = method_name
       @arguments = arguments

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -311,7 +311,7 @@ module Mocha
     def method_missing(symbol, *arguments, &block) # rubocop:disable Style/MethodMissingSuper
       check_expiry
       check_responder_responds_to(symbol)
-      invocation = Invocation.new(self, symbol, *arguments, &block)
+      invocation = Invocation.new(self, symbol, arguments, block)
       if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
         matching_expectation_allowing_invocation.invoke(invocation)
       elsif (matching_expectation = all_expectations.match(invocation)) || (!matching_expectation && !@everything_stubbed)

--- a/test/unit/expectation_list_test.rb
+++ b/test/unit/expectation_list_test.rb
@@ -21,7 +21,7 @@ class ExpectationListTest < Mocha::TestCase
     expectation2 = Expectation.new(nil, :my_method).with(:argument3, :argument4)
     expectation_list.add(expectation1)
     expectation_list.add(expectation2)
-    assert_same expectation1, expectation_list.match(Invocation.new(:irrelevant, :my_method, :argument1, :argument2))
+    assert_same expectation1, expectation_list.match(Invocation.new(:irrelevant, :my_method, [:argument1, :argument2]))
   end
 
   def test_should_remove_all_expectations_matching_method_name
@@ -44,7 +44,7 @@ class ExpectationListTest < Mocha::TestCase
     expectation2 = Expectation.new(nil, :my_method).with(:argument1, :argument2)
     expectation_list.add(expectation1)
     expectation_list.add(expectation2)
-    assert_same expectation2, expectation_list.match(Invocation.new(:irrelevant, :my_method, :argument1, :argument2))
+    assert_same expectation2, expectation_list.match(Invocation.new(:irrelevant, :my_method, [:argument1, :argument2]))
   end
 
   def test_should_find_matching_expectation_allowing_invocation
@@ -55,7 +55,7 @@ class ExpectationListTest < Mocha::TestCase
     define_instance_method(expectation2, :invocations_allowed?) { true }
     expectation_list.add(expectation1)
     expectation_list.add(expectation2)
-    assert_same expectation1, expectation_list.match_allowing_invocation(Invocation.new(:irrelevant, :my_method, :argument1, :argument2))
+    assert_same expectation1, expectation_list.match_allowing_invocation(Invocation.new(:irrelevant, :my_method, [:argument1, :argument2]))
   end
 
   def test_should_find_most_recent_matching_expectation_allowing_invocation

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -17,11 +17,11 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def invoke(expectation, &block)
-    expectation.invoke(Invocation.new(:irrelevant, :expected_method, &block))
+    expectation.invoke(Invocation.new(:irrelevant, :expected_method, [], block))
   end
 
   def test_should_match_calls_to_same_method_with_any_parameters
-    assert new_expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, 2, 3))
+    assert new_expectation.match?(Invocation.new(:irrelevant, :expected_method, [1, 2, 3]))
   end
 
   def test_should_match_calls_to_same_method_with_exactly_zero_parameters
@@ -29,21 +29,21 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_not_match_calls_to_same_method_with_more_than_zero_parameters
-    assert !new_expectation.with.match?(Invocation.new(:irrelevant, :expected_method, 1, 2, 3))
+    assert !new_expectation.with.match?(Invocation.new(:irrelevant, :expected_method, [1, 2, 3]))
   end
 
   def test_should_match_calls_to_same_method_with_expected_parameter_values
-    assert new_expectation.with(1, 2, 3).match?(Invocation.new(:irrelevant, :expected_method, 1, 2, 3))
+    assert new_expectation.with(1, 2, 3).match?(Invocation.new(:irrelevant, :expected_method, [1, 2, 3]))
   end
 
   def test_should_match_calls_to_same_method_with_parameters_constrained_as_expected
     expectation = new_expectation.with { |x, y, z| x + y == z }
-    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, 2, 3))
+    assert expectation.match?(Invocation.new(:irrelevant, :expected_method, [1, 2, 3]))
   end
 
   def test_should_not_match_calls_to_different_method_with_parameters_constrained_as_expected
     expectation = new_expectation.with { |x, y, z| x + y == z }
-    assert !expectation.match?(Invocation.new(:irrelevant, :different_method, 1, 2, 3))
+    assert !expectation.match?(Invocation.new(:irrelevant, :different_method, [1, 2, 3]))
   end
 
   def test_should_not_match_calls_to_different_methods_with_no_parameters
@@ -51,20 +51,20 @@ class ExpectationTest < Mocha::TestCase
   end
 
   def test_should_not_match_calls_to_same_method_with_too_few_parameters
-    assert !new_expectation.with(1, 2, 3).match?(Invocation.new(:irrelevant, :expected_method, 1, 2))
+    assert !new_expectation.with(1, 2, 3).match?(Invocation.new(:irrelevant, :expected_method, [1, 2]))
   end
 
   def test_should_not_match_calls_to_same_method_with_too_many_parameters
-    assert !new_expectation.with(1, 2).match?(Invocation.new(:irrelevant, :expected_method, 1, 2, 3))
+    assert !new_expectation.with(1, 2).match?(Invocation.new(:irrelevant, :expected_method, [1, 2, 3]))
   end
 
   def test_should_not_match_calls_to_same_method_with_unexpected_parameter_values
-    assert !new_expectation.with(1, 2, 3).match?(Invocation.new(:irrelevant, :expected_method, 1, 0, 3))
+    assert !new_expectation.with(1, 2, 3).match?(Invocation.new(:irrelevant, :expected_method, [1, 0, 3]))
   end
 
   def test_should_not_match_calls_to_same_method_with_parameters_not_constrained_as_expected
     expectation = new_expectation.with { |x, y, z| x + y == z }
-    assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, 1, 0, 3))
+    assert !expectation.match?(Invocation.new(:irrelevant, :expected_method, [1, 0, 3]))
   end
 
   def test_should_allow_invocations_until_expected_invocation_count_is_one_and_actual_invocation_count_would_be_two


### PR DESCRIPTION
The re-splatting of arguments from `Mock#method_missing` to `Invocation#initialize` is unnecessary and makes it harder for us to separate keyword args in Ruby 3. This is part of a refactor sketched out [here](https://github.com/freerange/mocha/pull/544/files#diff-da5d48e5ad765b1f8627bba5744b1b48fa3e6c7138a225bfbb4b6641746322eb), and hopefully allows us to easily mark possible keyword arguments in the future.