### PR TITLE
Deprecate support for Ruby versions earlier than v2.0

### DIFF
--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -1,3 +1,4 @@
+require 'mocha/ruby_version'
 require 'mocha/parameter_matchers'
 require 'mocha/hooks'
 require 'mocha/mockery'

--- a/lib/mocha/minitest.rb
+++ b/lib/mocha/minitest.rb
@@ -1,3 +1,4 @@
+require 'mocha/ruby_version'
 require 'mocha/integration/mini_test'
 require 'mocha/deprecation'
 

--- a/lib/mocha/ruby_version.rb
+++ b/lib/mocha/ruby_version.rb
@@ -1,3 +1,11 @@
+require 'mocha/deprecation'
+
 module Mocha
   RUBY_V2_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2')
+
+  unless RUBY_V2_PLUS
+    Mocha::Deprecation.warning(
+      'Versions of Ruby earlier than v2.0 will not be supported in future versions of Mocha.'
+    )
+  end
 end

--- a/lib/mocha/test_unit.rb
+++ b/lib/mocha/test_unit.rb
@@ -1,3 +1,4 @@
+require 'mocha/ruby_version'
 require 'mocha/integration/test_unit'
 require 'mocha/deprecation'
 


### PR DESCRIPTION
This was based on #553.

This is long overdue. [Extended maintenance of Ruby v1.9.3 ended on 23 Feb 2015][1]. Actually dropping support will allow significant simplification of the code.

The immediate motivation is to come up with better parameter matching for keyword arguments and we've run into parsing issues when trying to do this in conjunction with continuing to support Ruby v1.9.

See #325.

[1]: https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/