### PR TITLE
Use built-in Ruby debug option vs custom module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ jobs:
         type: string
     docker:
       - image: << parameters.docker-image >>
-    environment:
-      MOCHA_OPTIONS=debug
     steps:
       - checkout
       - run: ruby --version

--- a/README.md
+++ b/README.md
@@ -292,10 +292,9 @@ If you want, Mocha can generate a warning or raise an exception when:
 
 See the [documentation](https://mocha.jamesmead.org/Mocha/Configuration.html) for `Mocha::Configuration` for further details.
 
-##### MOCHA_OPTIONS
-`MOCHA_OPTIONS` is an environment variable whose value can be set to a comma-separated list, so that we can specify multiple options e.g. `MOCHA_OPTIONS=debug`.
-Only the following values are currently recognized and have an effect:
-* `debug`: Enables a debug mode which provides extra output to assist with debugging.
+### Debugging
+
+Mocha provides some extra output to help with debugging when the standard Ruby debug option (`-d`) is set.
 
 ### Semantic versioning
 

--- a/lib/mocha/debug.rb
+++ b/lib/mocha/debug.rb
@@ -1,9 +1,0 @@
-module Mocha
-  module Debug
-    OPTIONS = (ENV['MOCHA_OPTIONS'] || '').split(',').freeze
-
-    def self.puts(message)
-      warn(message) if OPTIONS.include?('debug')
-    end
-  end
-end

--- a/lib/mocha/integration/minitest.rb
+++ b/lib/mocha/integration/minitest.rb
@@ -1,4 +1,3 @@
-require 'mocha/debug'
 require 'mocha/detection/minitest'
 require 'mocha/integration/minitest/adapter'
 
@@ -10,14 +9,14 @@ module Mocha
         return false unless target
 
         minitest_version = Gem::Version.new(Detection::Minitest.version)
-        Debug.puts "Detected Minitest version: #{minitest_version}"
+        warn "Detected Minitest version: #{minitest_version}" if $DEBUG
 
         unless Minitest::Adapter.applicable_to?(minitest_version)
           raise 'Versions of minitest earlier than v3.3.0 are not supported.'
         end
 
         unless target < Minitest::Adapter
-          Debug.puts "Applying #{Minitest::Adapter.description}"
+          warn "Applying #{Minitest::Adapter.description}" if $DEBUG
           target.send(:include, Minitest::Adapter)
         end
 

--- a/lib/mocha/integration/monkey_patcher.rb
+++ b/lib/mocha/integration/monkey_patcher.rb
@@ -5,12 +5,12 @@ module Mocha
     module MonkeyPatcher
       def self.apply(mod, run_method_patch)
         if mod < Mocha::API
-          Debug.puts "Mocha::API already included in #{mod}"
+          warn "Mocha::API already included in #{mod}" if $DEBUG
         else
           mod.send(:include, Mocha::API)
         end
         if mod.method_defined?(:run_before_mocha)
-          Debug.puts "#{mod}#run_before_mocha method already defined"
+          warn "#{mod}#run_before_mocha method already defined" if $DEBUG
         elsif mod.method_defined?(:run)
           mod.send(:alias_method, :run_before_mocha, :run)
           mod.send(:remove_method, :run)

--- a/lib/mocha/integration/test_unit.rb
+++ b/lib/mocha/integration/test_unit.rb
@@ -1,4 +1,3 @@
-require 'mocha/debug'
 require 'mocha/detection/test_unit'
 require 'mocha/integration/test_unit/adapter'
 
@@ -10,14 +9,14 @@ module Mocha
         return false unless target
 
         test_unit_version = Gem::Version.new(Detection::TestUnit.version)
-        Debug.puts "Detected Test::Unit version: #{test_unit_version}"
+        warn "Detected Test::Unit version: #{test_unit_version}" if $DEBUG
 
         unless TestUnit::Adapter.applicable_to?(test_unit_version)
           raise 'Versions of test-unit earlier than v2.5.1 are not supported.'
         end
 
         unless target < TestUnit::Adapter
-          Debug.puts "Applying #{TestUnit::Adapter.description}"
+          warn "Applying #{TestUnit::Adapter.description}" if $DEBUG
           target.send(:include, TestUnit::Adapter)
         end
 


### PR DESCRIPTION
The debug mode has become less important in recent years since we stopped monkey-patching the test libraries.

The only downside I can see for this is that we'll see *all* Ruby debug output when this option is enabled which might obscure Mocha's debug output. However, I think we'll cross that bridge if/when we come to it.

I did consider setting `RUBYOPT=-d` in the `environment` entry in `.circleci/config.yml` to replace `MOCHA_OPTIONS=debug`. However, this would've cluttered up the CI build output unnecessarily.

Closes #714.