### PR TITLE
Improve rendering of keyword arguments

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -19,8 +19,19 @@ module Mocha
 
     module HashMethods
       def mocha_inspect
-        unwrapped = collect { |key, value| "#{key.mocha_inspect} => #{value.mocha_inspect}" }.join(', ')
-        Hash.ruby2_keywords_hash?(self) ? unwrapped : "{#{unwrapped}}"
+        if Hash.ruby2_keywords_hash?(self)
+          collect do |key, value|
+            case key
+            when Symbol
+              "#{key}: #{value.mocha_inspect}"
+            else
+              "#{key.mocha_inspect} => #{value.mocha_inspect}"
+            end
+          end.join(', ')
+        else
+          unwrapped = collect { |key, value| "#{key.mocha_inspect} => #{value.mocha_inspect}" }.join(', ')
+          "{#{unwrapped}}"
+        end
       end
     end
 

--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -25,7 +25,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       end
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
-        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (:key => 42)"
+        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
     end
@@ -55,7 +55,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       end
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
-        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (:key => 42)"
+        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
     end
@@ -104,7 +104,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected positional hash ({:key => 42})"
-        assert_includes Mocha::Deprecation.messages.last, 'but received keyword arguments (:key => 42)'
+        assert_includes Mocha::Deprecation.messages.last, 'but received keyword arguments (key: 42)'
       end
     end
     assert_passed(test_result)
@@ -133,7 +133,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       end
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
-        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (:key => 42)"
+        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
     end

--- a/test/acceptance/positional_and_keyword_has_inspect_test.rb
+++ b/test/acceptance/positional_and_keyword_has_inspect_test.rb
@@ -30,9 +30,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
     end
     if Mocha::RUBY_V27_PLUS
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(foo: 42)'
       ], test_result.failure_message_lines
     else
       assert_equal [
@@ -64,9 +64,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
     end
     if Mocha::RUBY_V27_PLUS
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(1, key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, foo: 42)'
       ], test_result.failure_message_lines
     else
       assert_equal [
@@ -102,9 +102,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
         end
       end
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(foo: 42)'
       ], test_result.failure_message_lines
     end
 
@@ -132,9 +132,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
         end
       end
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(1, key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, foo: 42)'
       ], test_result.failure_message_lines
     end
   end

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -45,7 +45,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
     message = Mocha::Deprecation.messages.last
     location = "#{execution_point.file_name}:#{execution_point.line_number}:in `new'"
-    assert_includes message, "Expectation defined at #{location} expected keyword arguments (:key_1 => 1, :key_2 => 2)"
+    assert_includes message, "Expectation defined at #{location} expected keyword arguments (key_1: 1, key_2: 2)"
     assert_includes message, 'but received positional hash ({:key_1 => 1, :key_2 => 2})'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
     assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
@@ -62,7 +62,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     message = Mocha::Deprecation.messages.last
     location = "#{execution_point.file_name}:#{execution_point.line_number}:in `new'"
     assert_includes message, "Expectation defined at #{location} expected positional hash ({:key_1 => 1, :key_2 => 2})"
-    assert_includes message, 'but received keyword arguments (:key_1 => 1, :key_2 => 2)'
+    assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
     assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
   end
@@ -119,7 +119,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
       message = Mocha::Deprecation.messages.last
       assert_includes message, 'Expectation expected positional hash ({:key_1 => 1, :key_2 => 2})'
-      assert_includes message, 'but received keyword arguments (:key_1 => 1, :key_2 => 2)'
+      assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     end
   end
 end


### PR DESCRIPTION
Using the `=>` for them is a bit confusing in my opinion.