### PR TITLE
Introduce Expectation#thrice

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 23
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 366
+  Max: 381
 
 # Offense count: 172
 # Configuration parameters: CountComments.

--- a/lib/mocha/expectation.rb
+++ b/lib/mocha/expectation.rb
@@ -48,6 +48,33 @@ module Mocha
       self
     end
 
+    # Modifies expectation so that the expected method must be called exactly thrice.
+    #
+    # @return [Expectation] the same expectation, thereby allowing invocations of other {Expectation} methods to be chained.
+    #
+    # @example Expected method must be invoked exactly thrice.
+    #   object = mock()
+    #   object.expects(:expected_method).twice
+    #   object.expected_method
+    #   object.expected_method
+    #   object.expected_method
+    #   # => verify succeeds
+    #
+    #   object = mock()
+    #   object.expects(:expected_method).twice
+    #   object.expected_method
+    #   object.expected_method
+    #   object.expected_method # => unexpected invocation
+    #
+    #   object = mock()
+    #   object.expects(:expected_method).twice
+    #   object.expected_method
+    #   # => verify fails
+    def thrice
+      @cardinality.exactly(3)
+      self
+    end
+
     # Modifies expectation so that the expected method must be called exactly twice.
     #
     # @return [Expectation] the same expectation, thereby allowing invocations of other {Expectation} methods to be chained.

--- a/test/unit/expectation_test.rb
+++ b/test/unit/expectation_test.rb
@@ -251,6 +251,30 @@ class ExpectationTest < Mocha::TestCase
     assert expectation.verified?
   end
 
+  def test_should_not_verify_successfully_if_call_expected_thrice_and_invoked_four_times
+    expectation = new_expectation.thrice
+    invoke(expectation)
+    invoke(expectation)
+    invoke(expectation)
+    invoke(expectation)
+    assert !expectation.verified?
+  end
+
+  def test_should_not_verify_successfully_if_call_expected_thrice_but_invoked_twice
+    expectation = new_expectation.thrice
+    invoke(expectation)
+    invoke(expectation)
+    assert !expectation.verified?
+  end
+
+  def test_should_verify_successfully_if_call_expected_thrice_and_invoked_thrice
+    expectation = new_expectation.thrice
+    invoke(expectation)
+    invoke(expectation)
+    invoke(expectation)
+    assert expectation.verified?
+  end
+
   def test_should_not_verify_successfully_if_call_expected_twice_and_invoked_three_times
     expectation = new_expectation.twice
     invoke(expectation)


### PR DESCRIPTION
I was surprised to get a `NoMethodError: undefined method 'thrice' for an instance of Mocha::Expectation` when I tried to do `foo.expects(:bar).thrice`

This PR introduces a `thrice` method which verifies the expected method is called exactly 3 times.