### PR TITLE
Expectation with never cardinality should display deprecation warning

### DIFF
--- a/lib/mocha/cardinality.rb
+++ b/lib/mocha/cardinality.rb
@@ -34,6 +34,10 @@ module Mocha
       @invocations.size < maximum
     end
 
+    def invocations_never_allowed?
+      maximum.zero?
+    end
+
     def satisfied?
       @invocations.size >= required
     end

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -654,6 +654,11 @@ module Mocha
     end
 
     # @private
+    def invocations_never_allowed?
+      @cardinality.invocations_never_allowed?
+    end
+
+    # @private
     def satisfied?
       @cardinality.satisfied?
     end

--- a/lib/mocha/expectation_list.rb
+++ b/lib/mocha/expectation_list.rb
@@ -25,6 +25,10 @@ module Mocha
       matching_expectations(invocation).detect(&:invocations_allowed?)
     end
 
+    def match_never_allowing_invocation(invocation)
+      matching_expectations(invocation).detect(&:invocations_never_allowed?)
+    end
+
     def verified?(assertion_counter = nil)
       @expectations.all? { |expectation| expectation.verified?(assertion_counter) }
     end

--- a/lib/mocha/expectation_list.rb
+++ b/lib/mocha/expectation_list.rb
@@ -53,8 +53,6 @@ module Mocha
       self.class.new(to_a + other.to_a)
     end
 
-    private
-
     def matching_expectations(invocation, ignoring_order: false)
       @expectations.select { |e| e.match?(invocation, ignoring_order: ignoring_order) }
     end

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -321,10 +321,14 @@ module Mocha
       check_expiry
       check_responder_responds_to(symbol)
       invocation = Invocation.new(self, symbol, arguments, block)
-      if (matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation))
+
+      matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation)
+      matching_expectation_ignoring_order = all_expectations.match(invocation, ignoring_order: true)
+
+      if matching_expectation_allowing_invocation
         matching_expectation_allowing_invocation.invoke(invocation)
-      elsif (matching_expectation = all_expectations.match(invocation, ignoring_order: true)) || (!matching_expectation && !@everything_stubbed)
-        raise_unexpected_invocation_error(invocation, matching_expectation)
+      elsif matching_expectation_ignoring_order || (!matching_expectation_ignoring_order && !@everything_stubbed)
+        raise_unexpected_invocation_error(invocation, matching_expectation_ignoring_order)
       end
     end
 

--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -8,6 +8,7 @@ require 'mocha/method_matcher'
 require 'mocha/parameters_matcher'
 require 'mocha/argument_iterator'
 require 'mocha/expectation_error_factory'
+require 'mocha/deprecation'
 
 module Mocha
   # Traditional mock object.
@@ -323,9 +324,13 @@ module Mocha
       invocation = Invocation.new(self, symbol, arguments, block)
 
       matching_expectation_allowing_invocation = all_expectations.match_allowing_invocation(invocation)
+      matching_expectation_never_allowing_invocation = all_expectations.match_never_allowing_invocation(invocation)
       matching_expectation_ignoring_order = all_expectations.match(invocation, ignoring_order: true)
 
       if matching_expectation_allowing_invocation
+        if matching_expectation_never_allowing_invocation
+          invocation_not_allowed_warning(invocation, matching_expectation_never_allowing_invocation)
+        end
         matching_expectation_allowing_invocation.invoke(invocation)
       elsif matching_expectation_ignoring_order || (!matching_expectation_ignoring_order && !@everything_stubbed)
         raise_unexpected_invocation_error(invocation, matching_expectation_ignoring_order)
@@ -372,6 +377,14 @@ module Mocha
     end
 
     private
+
+    def invocation_not_allowed_warning(invocation, expectation)
+      messages = [
+        "The expectation defined at #{expectation.definition_location} does not allow invocations, but #{invocation.call_description} was invoked.",
+        'This invocation will cause the test to fail fast in a future version of Mocha.'
+      ]
+      Deprecation.warning(messages.join(' '))
+    end
 
     def raise_unexpected_invocation_error(invocation, matching_expectation)
       if @unexpected_invocation.nil?

--- a/test/acceptance/parameter_matcher_test.rb
+++ b/test/acceptance/parameter_matcher_test.rb
@@ -373,4 +373,15 @@ class ParameterMatcherTest < Mocha::TestCase
     end
     assert_failed(test_result)
   end
+
+  def test_should_only_call_matcher_block_once
+    test_result = run_as_test do
+      number_of_invocations = 0
+      mock = mock()
+      mock.stubs(:method).with { number_of_invocations += 1; true }
+      mock.method
+      assert_equal 1, number_of_invocations
+    end
+    assert_passed(test_result)
+  end
 end

--- a/test/unit/cardinality_test.rb
+++ b/test/unit/cardinality_test.rb
@@ -22,6 +22,13 @@ class CardinalityTest < Mocha::TestCase
     assert !cardinality.invocations_allowed?
   end
 
+  def test_should_never_allow_invocations
+    cardinality = Cardinality.new.exactly(0)
+    assert cardinality.invocations_never_allowed?
+    cardinality << new_invocation
+    assert cardinality.invocations_never_allowed?
+  end
+
   def test_should_be_satisfied_if_invocations_so_far_have_reached_required_threshold
     cardinality = Cardinality.new(2, 3)
     assert !cardinality.satisfied?

--- a/test/unit/expectation_list_test.rb
+++ b/test/unit/expectation_list_test.rb
@@ -69,6 +69,17 @@ class ExpectationListTest < Mocha::TestCase
     assert_same expectation1, expectation_list.match_allowing_invocation(Invocation.new(:irrelevant, :my_method))
   end
 
+  def test_should_find_matching_expectation_never_allowing_invocation
+    expectation_list = ExpectationList.new
+    expectation1 = Expectation.new(nil, :my_method)
+    expectation2 = Expectation.new(nil, :my_method)
+    define_instance_method(expectation1, :invocations_never_allowed?) { true }
+    define_instance_method(expectation2, :invocations_never_allowed?) { false }
+    expectation_list.add(expectation1)
+    expectation_list.add(expectation2)
+    assert_same expectation1, expectation_list.match_never_allowing_invocation(Invocation.new(:irrelevant, :my_method))
+  end
+
   def test_should_combine_two_expectation_lists_into_one
     expectation_list1 = ExpectationList.new
     expectation_list2 = ExpectationList.new

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -88,6 +88,13 @@ class ExpectationTest < Mocha::TestCase
     assert !expectation.invocations_allowed?
   end
 
+  def test_should_never_allow_invocations
+    expectation = new_expectation.never
+    assert expectation.invocations_never_allowed?
+    invoke(expectation)
+    assert expectation.invocations_never_allowed?
+  end
+
   def test_should_store_provided_backtrace
     backtrace = Object.new
     assert_equal backtrace, Expectation.new(nil, :expected_method, backtrace).backtrace


### PR DESCRIPTION
Currently when an invocation matches an expectation which does not allow invocations (i.e. `Expectation#never` has been called on it), but the invocation also matches another expectation which does allow invocations, then the test does not fail with an unexpected invocation error.

In https://github.com/freerange/mocha/pull/679 I'm planning to change this behaviour so the test fails fast with an unexpected invocation error. This PR means we display a deprecation warning instead to give users a chance to update their code before the actual change is made.