### PR TITLE
Improve gemspec description

### DIFF
--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -2,6 +2,9 @@ lib = File.expand_path('../lib/', __FILE__)
 $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require 'mocha/version'
 
+DESCRIPTION =
+  'Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.'.freeze
+
 Gem::Specification.new do |s|
   s.name = 'mocha'
   s.version = Mocha::VERSION
@@ -9,7 +12,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.authors = ['James Mead']
-  s.description = 'Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.'
+  s.description = DESCRIPTION
   s.email = 'mocha-developer@googlegroups.com'
 
   s.files = Dir.chdir(File.expand_path('..', __FILE__)) do

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -3,8 +3,9 @@ $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require 'mocha/version'
 
 DESCRIPTION =
-  'Mocking and stubbing library with JMock/SchMock syntax, which allows ' \
-  'mocking and stubbing of methods on real (non-mock) classes.'.freeze
+  'A library for mocking and stubbing with a unified, simple and readable syntax ' \
+  'for both full & partial mocking. Built-in support for Minitest and Test::Unit. ' \
+  'Supported by many other test frameworks, e.g. RSpec.'.freeze
 
 Gem::Specification.new do |s|
   s.name = 'mocha'

--- a/mocha.gemspec
+++ b/mocha.gemspec
@@ -3,7 +3,8 @@ $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require 'mocha/version'
 
 DESCRIPTION =
-  'Mocking and stubbing library with JMock/SchMock syntax, which allows mocking and stubbing of methods on real (non-mock) classes.'.freeze
+  'Mocking and stubbing library with JMock/SchMock syntax, which allows ' \
+  'mocking and stubbing of methods on real (non-mock) classes.'.freeze
 
 Gem::Specification.new do |s|
   s.name = 'mocha'


### PR DESCRIPTION
This brings the gemspec description more into line with that in the README. Note that the gemspec description is used [on rubygems.org][1].

Closes #692.

[1]: https://rubygems.org/gems/mocha