### PR TITLE
Fix Ruby v3.4 warnings in ObjectInspectTest

### DIFF
--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -11,7 +11,7 @@ class ObjectInspectTest < Mocha::TestCase
       attr_accessor :attribute
     end
     object.attribute = 'instance_variable'
-    assert_match Regexp.new('^#<Object:0x[0-9A-Fa-f]{1,8}.*>$'), object.mocha_inspect
+    assert_match string_representation(id: object.__id__, klass: object.class), object.mocha_inspect
     assert_no_match(/instance_variable/, object.mocha_inspect)
   end
 
@@ -24,21 +24,24 @@ class ObjectInspectTest < Mocha::TestCase
   end
 
   def test_should_use_underscored_id_instead_of_object_id_or_id_so_that_they_can_be_stubbed
-    calls = []
     object = Object.new
-    replace_instance_method(object, :object_id) do
-      calls << :object_id
-      return 1
-    end
-    replace_instance_method(object, :__id__) do
-      calls << :__id__
-      return 1
-    end
-    replace_instance_method(object, :inspect) { 'object-description' }
 
-    object.mocha_inspect
+    if Mocha::RUBY_V34_PLUS
+      ignoring_warning(/warning: redefining 'object_id' may cause serious problems/) do
+        replace_instance_method(object, :object_id) do
+          flunk 'should not call `Object#object_id`'
+        end
+      end
+    else
+      replace_instance_method(object, :object_id) do
+        flunk 'should not call `Object#object_id`'
+      end
+    end
+    define_instance_method(object, :id) do
+      flunk 'should not call `Object#id`'
+    end
 
-    assert_equal [:__id__], calls.uniq
+    assert_equal string_representation(id: object.__id__, klass: object.class), object.mocha_inspect
   end
 
   def test_should_not_call_object_instance_format_method
@@ -49,5 +52,25 @@ class ObjectInspectTest < Mocha::TestCase
       end
     end
     assert_no_match(/internal_format/, object.mocha_inspect)
+  end
+
+  private
+
+  def string_representation(id:, klass:)
+    address = id * 2
+    address += 0x100000000 if address < 0
+    "#<#{klass}:0x#{Kernel.format('%<address>x', address: address)}>"
+  end
+
+  def ignoring_warning(pattern)
+    original_warn = Warning.method(:warn)
+    Warning.singleton_class.define_method(:warn) do |message|
+      original_warn.call(message) unless message =~ pattern
+    end
+
+    yield
+  ensure
+    Warning.singleton_class.undef_method(:warn)
+    Warning.singleton_class.define_method(:warn, original_warn)
   end
 end


### PR DESCRIPTION
I was seeing the following warnings with Ruby v3.4:

    test/method_definer.rb:3: warning: redefining 'object_id' may cause serious problems
    test/method_definer.rb:3: warning: redefining '__id__' may cause serious problems

* Assert the string representation of the object instead of just the pattern.
* Actually check `Object#id` is not called as implied by the test name.
* Ignore the Ruby warning when `Object#object_id` is redefined.

Closes #709.