### PR TITLE
Don't trust `Object#is_a?` in presence of Mocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,11 @@ Style/WhileUntilModifier:
 Style/AccessModifierDeclarations:
   Enabled: false
 
+# `Module#===` is useful in presence of objects such as mocks
+# that may have a `is_a?` implementation that lies.
+Style/CaseEquality:
+  Enabled: false
+
 # This is useful when using `ExecutionPoint.current` to make tests more robust
 Style/Semicolon:
   Enabled: false

--- a/lib/mocha/parameter_matchers/instance_methods.rb
+++ b/lib/mocha/parameter_matchers/instance_methods.rb
@@ -8,9 +8,9 @@ module Mocha
     module InstanceMethods
       # @private
       def to_matcher(expectation: nil, top_level: false)
-        if is_a?(Base)
+        if Base === self
           self
-        elsif is_a?(Hash) && top_level
+        elsif Hash === self && top_level
           Mocha::ParameterMatchers::PositionalOrKeywordHash.new(self, expectation)
         else
           Mocha::ParameterMatchers::Equals.new(self)


### PR DESCRIPTION
e9de64e493508457163a060220d3052d031af11f broke quite a few of our tests because since we use Sorbet, some of our mocks have to stub `is_a?` to comply with runtime type checking.

To be fair, our stubs were incorrect and after fixing them it's fine but the failure was happening deep in Mocha and I think it could be handled better.

Here's a small repro of the problem we ran into:

```ruby

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "minitest"
  gem "mocha"
end

require "minitest/autorun"
require "mocha/minitest"

module TypedAPI
  def self.call(user)
    raise TypeError, "Not a user" unless user.is_a?(User)
  end
end

class User
end

class BugTest < Minitest::Test
  def test_expect_mock
    user = mock("user")
    user.responds_like_instance_of(User)
    # This is wrong and shouldn't even work, but somehow it did
    # until now.
    user.stubs(:is_a? => User)
    TypedAPI.expects(:something).with(user)
    TypedAPI.call(user)
    TypedAPI.something(user)
  end
end
```

```
NoMethodError: undefined method `matches?' for #<Mock:user> which responds like #<User:0xde8>
    mocha-2.4.1/lib/mocha/mock.rb:389:in `check_responder_responds_to'
    mocha-2.4.1/lib/mocha/mock.rb:322:in `handle_method_call'
    mocha-2.4.1/lib/mocha/mock.rb:315:in `method_missing'
    mocha-2.4.1/lib/mocha/parameters_matcher.rb:21:in `block in parameters_match?'
    mocha-2.4.1/lib/mocha/parameters_matcher.rb:21:in `all?'
    mocha-2.4.1/lib/mocha/parameters_matcher.rb:21:in `parameters_match?'
    mocha-2.4.1/lib/mocha/parameters_matcher.rb:16:in `match?'
    mocha-2.4.1/lib/mocha/expectation.rb:647:in `match?'
    mocha-2.4.1/lib/mocha/expectation_list.rb:59:in `block in matching_expectations'
    mocha-2.4.1/lib/mocha/expectation_list.rb:59:in `select'
    mocha-2.4.1/lib/mocha/expectation_list.rb:59:in `matching_expectations'
    mocha-2.4.1/lib/mocha/expectation_list.rb:29:in `match_allowing_invocation'
    mocha-2.4.1/lib/mocha/mock.rb:324:in `handle_method_call'
    mocha-2.4.1/lib/mocha/stubbed_method.rb:47:in `block in define_new_method'
    /tmp/mocha.rb:35:in `test_expect_mock'
```