### PR TITLE
Add Ruby v3.4 to CI build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
                 - ruby:3.1
                 - ruby:3.2
                 - ruby:3.3
-                - ruby:3.4.0-rc1
+                - ruby:3.4
                 - ruby:latest
                 - jruby:latest
               gemfile:


### PR DESCRIPTION
From [this issue](https://github.com/docker-library/ruby/issues/488):

> As is [Ruby tradition](https://en.wikipedia.org/wiki/History_of_Ruby), 3.4.0 is extremely likely to be released/GA'd [on Christmas Day (Dec 25th)](https://en.wikipedia.org/wiki/History_of_Ruby#:~:text=Annual%20releases%20of%20the%20language%20often%20take%20place%20on%20Christmas%20Day.). I'm filing this in advance in our last actual/official working week of 2024 to make it clear that 3.4.0 will not be published on Christmas Day, and that the soonest we might get to it is going to be Dec 26th (if not sometime in January, given the holiday season). Please be patient. ❤️

[Ruby v3.4 was released earlier today][1].

[1]: https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/