### PR TITLE
Improve rendering of keyword arguments

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -19,8 +19,19 @@ module Mocha
 
     module HashMethods
       def mocha_inspect
-        unwrapped = collect { |key, value| "#{key.mocha_inspect} => #{value.mocha_inspect}" }.join(', ')
-        Hash.ruby2_keywords_hash?(self) ? unwrapped : "{#{unwrapped}}"
+        if Hash.ruby2_keywords_hash?(self)
+          collect do |key, value|
+            case key
+            when Symbol
+              "#{key}: #{value.mocha_inspect}"
+            else
+              "#{key.mocha_inspect} => #{value.mocha_inspect}"
+            end
+          end.join(', ')
+        else
+          unwrapped = collect { |key, value| "#{key.mocha_inspect} => #{value.mocha_inspect}" }.join(', ')
+          "{#{unwrapped}}"
+        end
       end
     end
 

--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -25,7 +25,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       end
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
-        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (:key => 42)"
+        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
     end
@@ -55,7 +55,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       end
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
-        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (:key => 42)"
+        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
     end
@@ -104,7 +104,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected positional hash ({:key => 42})"
-        assert_includes Mocha::Deprecation.messages.last, 'but received keyword arguments (:key => 42)'
+        assert_includes Mocha::Deprecation.messages.last, 'but received keyword arguments (key: 42)'
       end
     end
     assert_passed(test_result)
@@ -133,7 +133,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
       end
       if Mocha::RUBY_V27_PLUS
         location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
-        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (:key => 42)"
+        assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
     end

--- a/test/acceptance/positional_and_keyword_has_inspect_test.rb
+++ b/test/acceptance/positional_and_keyword_has_inspect_test.rb
@@ -30,9 +30,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
     end
     if Mocha::RUBY_V27_PLUS
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(foo: 42)'
       ], test_result.failure_message_lines
     else
       assert_equal [
@@ -64,9 +64,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
     end
     if Mocha::RUBY_V27_PLUS
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(1, key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, foo: 42)'
       ], test_result.failure_message_lines
     else
       assert_equal [
@@ -102,9 +102,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
         end
       end
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(:key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(:foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(foo: 42)'
       ], test_result.failure_message_lines
     end
 
@@ -132,9 +132,9 @@ class PositionalAndKeywordHashInspectTest < Mocha::TestCase
         end
       end
       assert_equal [
-        'unexpected invocation: #<Mock:mock>.method(1, :key => 42)',
+        'unexpected invocation: #<Mock:mock>.method(1, key: 42)',
         'unsatisfied expectations:',
-        '- expected exactly once, invoked never: #<Mock:mock>.method(1, :foo => 42)'
+        '- expected exactly once, invoked never: #<Mock:mock>.method(1, foo: 42)'
       ], test_result.failure_message_lines
     end
   end

--- a/test/unit/hash_inspect_test.rb
+++ b/test/unit/hash_inspect_test.rb
@@ -8,9 +8,14 @@ class HashInspectTest < Mocha::TestCase
   end
 
   if Mocha::RUBY_V27_PLUS
-    def test_should_return_unwrapped_hash_when_keyword_hash
+    def test_should_return_unwrapped_keyword_style_hash_when_keyword_hash
       hash = Hash.ruby2_keywords_hash(a: true, b: false)
-      assert_equal ':a => true, :b => false', hash.mocha_inspect
+      assert_equal 'a: true, b: false', hash.mocha_inspect
+    end
+
+    def test_should_return_unwrapped_hash_when_keyword_hash_keys_are_not_symbols
+      hash = Hash.ruby2_keywords_hash('a' => true, 'b' => false)
+      assert_equal '"a" => true, "b" => false', hash.mocha_inspect
     end
   end
 

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -50,7 +50,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
     message = Mocha::Deprecation.messages.last
     location = "#{execution_point.file_name}:#{execution_point.line_number}:in `new'"
-    assert_includes message, "Expectation defined at #{location} expected keyword arguments (:key_1 => 1, :key_2 => 2)"
+    assert_includes message, "Expectation defined at #{location} expected keyword arguments (key_1: 1, key_2: 2)"
     assert_includes message, 'but received positional hash ({:key_1 => 1, :key_2 => 2})'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
     assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
@@ -67,7 +67,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     message = Mocha::Deprecation.messages.last
     location = "#{execution_point.file_name}:#{execution_point.line_number}:in `new'"
     assert_includes message, "Expectation defined at #{location} expected positional hash ({:key_1 => 1, :key_2 => 2})"
-    assert_includes message, 'but received keyword arguments (:key_1 => 1, :key_2 => 2)'
+    assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
     assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
   end
@@ -124,7 +124,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
       message = Mocha::Deprecation.messages.last
       assert_includes message, 'Expectation expected positional hash ({:key_1 => 1, :key_2 => 2})'
-      assert_includes message, 'but received keyword arguments (:key_1 => 1, :key_2 => 2)'
+      assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     end
   end
 end


### PR DESCRIPTION
Using the `=>` for them was a bit confusing.

The string representation of the keyword hash `{a: true, b: 'c'}` is now 'a: true, b: "c"' instead of ':a => true, :b => "c"'.

One reason (perhaps the only reason?) we didn't make this change when we introduced keyword argument matching was the theoretical edge case where a keyword-style hash could have a non-symbol key.

However, the changes in this commit handle that scenario while still rendering a less-confusing string representation of a keyword hash in the most common scenario where the keys are all symbols.

I've taken @casoerisfine's changes from #649 and added some unit test coverage and expanded the commit note.