### PR TITLE
Workaround for JRuby jar-dependencies issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ if RUBY_VERSION >= '2.2.0'
   gem 'jaro_winkler', '>= 1.5.5'
   gem 'rubocop', '> 0.56', '<= 0.58.2'
 end
+if RUBY_ENGINE == 'jruby'
+  # Workaround for https://github.com/jruby/jruby/issues/8488
+  gem 'jar-dependencies', '~> 0.4.1'
+end
 if ENV['MOCHA_GENERATE_DOCS']
   gem 'redcarpet'
   gem 'yard'


### PR DESCRIPTION
Restricting the `jar-dependencies` gem to v0.4.x seems to avoid [the issue][1] which was causing errors in CI builds like [this][2].

[1]: https://github.com/jruby/jruby/issues/8488
[2]: https://app.circleci.com/pipelines/github/freerange/mocha/653/workflows/f0f2cde3-df02-4002-a1a7-69d2458aa0d9/jobs/9498