### PR TITLE
Fix nested parameter matching for keyword arguments

### DIFF
--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -13,7 +13,8 @@ module Mocha
 
       def matches?(available_parameters)
         parameter, is_last_parameter = extract_parameter(available_parameters)
-        return false unless parameter == @value
+
+        return false unless HasEntries.new(@value).matches?([parameter])
 
         if is_last_parameter && !same_type_of_hash?(parameter, @value)
           return false if Mocha.configuration.strict_keyword_argument_matching?

--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -189,6 +189,15 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  def test_should_match_keyword_args_with_nested_matcher
+    test_result = run_as_test do
+      mock = mock()
+      mock.expects(:method).with(key: is_a(Integer))
+      mock.method(key: 42)
+    end
+    assert_passed(test_result)
+  end
+
   def test_should_match_last_positional_hash_with_hash_matcher
     test_result = run_as_test do
       mock = mock()

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -35,6 +35,11 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })]) # rubocop:disable Style/BracesAroundHashParameters
   end
 
+  def test_should_match_keyword_args_with_matchers_using_keyword_args
+    matcher = Hash.ruby2_keywords_hash({ key_1: is_a(String), key_2: is_a(Integer) }).to_matcher # rubocop:disable Style/BracesAroundHashParameters
+    assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 'foo', key_2: 2 })]) # rubocop:disable Style/BracesAroundHashParameters
+  end
+
   def test_should_match_hash_arg_with_keyword_args_but_display_deprecation_warning_if_appropriate
     expectation = Mocha::Expectation.new(self, :foo); execution_point = ExecutionPoint.current
     matcher = Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }).to_matcher(expectation) # rubocop:disable Style/BracesAroundHashParameters


### PR DESCRIPTION
Previously, parameter matching for keyword arguments only worked when the matchers specified the exact value of each argument. This change means that we make use of the `HasEntries` matcher to ensure that any matchers for each of the keyword arguments are also taken into account.

Fixes #647.