### PR TITLE
Fixes for Ruby v3.4

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -114,11 +114,11 @@ module Mocha
     end
 
     def mocha_inspect
-      message = ''
-      message << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if unsatisfied_expectations.any?
-      message << "satisfied expectations:\n- #{satisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if satisfied_expectations.any?
-      message << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}\n" if state_machines.any?
-      message
+      lines = []
+      lines << "unsatisfied expectations:\n- #{unsatisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if unsatisfied_expectations.any?
+      lines << "satisfied expectations:\n- #{satisfied_expectations.map(&:mocha_inspect).join("\n- ")}\n" if satisfied_expectations.any?
+      lines << "states:\n- #{state_machines.map(&:mocha_inspect).join("\n- ")}\n" if state_machines.any?
+      lines.join
     end
 
     def on_stubbing(object, method)

--- a/lib/mocha/ruby_version.rb
+++ b/lib/mocha/ruby_version.rb
@@ -1,3 +1,4 @@
 module Mocha
   RUBY_V27_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7')
+  RUBY_V34_PLUS = Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('3.4')
 end

--- a/test/acceptance/failure_messages_test.rb
+++ b/test/acceptance/failure_messages_test.rb
@@ -52,11 +52,13 @@ class FailureMessagesTest < Mocha::TestCase
     assert_match Regexp.new("#<Mock:#{OBJECT_ADDRESS_PATTERN}>"), test_result.failures[0].message
   end
 
-  def test_should_display_string_when_expectation_was_on_string
-    test_result = run_as_test do
-      'Foo'.expects(:bar)
+  unless Mocha::RUBY_V34_PLUS
+    def test_should_display_string_when_expectation_was_on_string
+      test_result = run_as_test do
+        'Foo'.expects(:bar)
+      end
+      assert_match Regexp.new(%("Foo")), test_result.failures[0].message
     end
-    assert_match Regexp.new(%("Foo")), test_result.failures[0].message
   end
 
   def test_should_display_that_block_was_expected

--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -3,6 +3,7 @@ require File.expand_path('../acceptance_test_helper', __FILE__)
 require 'deprecation_disabler'
 require 'execution_point'
 require 'mocha/deprecation'
+require 'mocha/ruby_version'
 
 class KeywordArgumentMatchingTest < Mocha::TestCase
   include AcceptanceTest
@@ -24,7 +25,8 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method({ key: 42 }) # rubocop:disable Style/BracesAroundHashParameters
       end
       if Mocha::RUBY_V27_PLUS
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
+        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
@@ -54,7 +56,8 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method({ key: 42 }) # rubocop:disable Style/BracesAroundHashParameters
       end
       if Mocha::RUBY_V27_PLUS
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
+        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
@@ -102,7 +105,8 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method(1, key: 42)
       end
       if Mocha::RUBY_V27_PLUS
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
+        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected positional hash ({:key => 42})"
         assert_includes Mocha::Deprecation.messages.last, 'but received keyword arguments (key: 42)'
       end
@@ -132,7 +136,8 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method(1, { key: 42 }) # rubocop:disable Style/BracesAroundHashParameters
       end
       if Mocha::RUBY_V27_PLUS
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in `block in #{test_name}'"
+        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end

--- a/test/acceptance/partial_mocks_test.rb
+++ b/test/acceptance/partial_mocks_test.rb
@@ -13,8 +13,8 @@ class PartialMockTest < Mocha::TestCase
 
   def test_should_pass_if_all_expectations_are_satisfied
     test_result = run_as_test do
-      partial_mock_one = 'partial_mock_one'
-      partial_mock_two = 'partial_mock_two'
+      partial_mock_one = Object.new
+      partial_mock_two = Object.new
 
       partial_mock_one.expects(:first)
       partial_mock_one.expects(:second)
@@ -29,8 +29,8 @@ class PartialMockTest < Mocha::TestCase
 
   def test_should_fail_if_all_expectations_are_not_satisfied
     test_result = run_as_test do
-      partial_mock_one = 'partial_mock_one'
-      partial_mock_two = 'partial_mock_two'
+      partial_mock_one = Object.new
+      partial_mock_two = Object.new
 
       partial_mock_one.expects(:first)
       partial_mock_one.expects(:second)

--- a/test/acceptance/sequence_block_test.rb
+++ b/test/acceptance/sequence_block_test.rb
@@ -76,8 +76,8 @@ class SequenceBlockTest < Mocha::TestCase
 
   def test_should_constrain_invocations_to_occur_in_expected_order_even_if_expected_on_partial_mocks
     test_result = run_as_test do
-      partial_mock_one = '1'
-      partial_mock_two = '2'
+      partial_mock_one = Object.new
+      partial_mock_two = Object.new
 
       sequence('one') do
         partial_mock_one.expects(:first)
@@ -93,8 +93,8 @@ class SequenceBlockTest < Mocha::TestCase
 
   def test_should_allow_invocations_in_sequence_even_if_expected_on_partial_mocks
     test_result = run_as_test do
-      partial_mock_one = '1'
-      partial_mock_two = '2'
+      partial_mock_one = Object.new
+      partial_mock_two = Object.new
 
       sequence('one') do
         partial_mock_one.expects(:first)

--- a/test/acceptance/sequence_test.rb
+++ b/test/acceptance/sequence_test.rb
@@ -72,8 +72,8 @@ class SequenceTest < Mocha::TestCase
 
   def test_should_constrain_invocations_to_occur_in_expected_order_even_if_expected_on_partial_mocks
     test_result = run_as_test do
-      partial_mock_one = '1'
-      partial_mock_two = '2'
+      partial_mock_one = Object.new
+      partial_mock_two = Object.new
       sequence = sequence('one')
 
       partial_mock_one.expects(:first).in_sequence(sequence)
@@ -88,8 +88,8 @@ class SequenceTest < Mocha::TestCase
 
   def test_should_allow_invocations_in_sequence_even_if_expected_on_partial_mocks
     test_result = run_as_test do
-      partial_mock_one = '1'
-      partial_mock_two = '2'
+      partial_mock_one = Object.new
+      partial_mock_two = Object.new
       sequence = sequence('one')
 
       partial_mock_one.expects(:first).in_sequence(sequence)

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -71,7 +71,8 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
     message = Mocha::Deprecation.messages.last
     opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}new'"
+    method_description = Mocha::RUBY_V34_PLUS ? 'Class#new' : 'new'
+    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}#{method_description}'"
     assert_includes message, "Expectation defined at #{location} expected keyword arguments (key_1: 1, key_2: 2)"
     assert_includes message, 'but received positional hash ({:key_1 => 1, :key_2 => 2})'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
@@ -88,7 +89,8 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
     message = Mocha::Deprecation.messages.last
     opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}new'"
+    method_description = Mocha::RUBY_V34_PLUS ? 'Class#new' : 'new'
+    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}#{method_description}'"
     assert_includes message, "Expectation defined at #{location} expected positional hash ({:key_1 => 1, :key_2 => 2})"
     assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -6,6 +6,7 @@ require 'mocha/parameter_matchers/positional_or_keyword_hash'
 require 'mocha/parameter_matchers/instance_methods'
 require 'mocha/inspect'
 require 'mocha/expectation'
+require 'mocha/ruby_version'
 
 class PositionalOrKeywordHashTest < Mocha::TestCase
   include Mocha::ParameterMatchers
@@ -69,7 +70,8 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     return unless Mocha::RUBY_V27_PLUS
 
     message = Mocha::Deprecation.messages.last
-    location = "#{execution_point.file_name}:#{execution_point.line_number}:in `new'"
+    opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}new'"
     assert_includes message, "Expectation defined at #{location} expected keyword arguments (key_1: 1, key_2: 2)"
     assert_includes message, 'but received positional hash ({:key_1 => 1, :key_2 => 2})'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
@@ -85,7 +87,8 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     return unless Mocha::RUBY_V27_PLUS
 
     message = Mocha::Deprecation.messages.last
-    location = "#{execution_point.file_name}:#{execution_point.line_number}:in `new'"
+    opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}new'"
     assert_includes message, "Expectation defined at #{location} expected positional hash ({:key_1 => 1, :key_2 => 2})"
     assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'


### PR DESCRIPTION
Includes fixes for frozen string literal warnings and a couple of backtrace compatibility issues:
* [Backtrace opening quote change in Ruby v3.4](https://github.com/freerange/mocha/commit/2eacf06b07be34237b40b6c02cdea270e414eb6b)
* [Backtrace method description change in Ruby v3.4](https://github.com/freerange/mocha/commit/c4fe850bc8f5ef2f44013ff54505b8b7ef6a9861)
* [Fix frozen string literal warning in Mockery](https://github.com/freerange/mocha/commit/55dd0fca85a693d85b95e3fdbf07750988f8e48a)
* [Fix frozen string literal warning in InstanceMethod](https://github.com/freerange/mocha/commit/ce2ae260bb6efb868bb3af703719db0f9ad891fb)

Also closes #669.