### PR TITLE
Use Ruby v1.9 Hash syntax in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ class MiscExampleTest < Test::Unit::TestCase
   end
 
   def test_stubbing_instance_methods_on_real_objects
-    prices = [stub(:pence => 1000), stub(:pence => 2000)]
+    prices = [stub(pence: 1000), stub(pence: 2000)]
     product = Product.new
     product.stubs(:prices).returns(prices)
     assert_equal [1000, 2000], product.prices.collect {|p| p.pence}
@@ -170,7 +170,7 @@ class MiscExampleTest < Test::Unit::TestCase
   end
 
   def test_shortcuts
-    object = stub(:method1 => :result1, :method2 => :result2)
+    object = stub(method1: :result1, method2: :result2)
     assert_equal :result1, object.method1
     assert_equal :result2, object.method2
   end

--- a/lib/mocha/api.rb
+++ b/lib/mocha/api.rb
@@ -60,7 +60,7 @@ module Mocha
     #
     # @example Using expected_methods_vs_return_values Hash to setup expectations.
     #   def test_motor_starts_and_stops
-    #     motor = mock('motor', :start => true, :stop => true)
+    #     motor = mock('motor', start: true, stop: true)
     #     assert motor.start
     #     assert motor.stop
     #     # an error will be raised unless both Motor#start and Motor#stop have been called
@@ -88,7 +88,7 @@ module Mocha
     #
     # @example Using stubbed_methods_vs_return_values Hash to setup stubbed methods.
     #   def test_motor_starts_and_stops
-    #     motor = stub('motor', :start => true, :stop => true)
+    #     motor = stub('motor', start: true, stop: true)
     #     assert motor.start
     #     assert motor.stop
     #     # an error will not be raised even if either Motor#start or Motor#stop has not been called
@@ -115,7 +115,7 @@ module Mocha
     #
     # @example Ignore invocations of irrelevant methods.
     #   def test_motor_stops
-    #     motor = stub_everything('motor', :stop => true)
+    #     motor = stub_everything('motor', stop: true)
     #     assert_nil motor.irrelevant_method_1 # => no error raised
     #     assert_nil motor.irrelevant_method_2 # => no error raised
     #     assert motor.stop

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -100,7 +100,7 @@ module Mocha
     #
     # @example Setup multiple expectations using +expected_methods_vs_return_values+.
     #   object = mock()
-    #   object.expects(:expected_method_one => :result_one, :expected_method_two => :result_two)
+    #   object.expects(expected_method_one: :result_one, expected_method_two: :result_two)
     #
     #   # is exactly equivalent to
     #
@@ -138,7 +138,7 @@ module Mocha
     #
     # @example Setup multiple expectations using +stubbed_methods_vs_return_values+.
     #   object = mock()
-    #   object.stubs(:stubbed_method_one => :result_one, :stubbed_method_two => :result_two)
+    #   object.stubs(stubbed_method_one: :result_one, stubbed_method_two: :result_two)
     #
     #   # is exactly equivalent to
     #

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -59,7 +59,7 @@ module Mocha
     #
     # @example Setting up multiple expectations on a non-mock object.
     #   product = Product.new
-    #   product.expects(:valid? => true, :save => true)
+    #   product.expects(valid?: true, save: true)
     #
     #   # exactly equivalent to
     #
@@ -108,7 +108,7 @@ module Mocha
     #
     # @example Setting up multiple stubbed methods on a non-mock object.
     #   product = Product.new
-    #   product.stubs(:valid? => true, :save => true)
+    #   product.stubs(valid?: true, save: true)
     #
     #   # exactly equivalent to
     #

--- a/lib/mocha/parameter_matchers/base.rb
+++ b/lib/mocha/parameter_matchers/base.rb
@@ -21,12 +21,12 @@ module Mocha
       # @example Alternative ways to combine matchers with a logical AND.
       #   object = mock()
       #   object.expects(:run).with(all_of(has_key(:foo), has_key(:bar)))
-      #   object.run(:foo => 'foovalue', :bar => 'barvalue')
+      #   object.run(foo: 'foovalue', bar: 'barvalue')
       #
       #   # is exactly equivalent to
       #
       #   object.expects(:run).with(has_key(:foo) & has_key(:bar))
-      #   object.run(:foo => 'foovalue', :bar => 'barvalue)
+      #   object.run(foo: 'foovalue', bar: 'barvalue)
       def &(other)
         AllOf.new(self, other)
       end
@@ -45,12 +45,12 @@ module Mocha
       # @example Alternative ways to combine matchers with a logical OR.
       #   object = mock()
       #   object.expects(:run).with(any_of(has_key(:foo), has_key(:bar)))
-      #   object.run(:foo => 'foovalue')
+      #   object.run(foo: 'foovalue')
       #
       #   # is exactly equivalent to
       #
       #   object.expects(:run).with(has_key(:foo) | has_key(:bar))
-      #   object.run(:foo => 'foovalue')
+      #   object.run(foo: 'foovalue')
       #
       # @example Using an explicit {Equals} matcher in combination with {#|}.
       #   object.expects(:run).with(equals(1) | equals(2))

--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -24,7 +24,7 @@ module Mocha
     # @example Actual parameter includes item which matches nested matcher.
     #   object = mock()
     #   object.expects(:method_1).with(includes(has_key(:key)))
-    #   object.method_1(['foo', 'bar', {:key => 'baz'}])
+    #   object.method_1(['foo', 'bar', {key: 'baz'}])
     #   # no error raised
     #
     # @example Actual parameter does not include item matching nested matcher.
@@ -44,11 +44,11 @@ module Mocha
     # @example Actual parameter is a Hash including the given key.
     #   object = mock()
     #   object.expects(:method_1).with(includes(:bar))
-    #   object.method_1({:foo => 1, :bar => 2})
+    #   object.method_1({foo: 1, bar: 2})
     #   # no error raised
     #
     # @example Actual parameter is a Hash without the given key.
-    #   object.method_1({:foo => 1, :baz => 2})
+    #   object.method_1({foo: 1, baz: 2})
     #   # error raised, because hash does not include key 'bar'
     #
     # @example Actual parameter is a Hash with a key matching the given matcher.

--- a/lib/mocha/parameter_matchers/responds_with.rb
+++ b/lib/mocha/parameter_matchers/responds_with.rb
@@ -31,7 +31,7 @@ module Mocha
     #
     # @example Actual parameter responds with "FOO" when :upcase is invoked and "oof" when :reverse is invoked.
     #   object = mock()
-    #   object.expects(:method_1).with(responds_with(:upcase => "FOO", :reverse => "oof"))
+    #   object.expects(:method_1).with(responds_with(upcase: "FOO", reverse: "oof"))
     #   object.method_1("foo")
     #   # no error raised, because "foo".upcase == "FOO" and "foo".reverse == "oof"
     def responds_with(*options)


### PR DESCRIPTION
We updated the code to use Ruby v1.9 Hash syntax in #598. This brings the docs into line with that change.

Fixes #625.