### PR TITLE
Add acceptance tests for keyword arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,8 @@ Metrics/LineLength:
 # It's not possible to set TargetRubyVersion to Ruby < v2.2
 Gemspec/RequiredRubyVersion:
   Enabled: false
+
+Style/BracesAroundHashParameters:
+  Exclude:
+    # we specifically want to test hash parameters
+    - 'test/acceptance/keyword_arguments_test.rb'

--- a/test/acceptance/keyword_arguments_test.rb
+++ b/test/acceptance/keyword_arguments_test.rb
@@ -1,0 +1,120 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class KeywordArgumentsTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_should_match_hash_parameter_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(:key => 42)
+      mock.method({ :key => 42 })
+    end
+    assert_passed(test_result)
+    # with strict keyword matching:
+    # assert_failed(test_result)
+  end
+
+  def test_should_match_hash_parameter_with_splatted_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(**{ :key => 42 })
+      mock.method({ :key => 42 })
+    end
+    assert_passed(test_result)
+    # with strict keyword matching:
+    # assert_failed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(:key => 42)
+      mock.method(**{ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_splatted_hash
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(**{ :key => 42 })
+      mock.method(**{ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_positional_and_keyword_args_with_last_positional_hash
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, { :key => 42 })
+      mock.method(1, :key => 42)
+    end
+    assert_passed(test_result)
+    # with strict keyword matching:
+    # assert_failed(test_result)
+  end
+
+  def test_should_match_last_positional_hash_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, :key => 42)
+      mock.method(1, { :key => 42 })
+    end
+    assert_passed(test_result)
+    # with strict keyword matching:
+    # assert_failed(test_result)
+  end
+
+  def test_should_match_positional_and_keyword_args_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, :key => 42)
+      mock.method(1, :key => 42)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_hash_parameter_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(has_key(:key))
+      mock.method({ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(has_key(:key))
+      mock.method(**{ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_positional_and_keyword_args_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, has_key(:key))
+      mock.method(1, :key => 42)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_last_positional_hash_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, has_key(:key))
+      mock.method(1, { :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+end


### PR DESCRIPTION
Add some acceptance tests for keyword arguments, somewhat adapted from https://github.com/ruby/ruby/blob/4643bf5d55af6f79266dd67b69bb6eb4ff82029a/doc/NEWS-2.7.0#the-spec-of-keyword-arguments-is-changed-towards-30-. 

This is in preparation for supporting strict keyword argument matching, as sketched out in https://github.com/freerange/mocha/pull/544 and https://github.com/freerange/mocha/issues/446#issuecomment-1257198797. These tests will be adjusted subsequently when strict keyword matching is enabled.


TODO:
- [x] test Hash matchers e.g. has_value