### PR TITLE
Drop support for Ruby 1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,6 @@ workflows:
           matrix:
             parameters:
               docker-image:
-                - ruby:1.9
                 - ruby:2.0
                 - ruby:2.1
                 - ruby:2.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2 # closest to required_ruby_version of '>= 1.9'
+  TargetRubyVersion: 2.2 # closest to required_ruby_version of '>= 2.0'
 
 # Even the reference in the documentation suggests that you should prefer
 # `alias_method` vs `alias`, so I don't understand why that isn't the default.

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 # rubocop:disable Bundler/DuplicatedGem
-if RUBY_VERSION < '2'
-  gem 'rake', '~> 12.2.1'
-elsif RUBY_VERSION < '2.2'
+if RUBY_VERSION < '2.2'
   gem 'rake', '~> 12.3.3'
 else
   gem 'rake'

--- a/lib/mocha/ruby_version.rb
+++ b/lib/mocha/ruby_version.rb
@@ -1,11 +1,4 @@
 require 'mocha/deprecation'
 
 module Mocha
-  RUBY_V2_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2')
-
-  unless RUBY_V2_PLUS
-    Mocha::Deprecation.warning(
-      'Versions of Ruby earlier than v2.0 will not be supported in future versions of Mocha.'
-    )
-  end
 end

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -20,7 +20,6 @@ module Mocha
 
     def unstub
       remove_new_method
-      restore_original_method
       mock.unstub(method_name.to_sym)
       return if mock.any_expectations?
       reset_mocha
@@ -55,10 +54,6 @@ module Mocha
 
     def store_original_method
       @original_method = stubbee_method(method_name)
-    end
-
-    def restore_original_method
-      nil
     end
 
     def matches?(other)

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -58,11 +58,7 @@ module Mocha
     end
 
     def restore_original_method
-      return if true
-      if stub_method_overwrites_original_method?
-        original_method_owner.send(:define_method, method_name, @original_method)
-      end
-      retain_original_visibility(original_method_owner)
+      nil
     end
 
     def matches?(other)
@@ -85,10 +81,6 @@ module Mocha
 
     def store_original_method_visibility
       @original_visibility = original_method_owner.__method_visibility__(method_name)
-    end
-
-    def stub_method_overwrites_original_method?
-      @original_method && @original_method.owner == original_method_owner
     end
 
     def use_prepended_module_for_stub_method

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -37,7 +37,7 @@ module Mocha
     def hide_original_method
       return unless original_method_owner.__method_exists__?(method_name)
       store_original_method_visibility
-      if use_prepended_module_for_stub_method?
+      if true
         use_prepended_module_for_stub_method
       else
         begin
@@ -71,7 +71,7 @@ module Mocha
     end
 
     def restore_original_method
-      return if use_prepended_module_for_stub_method?
+      return if true
       if stub_method_overwrites_original_method?
         original_method_owner.send(:define_method, method_name, @original_method)
       end
@@ -106,10 +106,6 @@ module Mocha
 
     def remove_original_method_from_stubbee
       original_method_owner.send(:remove_method, method_name)
-    end
-
-    def use_prepended_module_for_stub_method?
-      RUBY_V2_PLUS
     end
 
     def use_prepended_module_for_stub_method

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -37,20 +37,7 @@ module Mocha
     def hide_original_method
       return unless original_method_owner.__method_exists__?(method_name)
       store_original_method_visibility
-      if true
-        use_prepended_module_for_stub_method
-      else
-        begin
-          store_original_method
-        # rubocop:disable Lint/HandleExceptions
-        rescue NameError
-          # deal with nasties like ActiveRecord::Associations::AssociationProxy
-        end
-        # rubocop:enable Lint/HandleExceptions
-        if stub_method_overwrites_original_method?
-          remove_original_method_from_stubbee
-        end
-      end
+      use_prepended_module_for_stub_method
     end
 
     def define_new_method
@@ -102,10 +89,6 @@ module Mocha
 
     def stub_method_overwrites_original_method?
       @original_method && @original_method.owner == original_method_owner
-    end
-
-    def remove_original_method_from_stubbee
-      original_method_owner.send(:remove_method, method_name)
     end
 
     def use_prepended_module_for_stub_method

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -52,10 +52,6 @@ module Mocha
       stub_method_owner.send(:remove_method, method_name)
     end
 
-    def store_original_method
-      @original_method = stubbee_method(method_name)
-    end
-
     def matches?(other)
       return false unless other.class == self.class
       (stubbee.object_id == other.stubbee.object_id) && (method_name == other.method_name)

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name = 'mocha'
   s.version = Mocha::VERSION
   s.licenses = ['MIT', 'BSD-2-Clause']
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.0'
 
   s.authors = ['James Mead']
   s.description = 'Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.'

--- a/test/acceptance/prepend_test.rb
+++ b/test/acceptance/prepend_test.rb
@@ -12,21 +12,29 @@ class PrependTest < Mocha::TestCase
     teardown_acceptance_test
   end
 
-  if Mocha::RUBY_V2_PLUS
-
-    module Mod1
-      def my_method
-        super + ' World'
-      end
+  module Mod1
+    def my_method
+      super + ' World'
     end
+  end
 
-    module Mod2
-      def my_method
-        super + ' Wide'
-      end
+  module Mod2
+    def my_method
+      super + ' Wide'
     end
+  end
 
-    class Klass1
+  class Klass1
+    prepend Mod1
+    prepend Mod2
+
+    def my_method
+      'Hello'
+    end
+  end
+
+  class Klass2
+    class << self
       prepend Mod1
       prepend Mod2
 
@@ -34,53 +42,41 @@ class PrependTest < Mocha::TestCase
         'Hello'
       end
     end
+  end
 
-    class Klass2
-      class << self
-        prepend Mod1
-        prepend Mod2
-
-        def my_method
-          'Hello'
-        end
+  def test_stubbing_any_instance_with_multiple_prepended_methods
+    assert_snapshot_unchanged(Klass1) do
+      test_result = run_as_test do
+        Klass1.any_instance.stubs(:my_method).returns('Bye World')
+        assert_equal 'Bye World', Klass1.new.my_method
       end
+      assert_passed(test_result)
     end
+    assert_equal 'Hello World Wide', Klass1.new.my_method
+  end
 
-    def test_stubbing_any_instance_with_multiple_prepended_methods
-      assert_snapshot_unchanged(Klass1) do
-        test_result = run_as_test do
-          Klass1.any_instance.stubs(:my_method).returns('Bye World')
-          assert_equal 'Bye World', Klass1.new.my_method
-        end
-        assert_passed(test_result)
+  def test_stubbing_instance_with_multiple_prepended_methods
+    object = Klass1.new
+
+    assert_snapshot_unchanged(object) do
+      test_result = run_as_test do
+        object.stubs(:my_method).returns('Bye World')
+        assert_equal 'Bye World', object.my_method
+        assert_equal 'Hello World Wide', Klass1.new.my_method
       end
-      assert_equal 'Hello World Wide', Klass1.new.my_method
+      assert_passed(test_result)
     end
+    assert_equal 'Hello World Wide', object.my_method
+  end
 
-    def test_stubbing_instance_with_multiple_prepended_methods
-      object = Klass1.new
-
-      assert_snapshot_unchanged(object) do
-        test_result = run_as_test do
-          object.stubs(:my_method).returns('Bye World')
-          assert_equal 'Bye World', object.my_method
-          assert_equal 'Hello World Wide', Klass1.new.my_method
-        end
-        assert_passed(test_result)
+  def test_stubbing_a_prepended_class_method
+    assert_snapshot_unchanged(Klass2) do
+      test_result = run_as_test do
+        Klass2.stubs(:my_method).returns('Bye World')
+        assert_equal 'Bye World', Klass2.my_method
       end
-      assert_equal 'Hello World Wide', object.my_method
+      assert_passed(test_result)
     end
-
-    def test_stubbing_a_prepended_class_method
-      assert_snapshot_unchanged(Klass2) do
-        test_result = run_as_test do
-          Klass2.stubs(:my_method).returns('Bye World')
-          assert_equal 'Bye World', Klass2.my_method
-        end
-        assert_passed(test_result)
-      end
-      assert_equal 'Hello World Wide', Klass2.my_method
-    end
-
+    assert_equal 'Hello World Wide', Klass2.my_method
   end
 end

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -66,7 +66,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 60
+    expected_line_number = 46
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|
@@ -84,21 +84,10 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.hide_original_method
     method.define_new_method
     method.remove_new_method
-    method.restore_original_method
 
     instance = klass.new
     assert instance.respond_to?(:method_x)
     assert_equal :original_result, instance.method_x
-  end
-
-  def test_should_not_restore_original_method_if_none_was_defined_in_first_place
-    klass = class_with_method(:method_x, :new_result)
-    method = AnyInstanceMethod.new(klass, :method_x)
-
-    method.restore_original_method
-
-    instance = klass.new
-    assert_equal :new_result, instance.method_x
   end
 
   def test_should_call_remove_new_method
@@ -108,7 +97,6 @@ class AnyInstanceMethodTest < Mocha::TestCase
     any_instance.stubs(:mocha).returns(any_instance_mocha)
     define_instance_method(klass, :any_instance) { any_instance }
     method = AnyInstanceMethod.new(klass, :method_x)
-    replace_instance_method(method, :restore_original_method) {}
     replace_instance_method(method, :reset_mocha) {}
     define_instance_accessor(method, :remove_called)
     replace_instance_method(method, :remove_new_method) { self.remove_called = true }
@@ -118,30 +106,12 @@ class AnyInstanceMethodTest < Mocha::TestCase
     assert method.remove_called
   end
 
-  def test_should_call_restore_original_method
-    klass = class_with_method(:method_x)
-    any_instance = build_mock
-    any_instance_mocha = build_mock
-    any_instance.stubs(:mocha).returns(any_instance_mocha)
-    define_instance_method(klass, :any_instance) { any_instance }
-    method = AnyInstanceMethod.new(klass, :method_x)
-    replace_instance_method(method, :remove_new_method) {}
-    replace_instance_method(method, :reset_mocha) {}
-    define_instance_accessor(method, :restore_called)
-    replace_instance_method(method, :restore_original_method) { self.restore_called = true }
-
-    method.unstub
-
-    assert method.restore_called
-  end
-
   def test_should_call_mock_unstub
     klass = class_with_method(:method_x)
 
     method = AnyInstanceMethod.new(klass, :method_x)
 
     replace_instance_method(method, :remove_new_method) {}
-    replace_instance_method(method, :restore_original_method) {}
     mocha = Class.new do
       class << self
         attr_accessor :unstub_method

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -66,7 +66,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     assert_not_nil matching_line, "Expected to find #{expected_filename}:#{expected_line_number} in the backtrace:\n #{exception.backtrace.join("\n")}"
   end
 
-  def test_should_restore_original_method
+  def test_remove_new_method_restores_original_method
     klass = class_with_method(:method_x, :original_result)
     method = AnyInstanceMethod.new(klass, :method_x)
 

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -16,17 +16,6 @@ class AnyInstanceMethodTest < Mocha::TestCase
     end
   end
 
-  unless RUBY_V2_PLUS
-    def test_should_hide_original_method
-      klass = class_with_method(:method_x)
-      method = AnyInstanceMethod.new(klass, :method_x)
-
-      method.hide_original_method
-
-      assert_equal false, klass.method_defined?(:method_x)
-    end
-  end
-
   def test_should_not_raise_error_hiding_method_that_isnt_defined
     klass = class_with_method(:irrelevant)
     method = AnyInstanceMethod.new(klass, :method_x)

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -70,7 +70,7 @@ class InstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 60
+    expected_line_number = 46
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|
@@ -98,7 +98,6 @@ class InstanceMethodTest < Mocha::TestCase
     method.hide_original_method
     method.define_new_method
     method.remove_new_method
-    method.restore_original_method
 
     assert klass.respond_to?(:method_x)
     assert_equal :original_result, klass.method_x
@@ -118,20 +117,10 @@ class InstanceMethodTest < Mocha::TestCase
     method.hide_original_method
     method.define_new_method
     method.remove_new_method
-    method.restore_original_method
 
     block_called = false
     klass.method_x { block_called = true }
     assert block_called
-  end
-
-  def test_should_not_restore_original_method_if_none_was_defined_in_first_place
-    klass = class_with_method(:method_x, :new_result)
-    method = InstanceMethod.new(klass, :method_x)
-
-    method.restore_original_method
-
-    assert_equal :new_result, klass.method_x
   end
 
   def test_should_call_hide_original_method
@@ -171,24 +160,9 @@ class InstanceMethodTest < Mocha::TestCase
     assert method.remove_called
   end
 
-  def test_should_call_restore_original_method
-    klass = class_with_method(:method_x)
-    mocha = build_mock
-    define_instance_method(klass, :mocha) { mocha }
-    method = InstanceMethod.new(klass, :method_x)
-    replace_instance_method(method, :reset_mocha) {}
-    define_instance_accessor(method, :restore_called)
-    replace_instance_method(method, :restore_original_method) { self.restore_called = true }
-
-    method.unstub
-
-    assert method.restore_called
-  end
-
   def test_should_call_mocha_unstub
     klass = class_with_method(:method_x)
     method = InstanceMethod.new(klass, :method_x)
-    replace_instance_method(method, :restore_original_method) {}
     mocha = Class.new do
       class << self
         attr_accessor :unstub_method
@@ -208,7 +182,6 @@ class InstanceMethodTest < Mocha::TestCase
     klass = class_with_method(:method_x)
     method = InstanceMethod.new(klass, :method_x)
     replace_instance_method(method, :remove_new_method) {}
-    replace_instance_method(method, :restore_original_method) {}
     mocha = Class.new
     define_instance_method(mocha, :unstub) { |method_name| }
     define_instance_method(mocha, :any_expectations?) { false }

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -18,18 +18,6 @@ class InstanceMethodTest < Mocha::TestCase
     end
   end
 
-  unless RUBY_V2_PLUS
-    def test_should_hide_original_method
-      klass = class_with_method(:method_x)
-      klass.singleton_class.send(:alias_method, :_method, :method)
-      method = InstanceMethod.new(klass, :method_x)
-
-      method.hide_original_method
-
-      assert_equal false, klass.respond_to?(:method_x)
-    end
-  end
-
   def test_should_not_raise_error_hiding_method_that_isnt_defined
     klass = class_with_method(:irrelevant)
     method = InstanceMethod.new(klass, :method_x)

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -78,7 +78,7 @@ class InstanceMethodTest < Mocha::TestCase
     assert_equal false, klass.respond_to?(:method_x)
   end
 
-  def test_should_restore_original_method
+  def test_remove_new_method_restores_original_method
     klass = class_with_method(:method_x, :original_result)
     klass.singleton_class.send(:alias_method, :_method, :method)
     method = InstanceMethod.new(klass, :method_x)
@@ -91,7 +91,7 @@ class InstanceMethodTest < Mocha::TestCase
     assert_equal :original_result, klass.method_x
   end
 
-  def test_should_restore_original_method_accepting_a_block_parameter
+  def test_remove_new_method_restores_original_method_accepting_a_block_parameter
     klass = Class.new do
       extend ClassMethods
       singleton_class.extend(ClassMethods)


### PR DESCRIPTION
Follow-up to https://github.com/freerange/mocha/pull/555, related to https://github.com/freerange/mocha/issues/325, and also unblocks https://github.com/freerange/mocha/issues/446.

Closes https://github.com/freerange/mocha/pull/547 🙇 (sorry about that @nitishr) 