### PR TITLE
Convert `ParameterMatchers::Base` class -> module

### DIFF
--- a/lib/mocha/parameter_matchers/all_of.rb
+++ b/lib/mocha/parameter_matchers/all_of.rb
@@ -27,10 +27,11 @@ module Mocha
     end
 
     # Parameter matcher which combines a number of other matchers using a logical AND.
-    class AllOf < Base
+    class AllOf
+      include Base
+
       # @private
       def initialize(*matchers)
-        super()
         @matchers = matchers
       end
 

--- a/lib/mocha/parameter_matchers/any_of.rb
+++ b/lib/mocha/parameter_matchers/any_of.rb
@@ -33,10 +33,11 @@ module Mocha
     end
 
     # Parameter matcher which combines a number of other matchers using a logical OR.
-    class AnyOf < Base
+    class AnyOf
+      include Base
+
       # @private
       def initialize(*matchers)
-        super()
         @matchers = matchers
       end
 

--- a/lib/mocha/parameter_matchers/any_parameters.rb
+++ b/lib/mocha/parameter_matchers/any_parameters.rb
@@ -25,7 +25,9 @@ module Mocha
     end
 
     # Parameter matcher which always matches whatever the parameters.
-    class AnyParameters < Base
+    class AnyParameters
+      include Base
+
       # @private
       def matches?(available_parameters)
         until available_parameters.empty?

--- a/lib/mocha/parameter_matchers/anything.rb
+++ b/lib/mocha/parameter_matchers/anything.rb
@@ -22,7 +22,9 @@ module Mocha
     end
 
     # Parameter matcher which always matches a single parameter.
-    class Anything < Base
+    class Anything
+      include Base
+
       # @private
       def matches?(available_parameters)
         available_parameters.shift

--- a/lib/mocha/parameter_matchers/base.rb
+++ b/lib/mocha/parameter_matchers/base.rb
@@ -2,8 +2,8 @@
 
 module Mocha
   module ParameterMatchers
-    # @abstract Subclass and implement +#matches?+ and +#mocha_inspect+ to define a custom matcher. Also add a suitably named instance method to {ParameterMatchers} to build an instance of the new matcher c.f. {#equals}.
-    class Base
+    # @abstract Include and implement +#matches?+ and +#mocha_inspect+ to define a custom matcher. Also add a suitably named instance method to {ParameterMatchers} to build an instance of the new matcher c.f. {#equals}.
+    module Base
       # A shorthand way of combining two matchers when both must match.
       #
       # Returns a new {AllOf} parameter matcher combining two matchers using a logical AND.

--- a/lib/mocha/parameter_matchers/equals.rb
+++ b/lib/mocha/parameter_matchers/equals.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter equals expected value.
-    class Equals < Base
+    class Equals
+      include Base
+
       # @private
       def initialize(value)
-        super()
         @value = value
       end
 

--- a/lib/mocha/parameter_matchers/equivalent_uri.rb
+++ b/lib/mocha/parameter_matchers/equivalent_uri.rb
@@ -29,10 +29,11 @@ module Mocha
     end
 
     # Parameter matcher which matches URIs with equivalent query strings.
-    class EquivalentUri < Base
+    class EquivalentUri
+      include Base
+
       # @private
       def initialize(uri)
-        super()
         @uri = URI.parse(uri)
       end
 

--- a/lib/mocha/parameter_matchers/has_entries.rb
+++ b/lib/mocha/parameter_matchers/has_entries.rb
@@ -30,10 +30,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter contains all expected +Hash+ entries.
-    class HasEntries < Base
+    class HasEntries
+      include Base
+
       # @private
       def initialize(entries, exact: false)
-        super()
         @entries = entries
         @exact = exact
       end

--- a/lib/mocha/parameter_matchers/has_entry.rb
+++ b/lib/mocha/parameter_matchers/has_entry.rb
@@ -57,10 +57,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter contains expected +Hash+ entry.
-    class HasEntry < Base
+    class HasEntry
+      include Base
+
       # @private
       def initialize(key, value)
-        super()
         @key = key
         @value = value
       end

--- a/lib/mocha/parameter_matchers/has_key.rb
+++ b/lib/mocha/parameter_matchers/has_key.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter contains +Hash+ entry with expected key.
-    class HasKey < Base
+    class HasKey
+      include Base
+
       # @private
       def initialize(key)
-        super()
         @key = key
       end
 

--- a/lib/mocha/parameter_matchers/has_keys.rb
+++ b/lib/mocha/parameter_matchers/has_keys.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter contains +Hash+ with all expected keys.
-    class HasKeys < Base
+    class HasKeys
+      include Base
+
       # @private
       def initialize(*keys)
-        super()
         raise ArgumentError, 'No arguments. Expecting at least one.' if keys.empty?
 
         @keys = keys

--- a/lib/mocha/parameter_matchers/has_value.rb
+++ b/lib/mocha/parameter_matchers/has_value.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter contains +Hash+ entry with expected value.
-    class HasValue < Base
+    class HasValue
+      include Base
+
       # @private
       def initialize(value)
-        super()
         @value = value
       end
 

--- a/lib/mocha/parameter_matchers/includes.rb
+++ b/lib/mocha/parameter_matchers/includes.rb
@@ -67,10 +67,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter includes expected values.
-    class Includes < Base
+    class Includes
+      include Base
+
       # @private
       def initialize(*items)
-        super()
         @items = items
       end
 

--- a/lib/mocha/parameter_matchers/instance_of.rb
+++ b/lib/mocha/parameter_matchers/instance_of.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter is an instance of the specified class.
-    class InstanceOf < Base
+    class InstanceOf
+      include Base
+
       # @private
       def initialize(klass)
-        super()
         @klass = klass
       end
 

--- a/lib/mocha/parameter_matchers/is_a.rb
+++ b/lib/mocha/parameter_matchers/is_a.rb
@@ -29,10 +29,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter is a specific class.
-    class IsA < Base
+    class IsA
+      include Base
+
       # @private
       def initialize(klass)
-        super()
         @klass = klass
       end
 

--- a/lib/mocha/parameter_matchers/kind_of.rb
+++ b/lib/mocha/parameter_matchers/kind_of.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches when actual parameter is a kind of specified class.
-    class KindOf < Base
+    class KindOf
+      include Base
+
       # @private
       def initialize(klass)
-        super()
         @klass = klass
       end
 

--- a/lib/mocha/parameter_matchers/not.rb
+++ b/lib/mocha/parameter_matchers/not.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which inverts the logic of the specified matcher using a logical NOT operation.
-    class Not < Base
+    class Not
+      include Base
+
       # @private
       def initialize(matcher)
-        super()
         @matcher = matcher
       end
 

--- a/lib/mocha/parameter_matchers/optionally.rb
+++ b/lib/mocha/parameter_matchers/optionally.rb
@@ -37,10 +37,11 @@ module Mocha
     end
 
     # Parameter matcher which allows optional parameters to be specified.
-    class Optionally < Base
+    class Optionally
+      include Base
+
       # @private
       def initialize(*parameters)
-        super()
         @matchers = parameters.map(&:to_matcher)
       end
 

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -9,9 +9,10 @@ require 'mocha/parameter_matchers/has_entries'
 module Mocha
   module ParameterMatchers
     # @private
-    class PositionalOrKeywordHash < Base
+    class PositionalOrKeywordHash
+      include Base
+
       def initialize(value, expectation)
-        super()
         @value = value
         @expectation = expectation
       end

--- a/lib/mocha/parameter_matchers/regexp_matches.rb
+++ b/lib/mocha/parameter_matchers/regexp_matches.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches if specified regular expression matches actual paramter.
-    class RegexpMatches < Base
+    class RegexpMatches
+      include Base
+
       # @private
       def initialize(regexp)
-        super()
         @regexp = regexp
       end
 

--- a/lib/mocha/parameter_matchers/responds_with.rb
+++ b/lib/mocha/parameter_matchers/responds_with.rb
@@ -56,10 +56,11 @@ module Mocha
     end
 
     # Parameter matcher which matches if actual parameter returns expected result when specified method is invoked.
-    class RespondsWith < Base
+    class RespondsWith
+      include Base
+
       # @private
       def initialize(message, result)
-        super()
         @message = message
         @result = result
       end

--- a/lib/mocha/parameter_matchers/yaml_equivalent.rb
+++ b/lib/mocha/parameter_matchers/yaml_equivalent.rb
@@ -28,10 +28,11 @@ module Mocha
     end
 
     # Parameter matcher which matches if actual parameter is YAML equivalent of specified object.
-    class YamlEquivalent < Base
+    class YamlEquivalent
+      include Base
+
       # @private
       def initialize(object)
-        super()
         @object = object
       end
 


### PR DESCRIPTION
It's possibly a bit weird to use the YARD "abstract" tag for a module, but it seems to work OK and so it will do for now.

Closes #712.