### PR TITLE
Builds fail fast on any ruby warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ jobs:
         type: string
     docker:
       - image: << parameters.docker-image >>
-    environment:
-      RUBYOPT: --enable-frozen-string-literal
     steps:
       - checkout
       - run: ruby --version
@@ -23,6 +21,10 @@ jobs:
       - run: gem --version
       - run: bundle --version
       - run: bundle install --gemfile=<< parameters.gemfile >>
+      - run: |
+          if [ "<< parameters.docker-image >>" > "ruby:2.2" ]; then
+            export RUBYOPT="--enable-frozen-string-literal"
+          fi
       - when:
           condition:
             equal: ["Gemfile", << parameters.gemfile >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
 version: 2.1
 
+commands:
+  run-fail-fast:
+    description: "Execute command and fail on any warning in output"
+    parameters:
+      command:
+        type: string
+    steps:
+      - run: << parameters.command >> 2>&1 | tee output.log
+      - run: |
+          if grep -q "warning:" output.log; then
+            echo "Warnings found in test output. Failing the job."
+            exit 1
+          fi
 jobs:
   build:
     parameters:
@@ -29,28 +42,32 @@ jobs:
           condition:
             equal: ["Gemfile", << parameters.gemfile >>]
           steps:
-            - run: bundle exec rake test
+            - run-fail-fast:
+                command: bundle exec rake test
       - when:
           condition:
             matches:
               pattern: ".*minitest.*"
               value: << parameters.gemfile >>
           steps:
-            - run: MOCHA_RUN_INTEGRATION_TESTS=minitest bundle exec --gemfile=<< parameters.gemfile >> rake test
+            - run-fail-fast:
+                command: MOCHA_RUN_INTEGRATION_TESTS=minitest bundle exec --gemfile=<< parameters.gemfile >> rake test
       - when:
           condition:
             matches:
               pattern: ".*test-unit.*"
               value: << parameters.gemfile >>
           steps:
-            - run: MOCHA_RUN_INTEGRATION_TESTS=test-unit bundle exec --gemfile=<< parameters.gemfile >> rake test
+            - run-fail-fast:
+                command: MOCHA_RUN_INTEGRATION_TESTS=test-unit bundle exec --gemfile=<< parameters.gemfile >> rake test
       - when:
           condition:
             and:
               - equal: ["ruby:latest", << parameters.docker-image >>]
               - equal: ["Gemfile", << parameters.gemfile >>]
           steps:
-            - run: bundle exec rake test:performance
+            - run-fail-fast:
+                command: bundle exec rake test:performance
             - run: MOCHA_GENERATE_DOCS=1 bundle install --gemfile=<< parameters.gemfile >>
             - run: RUBYOPT=--disable-frozen-string-literal MOCHA_GENERATE_DOCS=1 rake docs docs:coverage
   lint:

--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -20,7 +20,7 @@ module Mocha
       end
 
       def logger
-        @logger || Logger.new
+        @logger ||= Logger.new
       end
     end
   end

--- a/lib/mocha/ignoring_warning.rb
+++ b/lib/mocha/ignoring_warning.rb
@@ -1,15 +1,20 @@
 module Mocha
+  # @private
   module IgnoringWarning
-    def ignoring_warning(pattern)
-      original_warn = Warning.method(:warn)
-      Warning.singleton_class.define_method(:warn) do |message|
-        original_warn.call(message) unless message =~ pattern
-      end
+    def ignoring_warning(pattern, if_: true)
+      return yield unless if_
 
-      yield
-    ensure
-      Warning.singleton_class.undef_method(:warn)
-      Warning.singleton_class.define_method(:warn, original_warn)
+      begin
+        original_warn = Warning.method(:warn)
+        Warning.singleton_class.define_method(:warn) do |message|
+          original_warn.call(message) unless message =~ pattern
+        end
+
+        yield
+      ensure
+        Warning.singleton_class.undef_method(:warn)
+        Warning.singleton_class.define_method(:warn, original_warn)
+      end
     end
   end
 end

--- a/lib/mocha/ignoring_warning.rb
+++ b/lib/mocha/ignoring_warning.rb
@@ -1,0 +1,15 @@
+module Mocha
+  module IgnoringWarning
+    def ignoring_warning(pattern)
+      original_warn = Warning.method(:warn)
+      Warning.singleton_class.define_method(:warn) do |message|
+        original_warn.call(message) unless message =~ pattern
+      end
+
+      yield
+    ensure
+      Warning.singleton_class.undef_method(:warn)
+      Warning.singleton_class.define_method(:warn, original_warn)
+    end
+  end
+end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -4,26 +4,21 @@ require 'mocha/mockery'
 require 'mocha/instance_method'
 require 'mocha/argument_iterator'
 require 'mocha/expectation_error_factory'
+require 'mocha/ignoring_warning'
 
 module Mocha
   # Methods added to all objects to allow mocking and stubbing on real (i.e. non-mock) objects.
   #
   # Both {#expects} and {#stubs} return an {Expectation} which can be further modified by methods on {Expectation}.
   module ObjectMethods
-    if RUBY_ENGINE == 'jruby'
-      require 'mocha/ignoring_warning'
-      extend IgnoringWarning
+    extend IgnoringWarning
 
-      # @private
-      JRUBY_ALIAS_SPECIAL_METHODS_WARNING = /accesses caller method's state and should not be aliased/.freeze
+    # @private
+    JRUBY_ALIAS_SPECIAL_METHODS_WARNING = /accesses caller method's state and should not be aliased/.freeze
 
-      ignoring_warning(JRUBY_ALIAS_SPECIAL_METHODS_WARNING) do
-        alias_method :_method, :method
-      end
-    else
+    ignoring_warning(JRUBY_ALIAS_SPECIAL_METHODS_WARNING, if_: RUBY_ENGINE == 'jruby') do
       alias_method :_method, :method
     end
-
 
     # @private
     def mocha(instantiate: true)

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -10,8 +10,20 @@ module Mocha
   #
   # Both {#expects} and {#stubs} return an {Expectation} which can be further modified by methods on {Expectation}.
   module ObjectMethods
-    # @private
-    alias_method :_method, :method
+    if RUBY_ENGINE == 'jruby'
+      require 'mocha/ignoring_warning'
+      extend IgnoringWarning
+
+      # @private
+      JRUBY_ALIAS_SPECIAL_METHODS_WARNING = /accesses caller method's state and should not be aliased/.freeze
+
+      ignoring_warning(JRUBY_ALIAS_SPECIAL_METHODS_WARNING) do
+        alias_method :_method, :method
+      end
+    else
+      alias_method :_method, :method
+    end
+
 
     # @private
     def mocha(instantiate: true)

--- a/test/acceptance/loose_keyword_argument_matching_test.rb
+++ b/test/acceptance/loose_keyword_argument_matching_test.rb
@@ -56,10 +56,9 @@ class LooseKeywordArgumentMatchingTest < Mocha::TestCase
   end
 
   def test_should_match_positional_and_keyword_args_with_last_positional_hash
-    execution_point = nil
     test_result = run_as_test do
       mock = mock()
-      mock.expects(:method).with(1, { key: 42 }); execution_point = ExecutionPoint.current
+      mock.expects(:method).with(1, { key: 42 })
       capture_deprecation_warnings do
         mock.method(1, key: 42)
       end

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -3,10 +3,12 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/inspect'
 require 'mocha/ruby_version'
+require 'mocha/ignoring_warning'
 require 'method_definer'
 
 class ObjectInspectTest < Mocha::TestCase
   include MethodDefiner
+  include Mocha::IgnoringWarning
 
   def test_should_return_default_string_representation_of_object_not_including_instance_variables
     object = Object.new
@@ -29,15 +31,7 @@ class ObjectInspectTest < Mocha::TestCase
   def test_should_use_underscored_id_instead_of_object_id_or_id_so_that_they_can_be_stubbed
     object = Object.new
 
-    if Mocha::RUBY_V34_PLUS
-      require 'mocha/ignoring_warning'
-      include Mocha::IgnoringWarning
-      ignoring_warning(/warning: redefining 'object_id' may cause serious problems/) do
-        replace_instance_method(object, :object_id) do
-          flunk 'should not call `Object#object_id`'
-        end
-      end
-    else
+    ignoring_warning(/warning: redefining 'object_id' may cause serious problems/, if_: Mocha::RUBY_V34_PLUS) do
       replace_instance_method(object, :object_id) do
         flunk 'should not call `Object#object_id`'
       end

--- a/test/unit/object_inspect_test.rb
+++ b/test/unit/object_inspect_test.rb
@@ -30,6 +30,8 @@ class ObjectInspectTest < Mocha::TestCase
     object = Object.new
 
     if Mocha::RUBY_V34_PLUS
+      require 'mocha/ignoring_warning'
+      include Mocha::IgnoringWarning
       ignoring_warning(/warning: redefining 'object_id' may cause serious problems/) do
         replace_instance_method(object, :object_id) do
           flunk 'should not call `Object#object_id`'
@@ -63,17 +65,5 @@ class ObjectInspectTest < Mocha::TestCase
     address = id * 2
     address += 0x100000000 if address < 0
     "#<#{klass}:0x#{Kernel.format('%<address>x', address: address)}>"
-  end
-
-  def ignoring_warning(pattern)
-    original_warn = Warning.method(:warn)
-    Warning.singleton_class.define_method(:warn) do |message|
-      original_warn.call(message) unless message =~ pattern
-    end
-
-    yield
-  ensure
-    Warning.singleton_class.undef_method(:warn)
-    Warning.singleton_class.define_method(:warn, original_warn)
   end
 end


### PR DESCRIPTION
Closes #729 

Introduces and uses a reusable command in CircleCI config for failing fast on warnings. Addresses resulting warnings that originally caused builds to fail with the updated configuration.
# Changes:
1. **CircleCI Configuration:**
  - Introduce a reusable run-fail-fast command to execute commands and fail on any warnings in the output.
  - Conditionally set RUBYOPT for all Ruby versions except ruby:2.2 (as that version doesn't support the frozen-string-literal flag).
2. **Update Gemfile:** Add the rdoc gem to the development group (as rdoc will no longer be part of the default gems starting from Ruby 3.5.0)
3. **Fix Resulting Warnings:**
  - Update lib/mocha/deprecation.rb to use @logger ||= Logger.new to silence uninitialized ivar warning on older ruby versions.
  - Add a JRuby-specific warning filter in lib/mocha/object_methods.rb to suppress unnecessary warnings.
  - Modify test/acceptance/loose_keyword_argument_matching_test.rb to remove unused variable.

# Benefits:
- **Improved Maintainability:** The CI configuration is more maintainable and easier to update.
- **Faster Feedback Loop:** The run-fail-fast command ensures that the CI pipeline fails immediately if any warnings are encountered during test execution, providing faster feedback.

# Testing:
The CI pipeline has been tested to ensure that it correctly fails on warnings for the specified Ruby versions.
