### PR TITLE
Add metadata to gemspec, including changelog_uri

### DIFF
--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -21,6 +21,14 @@ Gem::Specification.new do |s|
   s.homepage = 'https://mocha.jamesmead.org'
   s.require_paths = ['lib']
   s.summary = 'Mocking and stubbing library'
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/freerange/mocha/issues',
+    'changelog_uri' => 'https://github.com/freerange/mocha/blob/main/RELEASE.md',
+    'documentation_uri' => 'https://mocha.jamesmead.org/',
+    'funding_uri' => 'https://github.com/sponsors/floehopper',
+    'homepage_uri' => s.homepage,
+    'source_code_uri' => 'https://github.com/freerange/mocha'
+  }
 
   s.add_runtime_dependency 'ruby2_keywords', '>= 0.0.5'
 end


### PR DESCRIPTION
This will make the changelog more discoverable.

Fixes #608.

Supersedes #665.