### PR TITLE
Fix never expectation deprecation warning logic

### DIFF
--- a/test/acceptance/mocked_methods_dispatch_test.rb
+++ b/test/acceptance/mocked_methods_dispatch_test.rb
@@ -94,4 +94,18 @@ class MockedMethodDispatchTest < Mocha::TestCase
     ]
     assert_equal expected.join(' '), message
   end
+
+  def test_should_not_display_deprecation_warning_if_invocation_matches_expectation_allowing_invocation_before_matching_expectation_with_never_cardinality
+    test_result = run_as_test do
+      mock = mock('mock')
+      mock.expects(:method).never
+      mock.expects(:method).once
+      Mocha::Deprecation.messages = []
+      DeprecationDisabler.disable_deprecations do
+        mock.method
+      end
+    end
+    assert_passed(test_result)
+    assert Mocha::Deprecation.messages.empty?
+  end
 end


### PR DESCRIPTION
In #681 I added logic to display a deprecation warning about a change I planned to make in #679. However, it turns out the logic in both was faulty as demonstrated in [this example][1] where the deprecation warning was incorrectly displayed for the 2nd call to `Foo.create_if`:

```ruby
    class Foo
      def self.create_if(condition)
        new if condition
      end
    end

    test "it creates only if condition is true" do
      Foo.expects(:new).never
      Foo.create_if(false)

      Foo.expects(:new).once
      Foo.create_if(true)
    end
```

This commit adds a new acceptance test to cover an example where the logic was incorrect and updates the logic in `Mock#handle_method_call` to fix the logic so this new test passes and none of the existing tests fail. Unfortunately the implementation is now rather complicated and hard to follow, but I think it will do for now. I have a couple of ideas for ways to simplify it, but I don't have time to work on that now.

I have [updated](https://github.com/freerange/mocha/pull/679/commits/29a8e085407fd50892be5c7f6e2768f019e6d47b) the equivalent logic in #679 to match the new logic implemented here.

[1]: https://github.com/freerange/mocha/pull/679#issuecomment-2503272428