### PR TITLE
Fix regression in Mock#responds_like behaviour

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.15.1
+
+### External changes
+
+* Fix regression in `Mock#responds_like` behaviour - thanks to @adrianna-chang-shopify for reporting (#580,#583,c586a08c)
+
 ## 1.15.0
 
 ### External changes

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -182,11 +182,11 @@ module Mocha
       end
     end
 
-    # Constrains the {Mock} instance so that it can only expect or stub methods to which +responder+ responds. The constraint is only applied at method invocation time.
+    # Constrains the {Mock} instance so that it can only expect or stub methods to which +responder+ responds publicly. The constraint is only applied at method invocation time.
     #
-    # A +NoMethodError+ will be raised if the +responder+ does not +#respond_to?+ a method invocation (even if the method has been expected or stubbed).
+    # A +NoMethodError+ will be raised if the +responder+ does not publicly +#respond_to?+ the invoked method (even if the method has been expected or stubbed).
     #
-    # The {Mock} instance will delegate its +#respond_to?+ method to the +responder+.
+    # The {Mock} instance will delegate its +#respond_to?+ method to the +responder+. However, the +include_all+ parameter is not passed through, so only public methods on the +responder+ will be considered.
     #
     # Note that the methods on +responder+ are never actually invoked.
     #
@@ -236,11 +236,11 @@ module Mocha
       self
     end
 
-    # Constrains the {Mock} instance so that it can only expect or stub methods to which an instance of the +responder_class+ responds. The constraint is only applied at method invocation time. Note that the responder instance is instantiated using +Class#allocate+.
+    # Constrains the {Mock} instance so that it can only expect or stub methods to which an instance of the +responder_class+ responds publicly. The constraint is only applied at method invocation time. Note that the responder instance is instantiated using +Class#allocate+.
     #
-    # A +NoMethodError+ will be raised if the responder instance does not +#respond_to?+ a method invocation (even if the method has been expected or stubbed).
+    # A +NoMethodError+ will be raised if the responder instance does not publicly +#respond_to?+ the invoked method (even if the method has been expected or stubbed).
     #
-    # The {Mock} instance will delegate its +#respond_to?+ method to the responder instance.
+    # The {Mock} instance will delegate its +#respond_to?+ method to the responder instance. However, the +include_all+ parameter is not passed through, so only public methods on the +responder+  will be considered.
     #
     # Note that the methods on the responder instance are never actually invoked.
     #
@@ -325,9 +325,9 @@ module Mocha
     end
 
     # @private
-    def respond_to_missing?(symbol, include_all)
+    def respond_to_missing?(symbol, _include_all)
       if @responder
-        @responder.respond_to?(symbol, include_all)
+        @responder.respond_to?(symbol)
       else
         @everything_stubbed || all_expectations.matches_method?(symbol)
       end

--- a/lib/mocha/version.rb
+++ b/lib/mocha/version.rb
@@ -1,3 +1,3 @@
 module Mocha
-  VERSION = '1.15.0'.freeze
+  VERSION = '1.15.1'.freeze
 end

--- a/test/acceptance/array_flatten_test.rb
+++ b/test/acceptance/array_flatten_test.rb
@@ -1,0 +1,28 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class ArrayFlattenTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_flattens_array_containing_mock_which_responds_like_active_record_model
+    model = Class.new do
+      # Ref: https://github.com/rails/rails/blob/7db044f38594eb43e1d241cc82025155666cc6f1/activerecord/lib/active_record/core.rb#L734-L745
+      def to_ary
+        nil
+      end
+      private :to_ary
+    end.new
+    test_result = run_as_test do
+      m = mock.responds_like(model)
+      assert_equal [m], [m].flatten
+    end
+    assert_passed(test_result)
+  end
+end

--- a/test/acceptance/responds_like_test.rb
+++ b/test/acceptance/responds_like_test.rb
@@ -1,0 +1,415 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+if RUBY_VERSION >= '2'
+  class RespondsLikeTest < Mocha::TestCase
+    include AcceptanceTest
+
+    def setup
+      setup_acceptance_test
+    end
+
+    def teardown
+      teardown_acceptance_test
+    end
+
+    # mock
+
+    def test_mock_does_not_respond_when_method_is_not_stubbed
+      test_result = run_as_test do
+        m = mock
+        assert !m.respond_to?(:foo, false)
+        assert !m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_raises_unexpected_invocation_exception_when_method_is_not_stubbed
+      test_result = run_as_test do
+        m = mock
+        assert_raises(Minitest::Assertion) { m.foo }
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_does_respond_when_method_is_stubbed
+      test_result = run_as_test do
+        m = mock
+        m.stubs(:foo)
+        assert m.respond_to?(:foo, false)
+        assert m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_does_not_raise_exception_when_method_is_stubbed
+      test_result = run_as_test do
+        m = mock
+        m.stubs(:foo)
+        assert_nil m.foo
+      end
+      assert_passed(test_result)
+    end
+
+    # mock which responds like object with public method
+
+    def test_mock_which_responds_like_object_with_public_method_does_respond_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert m.respond_to?(:foo, false)
+        assert m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_public_method_raises_unexpected_invocation_exception_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert_raises(Minitest::Assertion) { m.foo }
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_public_method_raises_no_method_error_when_another_method_is_invoked
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert_raises(NoMethodError) { m.bar }
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_public_method_does_respond_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        m.stubs(:foo)
+        assert m.respond_to?(:foo, false)
+        assert m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_public_method_does_not_raise_exception_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        m.stubs(:foo)
+        assert_nil m.foo
+      end
+      assert_passed(test_result)
+    end
+
+    # mock which responds like object with protected method
+
+    def test_mock_which_responds_like_object_with_protected_method_does_not_respond_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert !m.respond_to?(:foo, false)
+        assert !m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_protected_method_raises_no_method_error_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert_raises(NoMethodError) { m.foo } # vs Minitest::Assertion for public method
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_protected_method_raises_no_method_error_when_another_method_is_invoked
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert_raises(NoMethodError) { m.bar }
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_protected_method_does_not_respond_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        m.stubs(:foo)
+        assert !m.respond_to?(:foo, false)
+        assert !m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_protected_method_raises_no_method_error_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        m.stubs(:foo)
+        assert_raises(NoMethodError) { m.foo } # vs no exception for public method
+      end
+      assert_passed(test_result)
+    end
+
+    # mock which responds like object with private method
+
+    def test_mock_which_responds_like_object_with_private_method_does_not_respond_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert !m.respond_to?(:foo, false)
+        assert !m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_private_method_raises_no_method_error_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert_raises(NoMethodError) { m.foo } # vs Minitest::Assertion for public method
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_private_method_raises_no_method_error_when_another_method_is_invoked
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        assert_raises(NoMethodError) { m.bar }
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_private_method_does_not_respond_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        m.stubs(:foo)
+        assert !m.respond_to?(:foo, false)
+        assert !m.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_mock_which_responds_like_object_with_private_method_raises_no_method_error_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        m = mock.responds_like(object)
+        m.stubs(:foo)
+        assert_raises(NoMethodError) { m.foo } # vs no exception for public method
+      end
+      assert_passed(test_result)
+    end
+
+    # object with public method
+
+    def test_object_with_public_method_does_respond_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        assert object.respond_to?(:foo, false)
+        assert object.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_public_method_invokes_original_method_when_method_is_not_stubbed
+      object = Class.new do
+        def foo
+          'original'
+        end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        assert_equal 'original', object.foo
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_public_method_does_respond_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        object.stubs(:foo)
+        assert object.respond_to?(:foo, false)
+        assert object.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_public_method_invokes_stubbed_method_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        public :foo
+      end.new
+      test_result = run_as_test do
+        object.stubs(:foo).returns('stubbed')
+        assert_equal 'stubbed', object.foo
+      end
+      assert_passed(test_result)
+    end
+
+    # object with protected method
+
+    def test_object_with_protected_method_invokes_stubbed_method_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        object.stubs(:foo).returns('stubbed')
+        e = assert_raises(NoMethodError) { object.foo }
+        assert_match(/^protected method/, e.message)
+        assert_equal 'stubbed', object.send(:foo)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_protected_method_does_respond_privately_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        assert !object.respond_to?(:foo, false)
+        assert object.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_protected_method_invokes_original_method_when_method_is_not_stubbed
+      object = Class.new do
+        def foo
+          'original'
+        end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        e = assert_raises(NoMethodError) { object.foo }
+        assert_match(/^protected method/, e.message)
+        assert_equal 'original', object.send(:foo)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_protected_method_does_respond_privately_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        protected :foo
+      end.new
+      test_result = run_as_test do
+        object.stubs(:foo)
+        assert !object.respond_to?(:foo, false)
+        assert object.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    # object with private method
+
+    def test_object_with_private_method_does_respond_privately_when_method_is_not_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        assert !object.respond_to?(:foo, false)
+        assert object.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_private_method_invokes_original_method_when_method_is_not_stubbed
+      object = Class.new do
+        def foo
+          'original'
+        end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        e = assert_raises(NoMethodError) { object.foo }
+        assert_match(/^private method/, e.message)
+        assert_equal 'original', object.send(:foo)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_private_method_does_respond_privately_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        object.stubs(:foo)
+        assert !object.respond_to?(:foo, false)
+        assert object.respond_to?(:foo, true)
+      end
+      assert_passed(test_result)
+    end
+
+    def test_object_with_private_method_invokes_stubbed_method_when_method_is_stubbed
+      object = Class.new do
+        def foo; end
+        private :foo
+      end.new
+      test_result = run_as_test do
+        object.stubs(:foo).returns('stubbed')
+        e = assert_raises(NoMethodError) { object.foo }
+        assert_match(/^private method/, e.message)
+        assert_equal 'stubbed', object.send(:foo)
+      end
+      assert_passed(test_result)
+    end
+  end
+end


### PR DESCRIPTION
The regression was inadvertently introduced in [this commit][1] and indirectly led to [this issue][2].

I've attempted to thoroughly characterise the pre-regression behaviour of `Mock#responds_like` in a new acceptance test, `RespondsLikeTest`, in order to reduce the chances of any such regressions occurring in the future. I've also added another acceptance test, `ArrayFlattenTest`, which reproduced [the issue][2] until the regression was fixed.

Investigating this has made me realise that the behaviour of `Mock#responds_like` in combination with protected & private methods on the responder was not specified in the documentation. I've attempted to reverse engineer the documentation so that it more fully describes the pre-regression behaviour.

Note that the CI build for Ruby v1.9 is using an old version of Minitest which doesn't work with the `RespondsLikeTest` and since support for Ruby v1.9 was dropped in Mocha v2, I don't think it's worth the effort to sort this out so I've just disabled the test for Ruby v1.9.

[1]: https://github.com/freerange/mocha/commit/365a7348dbd8e8798584001e261d31a7355c19d8
[2]: https://github.com/freerange/mocha/issues/580