### PR TITLE
Add frozen_string_literal to mockery

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mocha/central'
 require 'mocha/mock'
 require 'mocha/names'
@@ -115,9 +117,9 @@ module Mocha
 
     def mocha_inspect
       message = ''
-      message << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if unsatisfied_expectations.any?
-      message << "satisfied expectations:\n- #{satisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if satisfied_expectations.any?
-      message << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}\n" if state_machines.any?
+      message = message.dup << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if unsatisfied_expectations.any?
+      message = message.dup << "satisfied expectations:\n- #{satisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if satisfied_expectations.any?
+      message = message.dup << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}\n" if state_machines.any?
       message
     end
 


### PR DESCRIPTION
### Description
This adds the magic comment for making string literals frozen in `Mockery`. This PR also purposely allows the string in `#mocha_inspect` to remain unfrozen with by duplicating it since that behavior relies on an unfrozen string. I couldn't use `+''` because that method isn't supported in earlier versions of Ruby.

### Context
There is a deprecation warning for chilled strings merged recently in Ruby: https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4

With that change we started to see a chilled string warning for the string in `#mocha_inspect`.