### PR TITLE
ruby2_keywords is runtime dependency; not development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,3 @@ if ENV['MOCHA_GENERATE_DOCS']
   gem 'redcarpet'
   gem 'yard'
 end
-
-gem 'ruby2_keywords', '~> 0.0.5'

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://mocha.jamesmead.org'
   s.require_paths = ['lib']
   s.summary = 'Mocking and stubbing library'
+
+  s.add_runtime_dependency 'ruby2_keywords', '>= 0.0.5'
 end


### PR DESCRIPTION
And so should be included as such in `mocha.gemspec`; not in the `Gemfile`.

I've specified the '>= 0.0.5' constraint, because v0.0.5 is the version we've been testing with.

I've used a '>=' constraint rather than a twiddle-wakka ('~> 0.0.5'), because that's equivalent to the combination of '>= 0.0.5' and '< 0.1.0' which seems a bit too restrictive. At the moment there's no reason to suppose later versions of `ruby2_keywords` won't work with Mocha and we can always add a constraint later if it turns out there is a problem.

Closes #581.