### PR TITLE
Add Ruby v3.2 to CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
                 - ruby:2.7
                 - ruby:3.0
                 - ruby:3.1
-                - ruby:3.2.0-preview3
+                - ruby:3.2
                 - ruby:latest
                 - jruby:9.3.9.0
               gemfile:


### PR DESCRIPTION
Ruby v3.2.0 was [recently released][1].

However, it's not yet available on CircleCI - see https://github.com/CircleCI-Public/cimg-ruby/pull/105.

[1]: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/