### PR TITLE
Support strict keyword argument matching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ if ENV['MOCHA_GENERATE_DOCS']
   gem 'redcarpet'
   gem 'yard'
 end
+
+gem 'ruby2_keywords', '~> 0.0.5'

--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -306,16 +306,16 @@ module Mocha
       @options[:reinstate_undocumented_behaviour_from_v1_9]
     end
 
-    # Configure whether to perform strict keyword argument comparision. Only supported in Ruby >= 2.7.
+    # Configure whether to perform strict keyword argument comparision. Only supported in Ruby >= v2.7.
     #
     # Without this option, positional hash and keyword arguments are treated the same during comparison, which can lead to false
-    # negatives in Ruby >= 3.0 (see examples below). For more details on keyword arguments in Ruby 3, refer to the relevant
-    # {https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0 blog post}.
+    # negatives in Ruby >= v3.0 (see examples below). For more details on keyword arguments in Ruby v3, refer to
+    # {https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0 this article}.
     #
     # Note that Hash matchers such as +has_value+ or +has_key+ will still treat positional hash and keyword arguments the same,
     # so false negatives are still possible when they are used.
     #
-    # This is turned off by default to enable gradual adoption, and may be turned on by default in the future.
+    # This configuration option is turned off by default to enable gradual adoption, but may be turned on by default in the future.
     #
     # When +value+ is +true+, strict keyword argument matching will be enabled.
     # When +value+ is +false+, strict keyword argument matching is disabled. This is the default.

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'mocha/method_matcher'
 require 'mocha/parameters_matcher'
 require 'mocha/expectation_error'
@@ -222,6 +223,7 @@ module Mocha
       @parameters_matcher = ParametersMatcher.new(expected_parameters, &matching_block)
       self
     end
+    ruby2_keywords(:with)
 
     # Modifies expectation so that the expected method must be called with a block.
     #

--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -20,7 +20,7 @@ module Mocha
     module HashMethods
       def mocha_inspect
         unwrapped = collect { |key, value| "#{key.mocha_inspect} => #{value.mocha_inspect}" }.join(', ')
-        "{#{unwrapped}}"
+        Hash.ruby2_keywords_hash?(self) ? unwrapped : "{#{unwrapped}}"
       end
     end
 

--- a/lib/mocha/invocation.rb
+++ b/lib/mocha/invocation.rb
@@ -79,7 +79,6 @@ module Mocha
     def argument_description
       signature = arguments.mocha_inspect
       signature = signature.gsub(/^\[|\]$/, '')
-      signature = signature.gsub(/^\{|\}$/, '') if arguments.length == 1
       "(#{signature})"
     end
   end

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'mocha/expectation'
 require 'mocha/expectation_list'
 require 'mocha/invocation'
@@ -312,6 +313,7 @@ module Mocha
     def method_missing(symbol, *arguments, &block)
       handle_method_call(symbol, arguments, block)
     end
+    ruby2_keywords(:method_missing)
     # rubocop:enable Style/MethodMissingSuper
 
     # @private

--- a/lib/mocha/parameter_matchers/instance_methods.rb
+++ b/lib/mocha/parameter_matchers/instance_methods.rb
@@ -1,4 +1,5 @@
 require 'mocha/parameter_matchers/equals'
+require 'mocha/parameter_matchers/positional_or_keyword_hash'
 
 module Mocha
   module ParameterMatchers
@@ -15,4 +16,12 @@ end
 # @private
 class Object
   include Mocha::ParameterMatchers::InstanceMethods
+end
+
+# @private
+class Hash
+  # @private
+  def to_matcher
+    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(self)
+  end
 end

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -1,0 +1,33 @@
+require 'mocha/configuration'
+require 'mocha/parameter_matchers/base'
+
+module Mocha
+  module ParameterMatchers
+    # @private
+    class PositionalOrKeywordHash < Base
+      def initialize(value)
+        @value = value
+      end
+
+      def matches?(available_parameters)
+        parameter, is_last_parameter = extract_parameter(available_parameters)
+        return false unless parameter.is_a?(Hash)
+
+        if is_last_parameter && Mocha.configuration.strict_keyword_argument_matching?
+          return false unless ::Hash.ruby2_keywords_hash?(parameter) == ::Hash.ruby2_keywords_hash?(@value)
+        end
+        parameter == @value
+      end
+
+      def mocha_inspect
+        @value.mocha_inspect
+      end
+
+      private
+
+      def extract_parameter(available_parameters)
+        [available_parameters.shift, available_parameters.empty?]
+      end
+    end
+  end
+end

--- a/lib/mocha/parameters_matcher.rb
+++ b/lib/mocha/parameters_matcher.rb
@@ -23,7 +23,6 @@ module Mocha
     def mocha_inspect
       signature = matchers.mocha_inspect
       signature = signature.gsub(/^\[|\]$/, '')
-      signature = signature.gsub(/^\{|\}$/, '') if matchers.length == 1
       "(#{signature})"
     end
 

--- a/lib/mocha/ruby_version.rb
+++ b/lib/mocha/ruby_version.rb
@@ -1,4 +1,5 @@
 require 'mocha/deprecation'
 
 module Mocha
+  RUBY_V27_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7')
 end

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -1,3 +1,4 @@
+require 'ruby2_keywords'
 require 'mocha/ruby_version'
 
 module Mocha
@@ -45,6 +46,7 @@ module Mocha
       stub_method_owner.send(:define_method, method_name) do |*args, &block|
         self_in_scope.mock.handle_method_call(method_name_in_scope, args, block)
       end
+      stub_method_owner.send(:ruby2_keywords, method_name)
       retain_original_visibility(stub_method_owner)
     end
 

--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -20,6 +20,19 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  if Mocha::RUBY_V27_PLUS
+    def test_should_not_match_hash_parameter_with_keyword_args_when_strict_keyword_matching_is_enabled
+      test_result = run_as_test do
+        mock = mock()
+        mock.expects(:method).with(:key => 42)
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_failed(test_result)
+    end
+  end
+
   def test_should_match_hash_parameter_with_splatted_keyword_args
     test_result = run_as_test do
       mock = mock()
@@ -27,6 +40,19 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
     end
     assert_passed(test_result)
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_should_not_match_hash_parameter_with_splatted_keyword_args_when_strict_keyword_matching_is_enabled
+      test_result = run_as_test do
+        mock = mock()
+        mock.expects(:method).with(**{ :key => 42 })
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_failed(test_result)
+    end
   end
 
   def test_should_match_splatted_hash_parameter_with_keyword_args
@@ -56,6 +82,19 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  if Mocha::RUBY_V27_PLUS
+    def test_should_not_match_positional_and_keyword_args_with_last_positional_hash_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock()
+        mock.expects(:method).with(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(1, :key => 42)
+        end
+      end
+      assert_failed(test_result)
+    end
+  end
+
   def test_should_match_last_positional_hash_with_keyword_args
     test_result = run_as_test do
       mock = mock()
@@ -63,6 +102,19 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
     end
     assert_passed(test_result)
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_should_not_match_last_positional_hash_with_keyword_args_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock()
+        mock.expects(:method).with(1, :key => 42)
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_failed(test_result)
+    end
   end
 
   def test_should_match_positional_and_keyword_args_with_keyword_args
@@ -108,5 +160,18 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
     end
     assert_passed(test_result)
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_should_not_match_non_hash_args_with_keyword_args
+      test_result = run_as_test do
+        mock = mock()
+        mock.expects(:method).with(**{ :key => 1 })
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method([2])
+        end
+      end
+      assert_failed(test_result)
+    end
   end
 end

--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -1,0 +1,112 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class KeywordArgumentMatchingTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_should_match_hash_parameter_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(:key => 42)
+      mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_hash_parameter_with_splatted_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(**{ :key => 42 })
+      mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(:key => 42)
+      mock.method(**{ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_splatted_hash
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(**{ :key => 42 })
+      mock.method(**{ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_positional_and_keyword_args_with_last_positional_hash
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+      mock.method(1, :key => 42)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_last_positional_hash_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, :key => 42)
+      mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_positional_and_keyword_args_with_keyword_args
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, :key => 42)
+      mock.method(1, :key => 42)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_hash_parameter_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(has_key(:key))
+      mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_splatted_hash_parameter_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(has_key(:key))
+      mock.method(**{ :key => 42 })
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_positional_and_keyword_args_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, has_key(:key))
+      mock.method(1, :key => 42)
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_match_last_positional_hash_with_hash_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(1, has_key(:key))
+      mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_passed(test_result)
+  end
+end

--- a/test/acceptance/positional_and_keyword_has_inspect_test.rb
+++ b/test/acceptance/positional_and_keyword_has_inspect_test.rb
@@ -16,9 +16,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
     end
     assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unexpected invocation: #<Mock:mock>.method({:key => 42})',
       'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
     ], test_result.failure_message_lines
   end
 
@@ -29,9 +29,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.method(:key => 42)
     end
     assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unexpected invocation: #<Mock:mock>.method({:key => 42})',
       'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
     ], test_result.failure_message_lines
   end
 

--- a/test/acceptance/positional_and_keyword_has_inspect_test.rb
+++ b/test/acceptance/positional_and_keyword_has_inspect_test.rb
@@ -28,11 +28,19 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.expects(:method).with(:foo => 42)
       mock.method(:key => 42)
     end
-    assert_equal [
-      'unexpected invocation: #<Mock:mock>.method({:key => 42})',
-      'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
-    ], test_result.failure_message_lines
+    if Mocha::RUBY_V27_PLUS
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      ], test_result.failure_message_lines
+    else
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method({:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
+      ], test_result.failure_message_lines
+    end
   end
 
   def test_last_hash_parameters_in_invocation_and_expectation_print_correctly
@@ -54,10 +62,80 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
       mock.expects(:method).with(1, :foo => 42)
       mock.method(1, :key => 42)
     end
-    assert_equal [
-      'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
-      'unsatisfied expectations:',
-      '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
-    ], test_result.failure_message_lines
+    if Mocha::RUBY_V27_PLUS
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+      ], test_result.failure_message_lines
+    else
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+      ], test_result.failure_message_lines
+    end
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_single_hash_parameters_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with({ :foo => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method({:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method({:foo => 42})'
+      ], test_result.failure_message_lines
+    end
+
+    def test_unexpected_keyword_arguments_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with(:foo => 42)
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(:key => 42)
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+      ], test_result.failure_message_lines
+    end
+
+    def test_last_hash_parameters_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with(1, { :foo => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+      ], test_result.failure_message_lines
+    end
+
+    def test_unexpected_keyword_arguments_with_other_positionals_in_invocation_and_expectation_print_correctly_when_strict_keyword_args_is_enabled
+      test_result = run_as_test do
+        mock = mock('mock')
+        mock.expects(:method).with(1, :foo => 42)
+        Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+          mock.method(1, :key => 42)
+        end
+      end
+      assert_equal [
+        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unsatisfied expectations:',
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+      ], test_result.failure_message_lines
+    end
   end
 end

--- a/test/acceptance/positional_and_keyword_has_inspect_test.rb
+++ b/test/acceptance/positional_and_keyword_has_inspect_test.rb
@@ -1,0 +1,63 @@
+class PositionalAndKeywordHashInspectTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_single_hash_parameters_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with({ :foo => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+      mock.method({ :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+    ], test_result.failure_message_lines
+  end
+
+  def test_unexpected_keyword_arguments_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with(:foo => 42)
+      mock.method(:key => 42)
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+    ], test_result.failure_message_lines
+  end
+
+  def test_last_hash_parameters_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with(1, { :foo => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+      mock.method(1, { :key => 42 }) # rubocop:disable Style/BracesAroundHashParameters
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+    ], test_result.failure_message_lines
+  end
+
+  def test_unexpected_keyword_arguments_with_other_positionals_in_invocation_and_expectation_print_correctly
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).with(1, :foo => 42)
+      mock.method(1, :key => 42)
+    end
+    assert_equal [
+      'unexpected invocation: #<Mock:mock>.method(1, {:key => 42})',
+      'unsatisfied expectations:',
+      '- expected exactly once, invoked never: #<Mock:mock>.method(1, {:foo => 42})'
+    ], test_result.failure_message_lines
+  end
+end

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -55,7 +55,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 46
+    expected_line_number = 47
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -1,7 +1,12 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/configuration'
+require 'mocha/ruby_version'
 
 class ConfigurationTest < Mocha::TestCase
+  def teardown
+    Mocha::Configuration.reset_configuration
+  end
+
   def test_allow_temporarily_changes_config_when_given_block
     Mocha.configure { |c| c.stubbing_method_unnecessarily = :warn }
     yielded = false
@@ -33,5 +38,22 @@ class ConfigurationTest < Mocha::TestCase
     end
     assert yielded
     assert_equal :allow, Mocha.configuration.stubbing_method_unnecessarily
+  end
+
+  def test_strict_keyword_argument_matching_works_is_false_by_default
+    assert !Mocha.configuration.strict_keyword_argument_matching?
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_enabling_strict_keyword_argument_matching_works_in_ruby_2_7_and_above
+      Mocha.configure { |c| c.strict_keyword_argument_matching = true }
+      assert Mocha.configuration.strict_keyword_argument_matching?
+    end
+  else
+    def test_enabling_strict_keyword_argument_matching_raises_error_if_below_ruby_2_7
+      assert_raises(RuntimeError, 'Strict keyword argument matching requires Ruby 2.7 and above.') do
+        Mocha.configure { |c| c.strict_keyword_argument_matching = true }
+      end
+    end
   end
 end

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -58,7 +58,7 @@ class InstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 46
+    expected_line_number = 47
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -1,0 +1,73 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+require 'mocha/parameter_matchers/positional_or_keyword_hash'
+require 'mocha/parameter_matchers/instance_methods'
+require 'mocha/inspect'
+
+class PositionalOrKeywordHashTest < Mocha::TestCase
+  include Mocha::ParameterMatchers
+
+  def test_should_describe_matcher
+    matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+    assert_equal '{:key_1 => 1, :key_2 => 2}', matcher.mocha_inspect
+  end
+
+  def test_should_match_hash_arg_with_hash_arg
+    matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+    assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }])
+  end
+
+  def test_should_match_non_last_hash_arg_with_hash_arg
+    matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+    assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }, %w[a b]])
+  end
+
+  def test_should_not_match_non_hash_arg_with_hash_arg
+    matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+    assert !matcher.matches?([%w[a b]])
+  end
+
+  if Mocha::RUBY_V27_PLUS
+    def test_should_match_non_last_hash_arg_with_hash_arg_when_strict_keyword_args_is_enabled
+      matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+      Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+        assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }, %w[a b]])
+      end
+    end
+
+    def test_should_not_match_non_hash_arg_with_hash_arg_when_strict_keyword_args_is_enabled
+      matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+      Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+        assert !matcher.matches?([%w[a b]])
+      end
+    end
+
+    def test_should_match_hash_arg_with_hash_arg_when_strict_keyword_args_is_enabled
+      matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+      Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+        assert matcher.matches?([{ :key_1 => 1, :key_2 => 2 }])
+      end
+    end
+
+    def test_should_match_keyword_args_with_keyword_args_when_strict_keyword_args_is_enabled
+      matcher = Hash.ruby2_keywords_hash({ :key_1 => 1, :key_2 => 2 }).to_matcher # rubocop:disable Style/BracesAroundHashParameters
+      Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+        assert matcher.matches?([Hash.ruby2_keywords_hash({ :key_1 => 1, :key_2 => 2 })]) # rubocop:disable Style/BracesAroundHashParameters
+      end
+    end
+
+    def test_should_not_match_hash_arg_with_keyword_args_when_strict_keyword_args_is_enabled
+      matcher = Hash.ruby2_keywords_hash({ :key_1 => 1, :key_2 => 2 }).to_matcher # rubocop:disable Style/BracesAroundHashParameters
+      Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+        assert !matcher.matches?([{ :key_1 => 1, :key_2 => 2 }])
+      end
+    end
+
+    def test_should_not_match_keyword_args_with_hash_arg_when_strict_keyword_args_is_enabled
+      matcher = { :key_1 => 1, :key_2 => 2 }.to_matcher
+      Mocha::Configuration.override(:strict_keyword_argument_matching => true) do
+        assert !matcher.matches?([Hash.ruby2_keywords_hash({ :key_1 => 1, :key_2 => 2 })]) # rubocop:disable Style/BracesAroundHashParameters
+      end
+    end
+  end
+end

--- a/test/unit/parameters_matcher_test.rb
+++ b/test/unit/parameters_matcher_test.rb
@@ -99,19 +99,6 @@ class ParametersMatcherTest < Mocha::TestCase
     assert_equal '(1, 2, 3)', parameters_matcher.mocha_inspect
   end
 
-  def test_should_remove_curly_braces_if_hash_is_only_argument
-    params = [{ :a => 1, :z => 2 }]
-    parameters_matcher = ParametersMatcher.new(params)
-    assert_nil parameters_matcher.mocha_inspect.index('{')
-    assert_nil parameters_matcher.mocha_inspect.index('}')
-  end
-
-  def test_should_not_remove_curly_braces_if_hash_is_not_the_only_argument
-    params = [1, { :a => 1 }]
-    parameters_matcher = ParametersMatcher.new(params)
-    assert_equal '(1, {:a => 1})', parameters_matcher.mocha_inspect
-  end
-
   def test_should_indicate_that_matcher_will_match_any_actual_parameters
     parameters_matcher = ParametersMatcher.new
     assert_equal '(any_parameters)', parameters_matcher.mocha_inspect


### PR DESCRIPTION
This introduces a new `strict_keyword_argument_matching` configuration option. This option is only available in Ruby >= v2.7 and is disabled by default to enable gradual adoption.

When the strict keyword argument option is enabled, an expectation expecting keyword arguments (via `Expectation#with`) will no longer match an invocation passing a positional Hash argument.

Without this option, positional hash and keyword arguments are treated the same during comparison, which can lead to false negatives in Ruby >= v3.0 (see examples below).

### Loose keyword argument matching (default)

```ruby
class Example
  def foo(a, bar:); end
end

example = Example.new
example.expects(:foo).with('a', bar: 'b')
example.foo('a', { bar: 'b' })
# This passes the test, but would result in an ArgumentError in practice
```

### Strict keyword argument matching

```ruby
Mocha.configure do |c|
  c.strict_keyword_argument_matching = true
end

class Example
  def foo(a, bar:); end
end

example = Example.new
example.expects(:foo).with('a', bar: 'b')
example.foo('a', { bar: 'b' })
# This now fails as expected
```

For more details on keyword arguments in Ruby v3, refer to [this article][1].

Note that Hash matchers such as has_value or has_key will still treat positional hash and keyword arguments the same, so false negatives are still possible when they are used.

Closes #446.

See also #535 & #544 for discussions relating to this change.

[1]: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0