### PR TITLE
Include the original test name in expired stub error messages

### DIFF
--- a/lib/mocha/hooks.rb
+++ b/lib/mocha/hooks.rb
@@ -35,8 +35,14 @@ module Mocha
     # Resets Mocha after a test (only for use by authors of test libraries).
     #
     # This method should be called after each individual test has finished (including after any "teardown" code).
-    def mocha_teardown
-      Mockery.teardown
+    def mocha_teardown(origin = mocha_test_name)
+      Mockery.teardown(origin)
+    end
+
+    # Returns a string representing the unit test name, to be included in some Mocha
+    # to help track down potential bugs.
+    def mocha_test_name
+      nil
     end
   end
 end

--- a/lib/mocha/integration/minitest/adapter.rb
+++ b/lib/mocha/integration/minitest/adapter.rb
@@ -46,6 +46,21 @@ module Mocha
           super
           mocha_teardown
         end
+
+        # @private
+        def mocha_test_name
+          if respond_to?(:name)
+            test_name = name
+          elsif respond_to?(:__name__) # Older minitest
+            test_name = __name__
+          end
+
+          if test_name
+            "#{self.class.name}##{test_name}"
+          else
+            self.class.name
+          end
+        end
       end
     end
   end

--- a/lib/mocha/integration/test_unit/adapter.rb
+++ b/lib/mocha/integration/test_unit/adapter.rb
@@ -38,6 +38,11 @@ module Mocha
         private
 
         # @private
+        def mocha_test_name
+          name
+        end
+
+        # @private
         def handle_mocha_expectation_error(exception)
           return false unless exception.is_a?(Mocha::ExpectationError)
           problem_occurred

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -343,8 +343,8 @@ module Mocha
     end
 
     # @private
-    def __expire__
-      @expired = true
+    def __expire__(origin)
+      @expired = origin || true
     end
 
     # @private
@@ -393,8 +393,10 @@ module Mocha
     def check_expiry
       return unless @expired
 
+      origin = @expired == true ? 'one test' : @expired
+
       sentences = [
-        "#{mocha_inspect} was instantiated in one test but it is receiving invocations within another test.",
+        "#{mocha_inspect} was instantiated in #{origin} but it is receiving invocations within another test.",
         'This can lead to unintended interactions between tests and hence unexpected test failures.',
         'Ensure that every test correctly cleans up any state that it introduces.'
       ]

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -48,8 +48,8 @@ module Mocha
         instance.verify(*args)
       end
 
-      def teardown
-        instance.teardown
+      def teardown(origin = nil)
+        instance.teardown(origin)
       ensure
         @instances.pop
       end
@@ -91,9 +91,9 @@ module Mocha
       end
     end
 
-    def teardown
+    def teardown(origin = nil)
       stubba.unstub_all
-      mocks.each(&:__expire__)
+      mocks.each { |m| m.__expire__(origin) }
       reset
     end
 

--- a/test/acceptance/mock_test.rb
+++ b/test/acceptance/mock_test.rb
@@ -159,7 +159,7 @@ class MockTest < Mocha::TestCase
     reuse_mock_test_result = run_as_test do
       Foo.logger.expects(:log).with('Foo was here')
       e = assert_raises(Mocha::StubbingError) { Foo.new.use_the_mock }
-      assert e.message.include?('#<Mock:Logger> was instantiated in one test but it is receiving invocations within another test.')
+      assert e.message.include?('#<Mock:Logger> was instantiated in FakeTest#test_me but it is receiving invocations within another test.')
       assert e.message.include?('This can lead to unintended interactions between tests and hence unexpected test failures.')
       assert e.message.include?('Ensure that every test correctly cleans up any state that it introduces.')
     end

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -7,10 +7,14 @@ module TestRunner
     run_as_tests(test_me: block)
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def run_as_tests(methods = {})
     base_class = Mocha::TestCase
     test_class = Class.new(base_class) do
+      def self.name;
+        'FakeTest'
+      end
+
       include Assertions
 
       methods.each do |(method_name, proc)|
@@ -45,7 +49,7 @@ module TestRunner
 
     test_result
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def assert_passed(test_result)
     flunk "Test errored unexpectedly with message: #{test_result.errors.map(&:exception)}" if test_result.error_count > 0

--- a/test/unit/hooks_test.rb
+++ b/test/unit/hooks_test.rb
@@ -14,7 +14,7 @@ class HooksTest < Mocha::TestCase
   class FakeMockery
     def verify(*args); end
 
-    def teardown
+    def teardown(_origin = nil)
       raise 'exception within Mockery#teardown'
     end
   end


### PR DESCRIPTION
It is currently very hard to track down such leaked stubs, when they happen, as they might be created in one test and cause an exception dozens of tests later.

By including the name of the test that invalidated them, it makes the debugging process a bit easier.

Note, I made `setup` also accept the current test instance purely for consistency with `teardown` but it's not strictly necessary.