### PR TITLE
Add block syntax for sequences

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -114,6 +114,7 @@ module Mocha
         method_name = args.shift
         ensure_method_not_already_defined(method_name)
         expectation = Expectation.new(self, method_name, backtrace)
+        expectation.in_sequence(@mockery.sequences.last) if @mockery.sequences.any?
         expectation.returns(args.shift) unless args.empty?
         @expectations.add(expectation)
       end
@@ -153,6 +154,7 @@ module Mocha
         ensure_method_not_already_defined(method_name)
         expectation = Expectation.new(self, method_name, backtrace)
         expectation.at_least(0)
+        expectation.in_sequence(@mockery.sequences.last) if @mockery.sequences.any?
         expectation.returns(args.shift) unless args.empty?
         @expectations.add(expectation)
       end

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -109,6 +109,10 @@ module Mocha
       @state_machines ||= []
     end
 
+    def sequences
+      @sequences ||= []
+    end
+
     def mocha_inspect
       message = ''
       message << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if unsatisfied_expectations.any?

--- a/test/acceptance/sequence_block_test.rb
+++ b/test/acceptance/sequence_block_test.rb
@@ -1,0 +1,182 @@
+require File.expand_path('../acceptance_test_helper', __FILE__)
+
+class SequenceBlockTest < Mocha::TestCase
+  include AcceptanceTest
+
+  def setup
+    setup_acceptance_test
+  end
+
+  def teardown
+    teardown_acceptance_test
+  end
+
+  def test_should_constrain_invocations_to_occur_in_expected_order
+    test_result = run_as_test do
+      mock = mock()
+
+      sequence('one') do
+        mock.expects(:first)
+        mock.expects(:second)
+      end
+
+      mock.second
+      mock.first
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_allow_invocations_in_sequence
+    test_result = run_as_test do
+      mock = mock()
+
+      sequence('one') do
+        mock.expects(:first)
+        mock.expects(:second)
+      end
+
+      mock.first
+      mock.second
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_constrain_invocations_to_occur_in_expected_order_even_if_expected_on_different_mocks
+    test_result = run_as_test do
+      mock_one = mock('1')
+      mock_two = mock('2')
+
+      sequence('one') do
+        mock_one.expects(:first)
+        mock_two.expects(:second)
+      end
+
+      mock_two.second
+      mock_one.first
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_allow_invocations_in_sequence_even_if_expected_on_different_mocks
+    test_result = run_as_test do
+      mock_one = mock('1')
+      mock_two = mock('2')
+
+      sequence('one') do
+        mock_one.expects(:first)
+        mock_two.expects(:second)
+      end
+
+      mock_one.first
+      mock_two.second
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_constrain_invocations_to_occur_in_expected_order_even_if_expected_on_partial_mocks
+    test_result = run_as_test do
+      partial_mock_one = '1'
+      partial_mock_two = '2'
+
+      sequence('one') do
+        partial_mock_one.expects(:first)
+        partial_mock_two.expects(:second)
+      end
+
+      partial_mock_two.second
+      partial_mock_one.first
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_allow_invocations_in_sequence_even_if_expected_on_partial_mocks
+    test_result = run_as_test do
+      partial_mock_one = '1'
+      partial_mock_two = '2'
+
+      sequence('one') do
+        partial_mock_one.expects(:first)
+        partial_mock_two.expects(:second)
+      end
+
+      partial_mock_one.first
+      partial_mock_two.second
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_allow_stub_expectations_to_be_skipped_in_sequence
+    test_result = run_as_test do
+      mock = mock()
+
+      sequence('one') do
+        mock.expects(:first)
+        mock.stubs(:second)
+        mock.expects(:third)
+      end
+
+      mock.first
+      mock.third
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_regard_nested_sequences_as_independent_of_each_other
+    test_result = run_as_test do
+      mock = mock()
+
+      sequence('one') do
+        mock.expects(:first)
+        mock.expects(:second)
+
+        sequence('two') do
+          mock.expects(:third)
+          mock.expects(:fourth)
+        end
+      end
+
+      mock.first
+      mock.third
+      mock.second
+      mock.fourth
+    end
+    assert_passed(test_result)
+  end
+
+  def test_should_include_sequence_in_failure_message
+    test_result = run_as_test do
+      mock = mock()
+
+      sequence('one') do
+        mock.expects(:first)
+        mock.expects(:second)
+      end
+
+      mock.second
+      mock.first
+    end
+    assert_failed(test_result)
+    assert_match Regexp.new(%(in sequence "one")), test_result.failures.first.message
+  end
+
+  def test_should_allow_expectations_to_be_in_more_than_one_sequence
+    test_result = run_as_test do
+      mock = mock()
+      sequence_one = sequence('one')
+
+      mock.expects(:first).in_sequence(sequence_one)
+
+      sequence('two') do
+        mock.expects(:second)
+        mock.expects(:third).in_sequence(sequence_one)
+      end
+
+      mock.first
+      mock.third
+      mock.second
+    end
+    assert_failed(test_result)
+    assert_match Regexp.new(%(in sequence "one")), test_result.failures.first.message
+    assert_match Regexp.new(%(in sequence "two")), test_result.failures.first.message
+  end
+end

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -2,6 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/ruby_version'
 require 'method_definer'
 require 'mocha/class_methods'
+require 'mocha/mockery'
 require 'mocha/mock'
 require 'mocha/any_instance_method'
 
@@ -130,6 +131,6 @@ class AnyInstanceMethodTest < Mocha::TestCase
   private
 
   def build_mock
-    Mock.new(nil)
+    Mock.new(Mockery.new)
   end
 end

--- a/test/unit/central_test.rb
+++ b/test/unit/central_test.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 require 'mocha/central'
+require 'mocha/mockery'
 require 'mocha/mock'
 
 class CentralTest < Mocha::TestCase
@@ -93,6 +94,6 @@ class CentralTest < Mocha::TestCase
   private
 
   def build_mock
-    Mock.new(nil)
+    Mock.new(Mockery.new)
   end
 end

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -2,6 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/ruby_version'
 require 'method_definer'
 require 'mocha/class_methods'
+require 'mocha/mockery'
 require 'mocha/mock'
 
 require 'mocha/instance_method'
@@ -238,6 +239,6 @@ class InstanceMethodTest < Mocha::TestCase
   private
 
   def build_mock
-    Mock.new(nil)
+    Mock.new(Mockery.new)
   end
 end

--- a/test/unit/mock_test.rb
+++ b/test/unit/mock_test.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/macos_version'
+require 'mocha/mockery'
 require 'mocha/mock'
 require 'mocha/expectation_error_factory'
 require 'set'
@@ -350,6 +351,6 @@ class MockTest < Mocha::TestCase
   private
 
   def build_mock
-    Mock.new(nil)
+    Mock.new(Mockery.new)
   end
 end


### PR DESCRIPTION
All expectations defined within the block are constrained by the sequence.

For example, the following requires that `Egg#crack` must be called 1st, `Egg#fry` must be called 2nd, and `Egg#eat` must be called 3rd:

```ruby
egg = mock('egg')
sequence('breakfast') do
  egg.expects(:crack)
  egg.expects(:fry)
  egg.expects(:eat)
end
```

Closes #61 (only 11 years late! 😂)