### PR TITLE
Extract handle_method_call from method_missing

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -309,6 +309,11 @@ module Mocha
 
     # @private
     def method_missing(symbol, *arguments, &block) # rubocop:disable Style/MethodMissingSuper
+      handle_method_call(symbol, arguments, block)
+    end
+
+    # @private
+    def handle_method_call(symbol, arguments, block)
       check_expiry
       check_responder_responds_to(symbol)
       invocation = Invocation.new(self, symbol, arguments, block)

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -57,7 +57,7 @@ module Mocha
       self_in_scope = self
       method_name_in_scope = method_name
       stub_method_owner.send(:define_method, method_name) do |*args, &block|
-        self_in_scope.mock.method_missing(method_name_in_scope, *args, &block)
+        self_in_scope.mock.handle_method_call(method_name_in_scope, args, block)
       end
       retain_original_visibility(stub_method_owner)
     end


### PR DESCRIPTION
Continues the refactoring started in https://github.com/freerange/mocha/pull/549 on the road to better keyword args matching. This is part of a refactor sketched out [here](https://github.com/freerange/mocha/pull/544).

The key change is to pass arguments and the block directly instead of re-splatting them. That way, we would only need to set `ruby2_keywords` at the edges, instead of with each splat (for contrast, see [initial spike](https://github.com/freerange/mocha/pull/534/files), where `ruby2_keywords` had to be set at multiple layers).

The extracting of `handle_method_call` is not strictly necessary, but it makes it clearer that `method_missing` is just one of the possible entry points for a method call.