### PR TITLE
Improve error if `Mockery.teardown` called before `Mockery.setup`

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -49,9 +49,13 @@ module Mocha
       end
 
       def teardown(origin = nil)
+        if @instances.nil?
+          raise NotInitializedError, 'Mocha::Mockery.teardown called before Mocha::Mockery.setup'
+        end
+
         instance.teardown(origin)
       ensure
-        @instances.pop
+        @instances.pop unless @instances.nil?
       end
     end
 

--- a/test/unit/mockery_test.rb
+++ b/test/unit/mockery_test.rb
@@ -3,6 +3,17 @@ require 'mocha/mockery'
 require 'mocha/state_machine'
 require 'mocha/expectation_error_factory'
 
+class MockeryNeverSetupTest < Mocha::TestCase
+  include Mocha
+
+  def test_should_raise_not_initialized_error
+    Mockery.instance_variable_set(:@instances, nil)
+    assert_raises(NotInitializedError) do
+      Mockery.teardown
+    end
+  end
+end
+
 class MockeryTest < Mocha::TestCase
   include Mocha
 


### PR DESCRIPTION
Closes #646.