### PR TITLE
Fix regression when stubbed method expects Hash but receives ActionController::Parameters object

### DIFF
--- a/lib/mocha/parameter_matchers/has_entries.rb
+++ b/lib/mocha/parameter_matchers/has_entries.rb
@@ -39,7 +39,8 @@ module Mocha
       def matches?(available_parameters)
         parameter = available_parameters.shift
         return false unless parameter
-        return false if @exact && @entries.length != parameter.length
+        return false unless parameter.respond_to?(:keys)
+        return false if @exact && @entries.length != parameter.keys.length
 
         has_entry_matchers = @entries.map { |key, value| HasEntry.new(key, value) }
         AllOf.new(*has_entry_matchers).matches?([parameter])

--- a/test/acceptance/parameter_matcher_test.rb
+++ b/test/acceptance/parameter_matcher_test.rb
@@ -1,5 +1,7 @@
 require File.expand_path('../acceptance_test_helper', __FILE__)
 
+require 'hashlike'
+
 class ParameterMatcherTest < Mocha::TestCase
   include AcceptanceTest
 
@@ -20,6 +22,16 @@ class ParameterMatcherTest < Mocha::TestCase
     assert_passed(test_result)
   end
 
+  def test_should_match_hash_parameter_when_method_invoked_with_hashlike_object_with_no_length_method
+    test_result = run_as_test do
+      mock = mock()
+      hash = { key_1: 'value_1' }
+      mock.expects(:method).with(hash)
+      mock.method(Hashlike.new(key_1: 'value_1'))
+    end
+    assert_passed(test_result)
+  end
+
   def test_should_not_match_hash_parameter_which_is_not_exactly_the_same
     test_result = run_as_test do
       mock = mock()
@@ -34,6 +46,17 @@ class ParameterMatcherTest < Mocha::TestCase
       mock = mock()
       mock.expects(:method).with(key_1: 'value_1')
       mock.method
+    end
+    assert_failed(test_result)
+  end
+
+  def test_should_not_match_hash_parameter_when_method_invoked_with_empty_hashlike_object_with_no_length_method
+    test_result = run_as_test do
+      mock = mock()
+      hash = { key_1: 'value_1' }
+      mock.expects(:method).with(hash)
+      hashlike = Hashlike.new({})
+      mock.method(hashlike)
     end
     assert_failed(test_result)
   end

--- a/test/hashlike.rb
+++ b/test/hashlike.rb
@@ -1,0 +1,11 @@
+require 'forwardable'
+
+class Hashlike
+  extend Forwardable
+
+  def_delegators :@hash, :keys, :[]
+
+  def initialize(hash = {})
+    @hash = hash
+  end
+end

--- a/test/unit/parameter_matchers/has_entries_test.rb
+++ b/test/unit/parameter_matchers/has_entries_test.rb
@@ -50,6 +50,18 @@ class HasEntriesTest < Mocha::TestCase
     assert !matcher.matches?([hashlike])
   end
 
+  def test_should_match_hashlike_object_with_no_length_method_when_exact_match_required
+    matcher = HasEntries.new({ key_1: 'value_1' }, exact: true)
+    hashlike = Hashlike.new(key_1: 'value_1')
+    assert matcher.matches?([hashlike])
+  end
+
+  def test_should_not_match_hashlike_object_with_no_length_method_when_exact_match_required
+    matcher = HasEntries.new({ key_1: 'value_1' }, exact: true)
+    hashlike = Hashlike.new(key_1: 'value_1', key_2: 'value_2')
+    assert !matcher.matches?([hashlike])
+  end
+
   def test_should_describe_matcher
     matcher = has_entries(key_1: 'value_1', key_2: 'value_2')
     description = matcher.mocha_inspect

--- a/test/unit/parameter_matchers/has_entries_test.rb
+++ b/test/unit/parameter_matchers/has_entries_test.rb
@@ -3,6 +3,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 require 'mocha/parameter_matchers/has_entries'
 require 'mocha/parameter_matchers/instance_methods'
 require 'mocha/inspect'
+require 'hashlike'
 
 class HasEntriesTest < Mocha::TestCase
   include Mocha::ParameterMatchers
@@ -25,6 +26,18 @@ class HasEntriesTest < Mocha::TestCase
   def test_should_not_match_no_arguments_when_exact_match_required
     matcher = HasEntries.new({ key_1: 'value_1' }, exact: true)
     assert !matcher.matches?([nil])
+  end
+
+  def test_should_match_hashlike_object
+    matcher = has_entries(key_1: 'value_1')
+    hashlike = Hashlike.new(key_1: 'value_1', key_2: 'value_2')
+    assert matcher.matches?([hashlike])
+  end
+
+  def test_should_not_match_hashlike_object
+    matcher = has_entries(key_1: 'value_1')
+    hashlike = Hashlike.new({})
+    assert !matcher.matches?([hashlike])
   end
 
   def test_should_describe_matcher

--- a/test/unit/parameter_matchers/has_entries_test.rb
+++ b/test/unit/parameter_matchers/has_entries_test.rb
@@ -18,6 +18,16 @@ class HasEntriesTest < Mocha::TestCase
     assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
   end
 
+  def test_should_match_hash_with_the_exact_specified_entries
+    matcher = HasEntries.new({ key_1: 'value_1', key_2: 'value_2' }, exact: true)
+    assert matcher.matches?([{ key_1: 'value_1', key_2: 'value_2' }])
+  end
+
+  def test_should_not_match_hash_with_the_exact_specified_entries
+    matcher = HasEntries.new({ key_1: 'value_1', key_2: 'value_2' }, exact: true)
+    assert !matcher.matches?([{ key_1: 'value_1', key_2: 'value_2', key_3: 'value_3' }])
+  end
+
   def test_should_not_match_no_arguments_when_exact_match_not_required
     matcher = has_entries(key_1: 'value_1')
     assert !matcher.matches?([nil])


### PR DESCRIPTION
This was broken in [this previous commit][1] which was part of https://github.com/freerange/mocha/pull/660 and which was released in v2.4.3.

Previously the only requirement we put on `Hash`-like arguments was that they respond to `#keys` & `#[]` methods. However, the change in [that commit][1] we introduced an implicit assumption that they also respond to a `#length` method which is caused the problem described [here][2].

However, [`ActionController::Parameters`][3] is commonly used in Rails apps and it does *not* respond to `#length`. So it seems better to add a guard condition to ensure the object responds to `#keys` and use that to determine the length.

Note that the `HasEntry`, `HasKey` and `HasKeys` matchers already work this way and so this feels like it makes `HasEntries` more consistent.

[1]: https://github.com/freerange/mocha/commit/5e6a07b2710dac76e9346def561ca0d44765bf86
[2]: https://github.com/freerange/mocha/issues/662#issuecomment-2246105530
[3]: https://api.rubyonrails.org/classes/ActionController/Parameters.html