### PR TITLE
Drop support for Ruby v2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ workflows:
           matrix:
             parameters:
               docker-image:
-                - ruby:2.0
                 - ruby:2.1
                 - ruby:2.2
                 - ruby:2.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2 # closest to required_ruby_version of '>= 2.0'
+  TargetRubyVersion: 2.2 # closest to required_ruby_version of '>= 2.1'
 
 # Even the reference in the documentation suggests that you should prefer
 # `alias_method` vs `alias`, so I don't understand why that isn't the default.

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name = 'mocha'
   s.version = Mocha::VERSION
   s.licenses = ['MIT', 'BSD-2-Clause']
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
 
   s.authors = ['James Mead']
   s.description = 'Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.'


### PR DESCRIPTION
Recently the image that the CircleCI builds were using has [stopped working][1]. I don't have time to dig into that and in any case Ruby v2.0 has been [EOL since 2016-02-24][2], so regrettably I'm going to drop support.

Closes #642.

[1]: https://app.circleci.com/pipelines/github/freerange/mocha/494/workflows/8d9720cf-6dd7-4c4b-a072-4d0978edbb25/jobs/7120
[2]: https://www.ruby-lang.org/en/downloads/branches/