### PR TITLE
Separate linting from test tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ jobs:
           condition:
             equal: [ "Gemfile", << parameters.gemfile >>]
           steps:
+            - run: bundle exec rake lint
+      - when:
+          condition:
+            equal: [ "Gemfile", << parameters.gemfile >>]
+          steps:
             - run: bundle exec rake test
       - when:
           condition:

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ require 'bundler/setup'
 
 require 'rake/testtask'
 
-desc 'Run all tests'
-task 'default' => ['test', 'test:performance']
+desc 'Run all linters and tests'
+task 'default' => ['lint', 'test', 'test:performance']
 
 desc 'Run tests'
 task 'test' do
@@ -76,13 +76,15 @@ namespace 'test' do # rubocop:disable Metrics/BlockLength
   end
 end
 
-begin
-  require 'rubocop/rake_task'
-  if RUBY_VERSION >= '2.2.0' && (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby') && ENV['MOCHA_RUN_INTEGRATION_TESTS'].nil?
-    RuboCop::RakeTask.new
-    task 'test' => 'rubocop'
+task 'lint' do
+  begin
+    require 'rubocop/rake_task'
+    if RUBY_VERSION >= '2.2.0' && (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby') && ENV['MOCHA_RUN_INTEGRATION_TESTS'].nil?
+      RuboCop::RakeTask.new
+      Rake::Task['rubocop'].invoke
+    end
+  rescue LoadError # rubocop:disable Lint/HandleExceptions
   end
-rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
 # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity


### PR DESCRIPTION
Early on, when running `bundle exec rake test`, I mistakenly assumed that if only linting errors showed, then the tests were fine. I think separating the linting from testing would prevent this newbie mistake 😄 and also make it easier for someone who was doing small steps (e.g. https://github.com/freerange/mocha/pull/552/commits/9361f8e6d8078ed844cfe0ac9235274a3e231035#diff-d9dbcb54883fff83b955f57c445b2c7c0862b1ab71378f266096443cb652c136R40 fails the linting).

I think CI-wise it might make sense to run linting separate from tests (so at a glance one can see whether linting/tests are failing) but have not done so in this PR. Does Rubocop need to be run for every Ruby version?