### PR TITLE
Allow keyword arguments to match an expectation expecting *only* positional arguments

### DIFF
--- a/lib/mocha/parameter_matchers/instance_methods.rb
+++ b/lib/mocha/parameter_matchers/instance_methods.rb
@@ -9,11 +9,11 @@ module Mocha
     # @private
     module InstanceMethods
       # @private
-      def to_matcher(expectation: nil, top_level: false)
+      def to_matcher(expectation: nil, top_level: false, last: false)
         if Base === self
           self
         elsif Hash === self && top_level
-          Mocha::ParameterMatchers::PositionalOrKeywordHash.new(self, expectation)
+          Mocha::ParameterMatchers::PositionalOrKeywordHash.new(self, expectation, last)
         else
           Mocha::ParameterMatchers::Equals.new(self)
         end

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -35,15 +35,16 @@ module Mocha
       private
 
       def matches_last_actual_value?(actual_value)
-        if !same_type_of_hash?(actual_value, @expected_value)
+        if same_type_of_hash?(actual_value, @expected_value)
+          return true
+        else
           return true if @last_expected_value && !ruby2_keywords_hash?(@expected_value)
 
           return false if Mocha.configuration.strict_keyword_argument_matching?
 
           deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
+          return true
         end
-
-        true
       end
 
       def extract_actual_value(actual_values)

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -12,9 +12,10 @@ module Mocha
     class PositionalOrKeywordHash
       include Base
 
-      def initialize(expected_value, expectation)
+      def initialize(expected_value, expectation, last_expected_value)
         @expected_value = expected_value
         @expectation = expectation
+        @last_expected_value = last_expected_value
       end
 
       def matches?(actual_values)
@@ -23,6 +24,8 @@ module Mocha
         return false unless HasEntries.new(@expected_value, exact: true).matches?([actual_value])
 
         if is_last_actual_value && !same_type_of_hash?(actual_value, @expected_value)
+          return true if @last_expected_value && !ruby2_keywords_hash?(@expected_value)
+
           return false if Mocha.configuration.strict_keyword_argument_matching?
 
           deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -12,27 +12,27 @@ module Mocha
     class PositionalOrKeywordHash
       include Base
 
-      def initialize(value, expectation)
-        @value = value
+      def initialize(expected_value, expectation)
+        @expected_value = expected_value
         @expectation = expectation
       end
 
       def matches?(available_parameters)
         parameter, is_last_parameter = extract_parameter(available_parameters)
 
-        return false unless HasEntries.new(@value, exact: true).matches?([parameter])
+        return false unless HasEntries.new(@expected_value, exact: true).matches?([parameter])
 
-        if is_last_parameter && !same_type_of_hash?(parameter, @value)
+        if is_last_parameter && !same_type_of_hash?(parameter, @expected_value)
           return false if Mocha.configuration.strict_keyword_argument_matching?
 
-          deprecation_warning(parameter, @value) if Mocha::RUBY_V27_PLUS
+          deprecation_warning(parameter, @expected_value) if Mocha::RUBY_V27_PLUS
         end
 
         true
       end
 
       def mocha_inspect
-        @value.mocha_inspect
+        @expected_value.mocha_inspect
       end
 
       private

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -37,7 +37,7 @@ module Mocha
       def matches_last_actual_value?(actual_value)
         if same_type_of_hash?(actual_value, @expected_value)
           return true
-        elsif @last_expected_value && !ruby2_keywords_hash?(@expected_value)
+        elsif last_expected_value_is_positional_hash?
           return true
         elsif Mocha.configuration.strict_keyword_argument_matching?
           return false
@@ -45,6 +45,10 @@ module Mocha
           deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
           return true
         end
+      end
+
+      def last_expected_value_is_positional_hash?
+        @last_expected_value && !ruby2_keywords_hash?(@expected_value)
       end
 
       def extract_actual_value(actual_values)

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -37,11 +37,11 @@ module Mocha
       def matches_last_actual_value?(actual_value)
         if same_type_of_hash?(actual_value, @expected_value)
           return true
+        elsif @last_expected_value && !ruby2_keywords_hash?(@expected_value)
+          return true
+        elsif Mocha.configuration.strict_keyword_argument_matching?
+          return false
         else
-          return true if @last_expected_value && !ruby2_keywords_hash?(@expected_value)
-
-          return false if Mocha.configuration.strict_keyword_argument_matching?
-
           deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
           return true
         end

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -23,13 +23,7 @@ module Mocha
 
         return false unless HasEntries.new(@expected_value, exact: true).matches?([actual_value])
 
-        if is_last_actual_value && !same_type_of_hash?(actual_value, @expected_value)
-          return true if @last_expected_value && !ruby2_keywords_hash?(@expected_value)
-
-          return false if Mocha.configuration.strict_keyword_argument_matching?
-
-          deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
-        end
+        return matches_last_actual_value?(actual_value) if is_last_actual_value
 
         true
       end
@@ -39,6 +33,18 @@ module Mocha
       end
 
       private
+
+      def matches_last_actual_value?(actual_value)
+        if !same_type_of_hash?(actual_value, @expected_value)
+          return true if @last_expected_value && !ruby2_keywords_hash?(@expected_value)
+
+          return false if Mocha.configuration.strict_keyword_argument_matching?
+
+          deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
+        end
+
+        true
+      end
 
       def extract_actual_value(actual_values)
         [actual_values.shift, actual_values.empty?]

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -21,11 +21,13 @@ module Mocha
       def matches?(actual_values)
         actual_value, is_last_actual_value = extract_actual_value(actual_values)
 
-        return false unless HasEntries.new(@expected_value, exact: true).matches?([actual_value])
-
-        return matches_last_actual_value?(actual_value) if is_last_actual_value
-
-        true
+        if !HasEntries.new(@expected_value, exact: true).matches?([actual_value])
+          return false
+        elsif is_last_actual_value
+          return matches_last_actual_value?(actual_value)
+        else
+          return true
+        end
       end
 
       def mocha_inspect

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -17,8 +17,8 @@ module Mocha
         @expectation = expectation
       end
 
-      def matches?(available_parameters)
-        parameter, is_last_parameter = extract_parameter(available_parameters)
+      def matches?(actual_values)
+        parameter, is_last_parameter = extract_parameter(actual_values)
 
         return false unless HasEntries.new(@expected_value, exact: true).matches?([parameter])
 
@@ -37,8 +37,8 @@ module Mocha
 
       private
 
-      def extract_parameter(available_parameters)
-        [available_parameters.shift, available_parameters.empty?]
+      def extract_parameter(actual_values)
+        [actual_values.shift, actual_values.empty?]
       end
 
       def same_type_of_hash?(actual, expected)

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -21,7 +21,7 @@ module Mocha
       def matches?(actual_values)
         actual_value, is_last_actual_value = extract_actual_value(actual_values)
 
-        if !HasEntries.new(@expected_value, exact: true).matches?([actual_value])
+        if !matches_entries_exactly?(actual_value)
           return false
         elsif is_last_actual_value
           return matches_last_actual_value?(actual_value)
@@ -35,6 +35,10 @@ module Mocha
       end
 
       private
+
+      def matches_entries_exactly?(actual_value)
+        HasEntries.new(@expected_value, exact: true).matches?([actual_value])
+      end
 
       def matches_last_actual_value?(actual_value)
         if same_type_of_hash?(actual_value, @expected_value)

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -22,11 +22,11 @@ module Mocha
         actual_value, is_last_actual_value = extract_actual_value(actual_values)
 
         if !matches_entries_exactly?(actual_value)
-          return false
+          false
         elsif is_last_actual_value
-          return matches_last_actual_value?(actual_value)
+          matches_last_actual_value?(actual_value)
         else
-          return true
+          true
         end
       end
 
@@ -42,14 +42,14 @@ module Mocha
 
       def matches_last_actual_value?(actual_value)
         if same_type_of_hash?(actual_value, @expected_value)
-          return true
+          true
         elsif last_expected_value_is_positional_hash?
-          return true
+          true
         elsif Mocha.configuration.strict_keyword_argument_matching?
-          return false
+          false
         else
           deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
-          return true
+          true
         end
       end
 

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -18,14 +18,14 @@ module Mocha
       end
 
       def matches?(actual_values)
-        parameter, is_last_parameter = extract_parameter(actual_values)
+        actual_value, is_last_actual_value = extract_actual_value(actual_values)
 
-        return false unless HasEntries.new(@expected_value, exact: true).matches?([parameter])
+        return false unless HasEntries.new(@expected_value, exact: true).matches?([actual_value])
 
-        if is_last_parameter && !same_type_of_hash?(parameter, @expected_value)
+        if is_last_actual_value && !same_type_of_hash?(actual_value, @expected_value)
           return false if Mocha.configuration.strict_keyword_argument_matching?
 
-          deprecation_warning(parameter, @expected_value) if Mocha::RUBY_V27_PLUS
+          deprecation_warning(actual_value, @expected_value) if Mocha::RUBY_V27_PLUS
         end
 
         true
@@ -37,7 +37,7 @@ module Mocha
 
       private
 
-      def extract_parameter(actual_values)
+      def extract_actual_value(actual_values)
         [actual_values.shift, actual_values.empty?]
       end
 

--- a/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
+++ b/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb
@@ -43,7 +43,7 @@ module Mocha
       def matches_last_actual_value?(actual_value)
         if same_type_of_hash?(actual_value, @expected_value)
           true
-        elsif last_expected_value_is_positional_hash?
+        elsif last_expected_value_is_positional_hash? # rubocop:disable Lint/DuplicateBranch
           true
         elsif Mocha.configuration.strict_keyword_argument_matching?
           false

--- a/lib/mocha/parameters_matcher.rb
+++ b/lib/mocha/parameters_matcher.rb
@@ -34,7 +34,13 @@ module Mocha
     end
 
     def matchers
-      @expected_parameters.map { |p| p.to_matcher(expectation: @expectation, top_level: true) }
+      @expected_parameters.map.with_index do |parameter, index|
+        parameter.to_matcher(
+          expectation: @expectation,
+          top_level: true,
+          last: index == @expected_parameters.length - 1
+        )
+      end
     end
   end
 end

--- a/test/acceptance/loose_keyword_argument_matching_test.rb
+++ b/test/acceptance/loose_keyword_argument_matching_test.rb
@@ -27,13 +27,13 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
         mock.method({ key: 42 })
       end
     end
-    if Mocha::RUBY_V27_PLUS
-      assert_deprecation_warning_location(test_result, execution_point)
-      assert_deprecation_warning(
-        test_result, 'expected keyword arguments (key: 42), but received positional hash ({key: 42})'
-      )
-    end
     assert_passed(test_result)
+    return unless Mocha::RUBY_V27_PLUS
+
+    assert_deprecation_warning_location(test_result, execution_point)
+    assert_deprecation_warning(
+      test_result, 'expected keyword arguments (key: 42), but received positional hash ({key: 42})'
+    )
   end
 
   def test_should_match_hash_parameter_with_splatted_keyword_args
@@ -46,13 +46,13 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
         mock.method({ key: 42 })
       end
     end
-    if Mocha::RUBY_V27_PLUS
-      assert_deprecation_warning_location(test_result, execution_point)
-      assert_deprecation_warning(
-        test_result, 'expected keyword arguments (key: 42), but received positional hash ({key: 42})'
-      )
-    end
     assert_passed(test_result)
+    return unless Mocha::RUBY_V27_PLUS
+
+    assert_deprecation_warning_location(test_result, execution_point)
+    assert_deprecation_warning(
+      test_result, 'expected keyword arguments (key: 42), but received positional hash ({key: 42})'
+    )
   end
 
   def test_should_match_positional_and_keyword_args_with_last_positional_hash
@@ -64,13 +64,13 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
         mock.method(1, key: 42)
       end
     end
-    if Mocha::RUBY_V27_PLUS
-      assert_deprecation_warning_location(test_result, execution_point)
-      assert_deprecation_warning(
-        test_result, 'expected positional hash ({key: 42}), but received keyword arguments (key: 42)'
-      )
-    end
     assert_passed(test_result)
+    return unless Mocha::RUBY_V27_PLUS
+
+    assert_deprecation_warning_location(test_result, execution_point)
+    assert_deprecation_warning(
+      test_result, 'expected positional hash ({key: 42}), but received keyword arguments (key: 42)'
+    )
   end
 
   def test_should_match_last_positional_hash_with_keyword_args
@@ -82,13 +82,13 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
         mock.method(1, { key: 42 })
       end
     end
-    if Mocha::RUBY_V27_PLUS
-      assert_deprecation_warning_location(test_result, execution_point)
-      assert_deprecation_warning(
-        test_result, 'expected keyword arguments (key: 42), but received positional hash ({key: 42})'
-      )
-    end
     assert_passed(test_result)
+    return unless Mocha::RUBY_V27_PLUS
+
+    assert_deprecation_warning_location(test_result, execution_point)
+    assert_deprecation_warning(
+      test_result, 'expected keyword arguments (key: 42), but received positional hash ({key: 42})'
+    )
   end
 
   private

--- a/test/acceptance/loose_keyword_argument_matching_test.rb
+++ b/test/acceptance/loose_keyword_argument_matching_test.rb
@@ -67,10 +67,7 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
     assert_passed(test_result)
     return unless Mocha::RUBY_V27_PLUS
 
-    assert_deprecation_warning_location(test_result, execution_point)
-    assert_deprecation_warning(
-      test_result, 'expected positional hash ({key: 42}), but received keyword arguments (key: 42)'
-    )
+    assert_no_deprecation_warning(test_result)
   end
 
   def test_should_match_last_positional_hash_with_keyword_args
@@ -95,6 +92,11 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
 
   def assert_deprecation_warning(test_result, expected_warning)
     assert_includes test_result.last_deprecation_warning, expected_warning
+  end
+
+  def assert_no_deprecation_warning(test_result)
+    warning = test_result.last_deprecation_warning
+    assert_nil warning, "Unexpected deprecation warning: #{warning}"
   end
 
   def assert_deprecation_warning_location(test_result, execution_point)

--- a/test/acceptance/strict_keyword_argument_matching_test.rb
+++ b/test/acceptance/strict_keyword_argument_matching_test.rb
@@ -43,7 +43,7 @@ if Mocha::RUBY_V27_PLUS
         mock.expects(:method).with(1, { key: 42 })
         mock.method(1, key: 42)
       end
-      assert_failed(test_result)
+      assert_passed(test_result)
     end
 
     def test_should_not_match_last_positional_hash_with_keyword_args

--- a/test/acceptance/strict_keyword_argument_matching_test.rb
+++ b/test/acceptance/strict_keyword_argument_matching_test.rb
@@ -18,7 +18,7 @@ if Mocha::RUBY_V27_PLUS
       teardown_acceptance_test
     end
 
-    def test_should_not_match_hash_parameter_with_keyword_args_when_strict_keyword_matching_is_enabled
+    def test_should_not_match_hash_parameter_with_keyword_args
       test_result = run_as_test do
         mock = mock()
         mock.expects(:method).with(key: 42)
@@ -27,7 +27,7 @@ if Mocha::RUBY_V27_PLUS
       assert_failed(test_result)
     end
 
-    def test_should_not_match_hash_parameter_with_splatted_keyword_args_when_strict_keyword_matching_is_enabled
+    def test_should_not_match_hash_parameter_with_splatted_keyword_args
       test_result = run_as_test do
         mock = mock()
         kwargs = { key: 42 }
@@ -37,7 +37,7 @@ if Mocha::RUBY_V27_PLUS
       assert_failed(test_result)
     end
 
-    def test_should_not_match_positional_and_keyword_args_with_last_positional_hash_when_strict_keyword_args_is_enabled
+    def test_should_not_match_positional_and_keyword_args_with_last_positional_hash
       test_result = run_as_test do
         mock = mock()
         mock.expects(:method).with(1, { key: 42 })
@@ -46,7 +46,7 @@ if Mocha::RUBY_V27_PLUS
       assert_failed(test_result)
     end
 
-    def test_should_not_match_last_positional_hash_with_keyword_args_when_strict_keyword_args_is_enabled
+    def test_should_not_match_last_positional_hash_with_keyword_args
       test_result = run_as_test do
         mock = mock()
         mock.expects(:method).with(1, key: 42)

--- a/test/unit/parameter_matchers/loose_positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/loose_positional_or_keyword_hash_test.rb
@@ -27,9 +27,10 @@ class LoosePositionalOrKeywordHashTest < Mocha::TestCase
     Mocha.configure { |c| c.strict_keyword_argument_matching = @original }
   end
 
-  def test_should_match_hash_arg_with_keyword_args_but_display_deprecation_warning_if_appropriate
+  def test_should_match_hash_arg_with_keyword_args_but_display_deprecation_warning_if_not_last_matcher
     expectation = Mocha::Expectation.new(self, :foo)
-    matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }), expectation)
+    last_matcher = false
+    matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }), expectation, last_matcher)
     capture_deprecation_warnings do
       assert matcher.matches?([{ key_1: 1, key_2: 2 }])
     end
@@ -43,9 +44,27 @@ class LoosePositionalOrKeywordHashTest < Mocha::TestCase
     assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
   end
 
-  def test_should_match_keyword_args_with_hash_arg_but_display_deprecation_warning_if_appropriate
+  def test_should_match_hash_arg_with_keyword_args_but_display_deprecation_warning_if_last_matcher
     expectation = Mocha::Expectation.new(self, :foo)
-    matcher = build_matcher({ key_1: 1, key_2: 2 }, expectation)
+    last_matcher = true
+    matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }), expectation, last_matcher)
+    capture_deprecation_warnings do
+      assert matcher.matches?([{ key_1: 1, key_2: 2 }])
+    end
+    return unless Mocha::RUBY_V27_PLUS
+
+    message = last_deprecation_warning
+    location = expectation.definition_location
+    assert_includes message, "Expectation defined at #{location} expected keyword arguments (key_1: 1, key_2: 2)"
+    assert_includes message, 'but received positional hash ({key_1: 1, key_2: 2})'
+    assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
+    assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
+  end
+
+  def test_should_match_keyword_args_with_hash_arg_but_display_deprecation_warning_if_not_last_matcher
+    expectation = Mocha::Expectation.new(self, :foo)
+    last_matcher = false
+    matcher = build_matcher({ key_1: 1, key_2: 2 }, expectation, last_matcher)
     capture_deprecation_warnings do
       assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })])
     end
@@ -57,6 +76,18 @@ class LoosePositionalOrKeywordHashTest < Mocha::TestCase
     assert_includes message, 'but received keyword arguments (key_1: 1, key_2: 2)'
     assert_includes message, 'These will stop matching when strict keyword argument matching is enabled.'
     assert_includes message, 'See the documentation for Mocha::Configuration#strict_keyword_argument_matching=.'
+  end
+
+  def test_should_match_keyword_args_with_hash_arg_but_not_display_deprecation_warning_if_last_matcher
+    expectation = Mocha::Expectation.new(self, :foo)
+    last_matcher = true
+    matcher = build_matcher({ key_1: 1, key_2: 2 }, expectation, last_matcher)
+    capture_deprecation_warnings do
+      assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })])
+    end
+    return unless Mocha::RUBY_V27_PLUS
+
+    assert_nil last_deprecation_warning
   end
 
   def test_should_display_deprecation_warning_even_if_parent_expectation_is_nil
@@ -74,7 +105,7 @@ class LoosePositionalOrKeywordHashTest < Mocha::TestCase
 
   private
 
-  def build_matcher(hash, expectation = nil)
-    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation)
+  def build_matcher(hash, expectation = nil, last = nil)
+    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation, last)
   end
 end

--- a/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/positional_or_keyword_hash_test.rb
@@ -63,7 +63,7 @@ class PositionalOrKeywordHashTest < Mocha::TestCase
 
   private
 
-  def build_matcher(hash, expectation = nil)
-    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation)
+  def build_matcher(hash, expectation = nil, last = nil)
+    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation, last)
   end
 end

--- a/test/unit/parameter_matchers/strict_positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/strict_positional_or_keyword_hash_test.rb
@@ -9,23 +9,19 @@ require 'mocha/expectation'
 require 'mocha/ruby_version'
 require 'mocha/configuration'
 
-class StrictPositionalOrKeywordHashTest < Mocha::TestCase
-  include Mocha::ParameterMatchers
+if Mocha::RUBY_V27_PLUS
+  class StrictPositionalOrKeywordHashTest < Mocha::TestCase
+    include Mocha::ParameterMatchers
 
-  def setup
-    return unless Mocha::RUBY_V27_PLUS
+    def setup
+      @original = Mocha.configuration.strict_keyword_argument_matching?
+      Mocha.configure { |c| c.strict_keyword_argument_matching = true }
+    end
 
-    @original = Mocha.configuration.strict_keyword_argument_matching?
-    Mocha.configure { |c| c.strict_keyword_argument_matching = true }
-  end
+    def teardown
+      Mocha.configure { |c| c.strict_keyword_argument_matching = @original }
+    end
 
-  def teardown
-    return unless Mocha::RUBY_V27_PLUS
-
-    Mocha.configure { |c| c.strict_keyword_argument_matching = @original } if Mocha::RUBY_V27_PLUS
-  end
-
-  if Mocha::RUBY_V27_PLUS
     def test_should_match_non_last_hash_arg_with_hash_arg
       hash = { key_1: 1, key_2: 2 }
       matcher = build_matcher(hash)
@@ -74,11 +70,11 @@ class StrictPositionalOrKeywordHashTest < Mocha::TestCase
       matcher = build_matcher(hash, nil, last_matcher)
       assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })])
     end
-  end
 
-  private
+    private
 
-  def build_matcher(hash, expectation = nil, last = nil)
-    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation, last)
+    def build_matcher(hash, expectation = nil, last = nil)
+      Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation, last)
+    end
   end
 end

--- a/test/unit/parameter_matchers/strict_positional_or_keyword_hash_test.rb
+++ b/test/unit/parameter_matchers/strict_positional_or_keyword_hash_test.rb
@@ -49,21 +49,36 @@ class StrictPositionalOrKeywordHashTest < Mocha::TestCase
       assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })])
     end
 
-    def test_should_not_match_hash_arg_with_keyword_args
-      matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }))
+    def test_should_not_match_hash_arg_with_keyword_args_if_not_last_matcher
+      last_matcher = false
+      matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }), nil, last_matcher)
       assert !matcher.matches?([{ key_1: 1, key_2: 2 }])
     end
 
-    def test_should_not_match_keyword_args_with_hash_arg
+    def test_should_not_match_hash_arg_with_keyword_args_if_last_matcher
+      last_matcher = true
+      matcher = build_matcher(Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 }), nil, last_matcher)
+      assert !matcher.matches?([{ key_1: 1, key_2: 2 }])
+    end
+
+    def test_should_not_match_keyword_args_with_hash_arg_if_not_last_matcher
       hash = { key_1: 1, key_2: 2 }
-      matcher = build_matcher(hash)
+      last_matcher = false
+      matcher = build_matcher(hash, nil, last_matcher)
       assert !matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })])
+    end
+
+    def test_should_match_keyword_args_with_hash_arg_if_last_matcher
+      hash = { key_1: 1, key_2: 2 }
+      last_matcher = true
+      matcher = build_matcher(hash, nil, last_matcher)
+      assert matcher.matches?([Hash.ruby2_keywords_hash({ key_1: 1, key_2: 2 })])
     end
   end
 
   private
 
-  def build_matcher(hash, expectation = nil)
-    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation)
+  def build_matcher(hash, expectation = nil, last = nil)
+    Mocha::ParameterMatchers::PositionalOrKeywordHash.new(hash, expectation, last)
   end
 end


### PR DESCRIPTION
TODO:
* [x] Address to-do list in WIP commit
    * [x] Try to simpify logic in `PositionalOrKeywordHash#matches?`
    * ~~[ ] Maybe use keyword arguments for `PositionalOrKeywordHash` constructor~~
    * [x] Check whether all relevant scenarios are covered by tests
    * [x] Check whether this has any effect on https://github.com/freerange/mocha/issues/594 (I don't think it does)
* [x] Check the examples below

This is a (very belated) possible fix for #593.

According to [these docs](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/):

> Note that Ruby 3.0 doesn’t behave differently when calling a method which doesn’t accept keyword arguments with keyword arguments. For instance, the following case is not going to be deprecated and will keep working in Ruby 3.0. The keyword arguments are still treated as a positional Hash argument.
> 
> ```ruby
> def foo(kwargs = {})
>  kwargs
> end
> 
> foo(k: 1) #=> {:k=>1}
> ```
> 
> This is because this style is used very frequently, and there is no ambiguity in how the argument should be treated. Prohibiting this conversion would result in additional incompatibility for little benefit.

This solution takes an alternative approach to #605 which depended on #532. Instead of basing the logic in `Mocha::ParameterMatchers::PositionalOrKeywordHash#matches?` on the original method signature, it bases it on the expected arguments, i.e. the parameter matchers. Since keyword arguments can only appear after all positional arguments, we can detect an expectation which only expects positional arguments by checking whether the last parameter matcher is expecting a positional Hash or a keyword Hash. If it's expecting a positional Hash then we can assume the expectation only expects positional arguments and thus it should successfully match keyword arguments with that positional Hash without issuing a deprecation warning.

I think my work on #532 at the time must've blinded me to the idea that we needed to base the logic on the original method signature which is a considerably more complicated undertaking. Although the solution in this PR might not be perfect, I think it's probably an improvement and we can look at ensuring that expected parameters match the original method signature as a separate issue which relates to #149, #531 & #532.

#### Before fix

```ruby
foo = mock('foo')
foo.stubs(:bar).with(123, { baz: 456 })

Mocha::Configuration.override(strict_keyword_argument_matching: false) do
  foo.bar(123, { baz: 456 }) # => matched *without* deprecation warning
  foo.bar(123, baz: 456) # => matched *with* deprecation warning
end

Mocha::Configuration.override(strict_keyword_argument_matching: true) do
  foo.bar(123, { baz: 456 }) # => matched *without* deprecation warning
  foo.bar(123, baz: 456) # => did not match
end
```

#### After fix

```ruby
foo = mock('foo')
foo.stubs(:bar).with(123, { baz: 456 })

Mocha::Configuration.override(strict_keyword_argument_matching: false) do
  foo.bar(123, { baz: 456 }) # => matches *without* deprecation warning
  foo.bar(123, baz: 456) # => matches *without* deprecation warning
end

Mocha::Configuration.override(strict_keyword_argument_matching: true) do
  foo.bar(123, { baz: 456 }) # => matches *without* deprecation warning
  foo.bar(123, baz: 456) # => matches *without* deprecation warning
end
```
