### PR TITLE
Rubocop: resolve Style/EachWithObject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ Style/Alias:
 Style/Documentation:
   Enabled: false
 
-# Enumerable#each_with_object only available since Ruby v1.9
-Style/EachWithObject:
-  Enabled: false
-
 # Kernel#__dir__ has only been available since Ruby v2.0
 Style/ExpandPathArguments:
   Enabled: false

--- a/lib/mocha/debug.rb
+++ b/lib/mocha/debug.rb
@@ -1,12 +1,11 @@
+require 'set'
+
 module Mocha
   module Debug
-    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').inject({}) do |hash, key|
-      hash[key] = true
-      hash
-    end.freeze
+    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').to_set.freeze
 
     def self.puts(message)
-      warn(message) if OPTIONS['debug']
+      warn(message) if OPTIONS.include?('debug')
     end
   end
 end


### PR DESCRIPTION
Ruby 1.9 is the lowest supported version, so this is always available.

But the actual implementation was using a Hash lookup for the keys, but ignored the values. Set is a better datatype for this.

The change has been tested on the command line:
```
~/code/mocha$ bundle exec ruby -e 'require "mocha"; require "mocha/debug"; Mocha::Debug.puts("test")'
~/code/mocha$ MOCHA_OPTIONS="foo,debug,bar" bundle exec ruby -e 'require "mocha"; require "mocha/debug"; Mocha::Debug.puts("test")'
test
~/code/mocha$ 
```