### PR TITLE
Add ruby2_keywords to invocations and expectations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ if ENV['MOCHA_GENERATE_DOCS']
   gem 'redcarpet'
   gem 'yard'
 end
+
+gem 'ruby2_keywords', '~> 0.0.5'

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'mocha/method_matcher'
 require 'mocha/parameters_matcher'
 require 'mocha/expectation_error'
@@ -222,6 +223,7 @@ module Mocha
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end
+    ruby2_keywords(:with)
 
     # Modifies expectation so that the expected method must be called with a block.
     #

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'mocha/expectation'
 require 'mocha/expectation_list'
 require 'mocha/invocation'
@@ -308,9 +309,12 @@ module Mocha
     end
 
     # @private
-    def method_missing(symbol, *arguments, &block) # rubocop:disable Style/MethodMissingSuper
+    # rubocop:disable Style/MethodMissingSuper
+    def method_missing(symbol, *arguments, &block)
       handle_method_call(symbol, arguments, block)
     end
+    ruby2_keywords(:method_missing)
+    # rubocop:enable Style/MethodMissingSuper
 
     # @private
     def handle_method_call(symbol, arguments, block)

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'mocha/ruby_version'
 
 module Mocha
@@ -45,6 +46,7 @@ module Mocha
       stub_method_owner.send(:define_method, method_name) do |*args, &block|
         self_in_scope.mock.handle_method_call(method_name_in_scope, args, block)
       end
+      stub_method_owner.send(:ruby2_keywords, method_name)
       retain_original_visibility(stub_method_owner)
     end
 

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -55,7 +55,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 46
+    expected_line_number = 47
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -58,7 +58,7 @@ class InstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 46
+    expected_line_number = 47
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|


### PR DESCRIPTION
Enables ruby2_keywords flagging for invocations and expectations, so they can be used later for strict keyword argument matching. This is sketched out in https://github.com/freerange/mocha/pull/544 and https://github.com/freerange/mocha/issues/446#issuecomment-1257198797.