### PR TITLE
Un-pin JRuby in CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: ruby --version
       - when:
           condition:
-            equal: [ "jruby:9.3.9.0", << parameters.docker-image >>]
+            equal: [ "jruby:latest", << parameters.docker-image >>]
           steps:
             - run: apt-get update
             - run: apt-get install -y git
@@ -82,7 +82,7 @@ workflows:
                 - ruby:3.1
                 - ruby:3.2
                 - ruby:latest
-                - jruby:9.3.9.0
+                - jruby:latest
               gemfile:
                 - Gemfile
       - build:


### PR DESCRIPTION
Revert the change in b8e6d064b8b9bfeb37d6534bbb4e37856dfec5b7 so CircleCI builds pick up the latest JRuby version again.

This is waiting on the JRuby fix referenced in #591 which is going to be released in JRuby v9.4.1.0. The CircleCI build for this PR will fail until the fix is released.