### PR TITLE
Fix benchmark-related warning #733

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'benchmark'
   gem 'introspection', '~> 0.0.1'
   gem 'minitest'
   gem 'rake'


### PR DESCRIPTION
Closes #733 

per the suggestion in the benchmark-related warning:

warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.You can add benchmark to your Gemfile or gemspec to silence this warning.