### PR TITLE
More fixes in preparation for Ruby v3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ workflows:
                 - ruby:3.1
                 - ruby:3.2
                 - ruby:3.3
+                - ruby:3.4.0-preview2
                 - ruby:latest
                 - jruby:latest
               gemfile:

--- a/test/integration/shared_tests.rb
+++ b/test/integration/shared_tests.rb
@@ -1,5 +1,6 @@
 require 'test_runner'
 require 'execution_point'
+require 'mocha/ruby_version'
 
 # rubocop:disable Metrics/ModuleLength
 module SharedTests
@@ -156,6 +157,8 @@ module SharedTests
   end
 
   def test_real_object_expectation_does_not_leak_into_subsequent_test
+    opening_quote = Mocha::RUBY_V34_PLUS ? "'" : '`'
+
     execution_point = nil
     klass = Class.new
     test_result = run_as_tests(
@@ -170,7 +173,7 @@ module SharedTests
     assert_errored(test_result)
     exception = test_result.errors.first.exception
     assert_equal execution_point, ExecutionPoint.new(exception.backtrace)
-    assert_match(/undefined method `foo'/, exception.message)
+    assert_match(/undefined method #{opening_quote}foo'/, exception.message)
   end
 
   def test_leaky_mock


### PR DESCRIPTION
This incorporates changes to support Ruby v3.4 that have become necessary since #672.

It also adds Ruby v3.4.0-preview2 to the CI build matrix so we can be more certain that all issues have been addressed.

There is also [a JRuby issue](https://github.com/jruby/jruby/issues/8488) which is causing the [CI build error](https://app.circleci.com/pipelines/github/freerange/mocha/653/workflows/f0f2cde3-df02-4002-a1a7-69d2458aa0d9/jobs/9498).