### PR TITLE
Consistently use development group in Gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,18 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'introspection', '~> 0.0.1'
-gem 'minitest'
-gem 'rake'
+group :development do
+  gem 'introspection', '~> 0.0.1'
+  gem 'minitest'
+  gem 'rake'
 
-if RUBY_ENGINE == 'jruby'
-  # Workaround for https://github.com/jruby/jruby/issues/8488
-  gem 'jar-dependencies', '~> 0.4.1'
-end
+  if RUBY_ENGINE == 'jruby'
+    # Workaround for https://github.com/jruby/jruby/issues/8488
+    gem 'jar-dependencies', '~> 0.4.1'
+  end
 
-if ENV['MOCHA_GENERATE_DOCS']
-  gem 'redcarpet'
-  gem 'yard'
+  if ENV['MOCHA_GENERATE_DOCS']
+    gem 'redcarpet'
+    gem 'yard'
+  end
 end

--- a/gemfiles/Gemfile.rubocop
+++ b/gemfiles/Gemfile.rubocop
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'rake'
-gem 'rubocop'
-gem 'rubocop-rake'
+group :development do
+  gem 'rake'
+  gem 'rubocop'
+  gem 'rubocop-rake'
+end


### PR DESCRIPTION
Using a `development` group isn't really necessary, because all these Gemfiles are only ever used in the context of development, linting or running the tests. However, it would be good to be consistent and using a `development` group probably make things clearer.

Previously we were only using a group in `gemfiles/Gemfile.minitest.latest` & `gemfiles/Gemfile.test-unit.latest`.

Closes #706.