### PR TITLE
Fix BacktraceFilter to handle special characters

### DIFF
--- a/lib/mocha/backtrace_filter.rb
+++ b/lib/mocha/backtrace_filter.rb
@@ -3,11 +3,11 @@ module Mocha
     LIB_DIRECTORY = File.expand_path(File.join(File.dirname(__FILE__), '..')) + File::SEPARATOR
 
     def initialize(lib_directory = LIB_DIRECTORY)
-      @path_pattern = Regexp.new(lib_directory)
+      @lib_directory = lib_directory
     end
 
     def filtered(backtrace)
-      backtrace.reject { |location| @path_pattern.match(File.expand_path(location)) }
+      backtrace.reject { |location| File.expand_path(location).start_with?(@lib_directory) }
     end
   end
 end

--- a/test/unit/backtrace_filter_test.rb
+++ b/test/unit/backtrace_filter_test.rb
@@ -14,4 +14,11 @@ class BacktraceFilterTest < Mocha::TestCase
   def test_should_determine_path_for_mocha_lib_directory
     assert_match Regexp.new('/lib/$'), BacktraceFilter::LIB_DIRECTORY
   end
+
+  def test_should_handle_special_characters
+    lib_directory = '/tmp/bundle/ruby/3.2.0+3/gems/mocha-2.0.2/lib/'
+    filter = BacktraceFilter.new(lib_directory)
+    backtrace = ['/keep/me', "#{lib_directory}mocha/deprecation.rb"]
+    assert_equal ['/keep/me'], filter.filtered(backtrace)
+  end
 end


### PR DESCRIPTION
We do regular testing of ruby-head, so our gem paths include a `+` which has a special meaning in Regexp.

But either way the regexp capability doesn't seem used, so it's much simpler to just assert the path starts with the lib dir.

cc @floehopper @wasabigeek 