### PR TITLE
Improve `#mocha_inspect` for empty keyword argument Hash

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -28,7 +28,11 @@ module Mocha
           end
         end.join(', ')
 
-        Hash.ruby2_keywords_hash?(self) ? unwrapped : "{#{unwrapped}}"
+        if Hash.ruby2_keywords_hash?(self)
+          empty? ? '**{}' : unwrapped
+        else
+          "{#{unwrapped}}"
+        end
       end
     end
 

--- a/test/unit/hash_inspect_test.rb
+++ b/test/unit/hash_inspect_test.rb
@@ -19,6 +19,11 @@ class HashInspectTest < Mocha::TestCase
       assert_equal 'a: true, b: false', hash.mocha_inspect
     end
 
+    def test_should_return_double_splatted_empty_hash_when_empty_keyword_hash
+      hash = Hash.ruby2_keywords_hash({})
+      assert_equal '**{}', hash.mocha_inspect
+    end
+
     def test_should_return_unwrapped_hash_when_keyword_hash_keys_are_not_symbols
       hash = Hash.ruby2_keywords_hash('a' => true, 'b' => false)
       assert_equal '"a" => true, "b" => false', hash.mocha_inspect


### PR DESCRIPTION
Previously in Ruby v2.7 the following code resulted in confusing output:

    object = mock()
    object.expects(:expected_method).with(:param1, :param2)
    object.expected_method(:param1, :param2, **{})

    # => unexpected invocation: #<Mock:0x1630>.expected_method(:param1, :param2, )

Now the output for the same code is:

    # => unexpected invocation: #<Mock:0x1630>.expected_method(:param1, :param2, **{})

Which I think it less confusing, because it makes it clear that there was an extra keyword argument Hash in the invocation arguments.

Closes #588.