### PR TITLE
Simplify backtrace-related assertions

### DIFF
--- a/test/acceptance/keyword_argument_matching_test.rb
+++ b/test/acceptance/keyword_argument_matching_test.rb
@@ -17,7 +17,6 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
   end
 
   def test_should_match_hash_parameter_with_keyword_args
-    test_name = __method__
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(key: 42); execution_point = ExecutionPoint.current
@@ -25,8 +24,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method({ key: 42 }) # rubocop:disable Style/BracesAroundHashParameters
       end
       if Mocha::RUBY_V27_PLUS
-        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
+        location = execution_point.location
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
@@ -48,7 +46,6 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
   end
 
   def test_should_match_hash_parameter_with_splatted_keyword_args
-    test_name = __method__
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(**{ key: 42 }); execution_point = ExecutionPoint.current
@@ -56,8 +53,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method({ key: 42 }) # rubocop:disable Style/BracesAroundHashParameters
       end
       if Mocha::RUBY_V27_PLUS
-        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
+        location = execution_point.location
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end
@@ -97,7 +93,6 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
   end
 
   def test_should_match_positional_and_keyword_args_with_last_positional_hash
-    test_name = __method__
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(1, { key: 42 }); execution_point = ExecutionPoint.current # rubocop:disable Style/BracesAroundHashParameters
@@ -105,8 +100,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method(1, key: 42)
       end
       if Mocha::RUBY_V27_PLUS
-        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
+        location = execution_point.location
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected positional hash ({:key => 42})"
         assert_includes Mocha::Deprecation.messages.last, 'but received keyword arguments (key: 42)'
       end
@@ -128,7 +122,6 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
   end
 
   def test_should_match_last_positional_hash_with_keyword_args
-    test_name = __method__
     test_result = run_as_test do
       mock = mock()
       mock.expects(:method).with(1, key: 42); execution_point = ExecutionPoint.current
@@ -136,8 +129,7 @@ class KeywordArgumentMatchingTest < Mocha::TestCase
         mock.method(1, { key: 42 }) # rubocop:disable Style/BracesAroundHashParameters
       end
       if Mocha::RUBY_V27_PLUS
-        opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-        location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}block in #{test_name}'"
+        location = execution_point.location
         assert_includes Mocha::Deprecation.messages.last, "Expectation defined at #{location} expected keyword arguments (key: 42)"
         assert_includes Mocha::Deprecation.messages.last, 'but received positional hash ({:key => 42})'
       end

--- a/test/execution_point.rb
+++ b/test/execution_point.rb
@@ -30,6 +30,10 @@ class ExecutionPoint
     "file: #{file_name}; line: #{line_number}"
   end
 
+  def location
+    @backtrace.first
+  end
+
   def inspect
     to_s
   end

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../../../test_helper', __FILE__)
 
 require 'deprecation_disabler'
-require 'execution_point'
 require 'mocha/parameter_matchers/positional_or_keyword_hash'
 require 'mocha/parameter_matchers/instance_methods'
 require 'mocha/inspect'
@@ -62,7 +61,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
   end
 
   def test_should_match_hash_arg_with_keyword_args_but_display_deprecation_warning_if_appropriate
-    expectation = Mocha::Expectation.new(self, :foo); execution_point = ExecutionPoint.current
+    expectation = Mocha::Expectation.new(self, :foo)
     matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }), expectation) # rubocop:disable Style/BracesAroundHashParameters
     DeprecationDisabler.disable_deprecations do
       assert matcher.matches?([{ key_1: 1, key_2: 2 }])
@@ -70,9 +69,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     return unless Mocha::RUBY_V27_PLUS
 
     message = Mocha::Deprecation.messages.last
-    opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-    method_description = Mocha::RUBY_V34_PLUS ? 'Class#new' : 'new'
-    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}#{method_description}'"
+    location = expectation.definition_location
     assert_includes message, "Expectation defined at #{location} expected keyword arguments (key_1: 1, key_2: 2)"
     assert_includes message, 'but received positional hash ({:key_1 => 1, :key_2 => 2})'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
@@ -80,7 +77,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
   end
 
   def test_should_match_keyword_args_with_hash_arg_but_display_deprecation_warning_if_appropriate
-    expectation = Mocha::Expectation.new(self, :foo); execution_point = ExecutionPoint.current
+    expectation = Mocha::Expectation.new(self, :foo)
     matcher = build_matcher({ key_1: 1, key_2: 2 }, expectation)
     DeprecationDisabler.disable_deprecations do
       assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })]) # rubocop:disable Style/BracesAroundHashParameters
@@ -88,9 +85,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
     return unless Mocha::RUBY_V27_PLUS
 
     message = Mocha::Deprecation.messages.last
-    opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
-    method_description = Mocha::RUBY_V34_PLUS ? 'Class#new' : 'new'
-    location = "#{execution_point.file_name}:#{execution_point.line_number}:in #{opening_quote}#{method_description}'"
+    location = expectation.definition_location
     assert_includes message, "Expectation defined at #{location} expected positional hash ({:key_1 => 1, :key_2 => 2})"
     assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'


### PR DESCRIPTION
Previously we were generating the expected backtrace-related strings from scratch, but that was (a) quite complicated; and (b) suffered from Ruby version differences. Now we're using strings obtained directly from a Ruby backtrace which is a lot simpler and avoids the Ruby version differences.

* [Use ExecutionPoint#location to simplify assertions](https://github.com/freerange/mocha/commit/174e86ab3d34e6434918b6b15539086e3f42357a)
* [Use Expectation#definition_location to simplify assertions](https://github.com/freerange/mocha/commit/468a313bbf26af698b4f0fd2f88fa02644c6bd46)