### PR TITLE
Remove workaround for JRuby jar-dependencies issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,6 @@ group :development do
   gem 'minitest'
   gem 'rake'
 
-  if RUBY_ENGINE == 'jruby'
-    # Workaround for https://github.com/jruby/jruby/issues/8488
-    gem 'jar-dependencies', '~> 0.4.1'
-  end
-
   if ENV['MOCHA_GENERATE_DOCS']
     gem 'redcarpet'
     gem 'yard'


### PR DESCRIPTION
A fix for [this issue][1] was released in [JRuby 9.4.11.0][2] and so [this workaround][3] can be removed, since the `Gemfile` is only used for development.

[1]: https://github.com/jruby/jruby/issues/8488
[2]: https://github.com/jruby/jruby/releases/tag/9.4.11.0
[3]: https://github.com/freerange/mocha/pull/690