### PR TITLE
Simplify storage of MOCHA_OPTIONS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ Style/Alias:
 Style/Documentation:
   Enabled: false
 
-# Enumerable#each_with_object only available since Ruby v1.9
-Style/EachWithObject:
-  Enabled: false
-
 # Kernel#__dir__ has only been available since Ruby v2.0
 Style/ExpandPathArguments:
   Enabled: false

--- a/lib/mocha/debug.rb
+++ b/lib/mocha/debug.rb
@@ -1,12 +1,9 @@
 module Mocha
   module Debug
-    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').inject({}) do |hash, key|
-      hash[key] = true
-      hash
-    end.freeze
+    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').freeze
 
     def self.puts(message)
-      warn(message) if OPTIONS['debug']
+      warn(message) if OPTIONS.include?('debug')
     end
   end
 end


### PR DESCRIPTION
This has only ever supported `debug`, `verbose` & `skip_integration` options. However, it currently only supports `debug`.

Storing these options in a `Hash` was always a bit over the top and since it was the only reason we needed to disabled the `Style/EachWithObject` Rubocop rule, it seems more sensible to use an `Array` instead.

I don't think that the "uniqueness" of the options in the comma-separated list was ever a motivation for storing them in a `Hash` and so an `Array` (rather than a `Set`) seems good enough.

Supersedes #599.