### PR TITLE
Rubocop: enable Style/FormatStringToken cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,10 +15,6 @@ Style/Documentation:
 Style/ExpandPathArguments:
   Enabled: false
 
-# Kernel#format has only supported named references since Ruby v1.9
-Style/FormatStringToken:
-  EnforcedStyle: unannotated
-
 # I'm not keen on this cop, because it's easy to miss the conditional
 # I think the results are particularly unhelpful when Metrics/LineLength is big
 Style/IfUnlessModifier:

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -674,7 +674,7 @@ module Mocha
     def inspect
       address = __id__ * 2
       address += 0x100000000 if address < 0
-      "#<Expectation:0x#{format('%x', address)} #{mocha_inspect} >"
+      "#<Expectation:0x#{format('%<address>x', address: address)} #{mocha_inspect} >"
     end
 
     # @private

--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -6,7 +6,7 @@ module Mocha
       def mocha_inspect
         address = __id__ * 2
         address += 0x100000000 if address < 0
-        inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%x', address)}>" : inspect
+        inspect =~ /#</ ? "#<#{self.class}:0x#{Kernel.format('%<address>x', address: address)}>" : inspect
       end
     end
 

--- a/lib/mocha/names.rb
+++ b/lib/mocha/names.rb
@@ -37,7 +37,7 @@ module Mocha
     def mocha_inspect
       address = @mock.__id__ * 2
       address += 0x100000000 if address < 0
-      "#<Mock:0x#{format('%x', address)}>"
+      "#<Mock:0x#{format('%<address>x', address: address)}>"
     end
   end
 end


### PR DESCRIPTION
Since support for Ruby 1.8 has been dropped.