### PR TITLE
rename: respond_to? ->stubba_respond_to?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,37 +72,6 @@ Layout/LineLength:
 Gemspec/RequiredRubyVersion:
   Enabled: false
 
-# It can be useful to violate this cop in tests in order to be more explicit
-Lint/UselessTimes:
-  Exclude:
-    - 'test/**/*.rb'
-
-# It can be useful to violate this cop in tests
-Lint/EmptyClass:
-  Exclude:
-    - 'test/**/*.rb'
-
-# It can be useful to violate this cop in tests when testing methods that accept a block
-Lint/EmptyBlock:
-  Exclude:
-    - 'test/**/*.rb'
-
-# There are a mix of styles in the tests and so I don't think it's worth enforcing for now
-Naming/VariableNumber:
-  Exclude:
-    - 'test/**/*.rb'
-
-# These methods from Ruby core are legitimately overridden in the tests
-Style/OptionalBooleanParameter:
-  AllowedMethods:
-    - respond_to?
-    - public_methods
-    - protected_methods
-    - private_methods
-    - public_instance_methods
-    - protected_instance_methods
-    - private_instance_methods
-
 # This cop is useful for required environment variables, but not for optional ones
 Style/FetchEnvVar:
   AllowedVars:
@@ -110,9 +79,6 @@ Style/FetchEnvVar:
 
 Naming/FileName:
   ExpectMatchingDefinition: true
-  CheckDefinitionPathHierarchyRoots:
-    - test/unit
-    - test/acceptance
   Exclude:
     - lib/mocha/version.rb
     - lib/mocha/minitest.rb

--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -28,8 +28,8 @@ module Mocha
         @stubba_object
       end
 
-      def respond_to?(symbol, include_all = false)
-        @stubba_object.allocate.respond_to?(symbol.to_sym, include_all)
+      def stubba_respond_to?(symbol)
+        @stubba_object.allocate.respond_to?(symbol.to_sym)
       end
 
       attr_reader :stubba_object

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -133,7 +133,7 @@ module Mocha
     def on_stubbing(object, method)
       signature_proc = lambda { "#{object.mocha_inspect}.#{method}" }
       check(:stubbing_non_existent_method, 'non-existent method', signature_proc) do
-        !(object.stubba_class.__method_exists__?(method) || object.respond_to?(method))
+        !(object.stubba_class.__method_exists__?(method) || object.stubba_respond_to?(method))
       end
       check(:stubbing_non_public_method, 'non-public method', signature_proc) do
         object.stubba_class.__method_exists__?(method, include_public_methods: false)

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -49,6 +49,11 @@ module Mocha
       singleton_class
     end
 
+    # @private
+    def stubba_respond_to?(symbol)
+      respond_to?(symbol)
+    end
+
     # Adds an expectation that the specified method must be called exactly once with any parameters.
     #
     # The original implementation of the method is replaced during the test and then restored at the end of the test. The temporary replacement method has the same visibility as the original method.

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -19,7 +19,7 @@ Naming/VariableNumber:
 # These methods from Ruby core are legitimately overridden in the tests
 Style/OptionalBooleanParameter:
   AllowedMethods:
-    - respond_to?
+    - respond_to_missing?
     - public_methods
     - protected_methods
     - private_methods

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -1,0 +1,33 @@
+inherit_from: ../.rubocop.yml # Inherit from the global configuration
+
+# It can be useful to violate this cop in tests in order to be more explicit
+Lint/UselessTimes:
+  Enabled: false
+
+# It can be useful to violate this cop in tests
+Lint/EmptyClass:
+  Enabled: false
+
+# It can be useful to violate this cop in tests when testing methods that accept a block
+Lint/EmptyBlock:
+  Enabled: false
+
+# There are a mix of styles in the tests and so I don't think it's worth enforcing for now
+Naming/VariableNumber:
+  Enabled: false
+
+# These methods from Ruby core are legitimately overridden in the tests
+Style/OptionalBooleanParameter:
+  AllowedMethods:
+    - respond_to?
+    - public_methods
+    - protected_methods
+    - private_methods
+    - public_instance_methods
+    - protected_instance_methods
+    - private_instance_methods
+
+Naming/FileName:
+  CheckDefinitionPathHierarchyRoots:
+    - test/unit
+    - test/acceptance

--- a/test/acceptance/stubbing_non_existent_any_instance_method_test.rb
+++ b/test/acceptance/stubbing_non_existent_any_instance_method_test.rb
@@ -68,7 +68,7 @@ class StubbingNonExistentAnyInstanceMethodTest < Mocha::TestCase
   def test_should_allow_stubbing_method_to_which_any_instance_responds
     Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
     klass = Class.new do
-      def respond_to?(method, _include_all = false)
+      def respond_to_missing?(method, _include_all = false)
         (method == :method_to_which_instance_responds)
       end
     end
@@ -84,7 +84,7 @@ class StubbingNonExistentAnyInstanceMethodTest < Mocha::TestCase
         @attributes = attrs
       end
 
-      def respond_to?(method, _include_all = false)
+      def respond_to_missing?(method, _include_all = false)
         @attributes.key?(method) ? @attributes[method] : super
       end
     end

--- a/test/acceptance/stubbing_non_existent_class_method_test.rb
+++ b/test/acceptance/stubbing_non_existent_class_method_test.rb
@@ -71,7 +71,7 @@ class StubbingNonExistentClassMethodTest < Mocha::TestCase
     Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
     klass = Class.new do
       class << self
-        def respond_to?(method, _include_all = false)
+        def respond_to_missing?(method, _include_all = false)
           (method == :method_to_which_class_responds)
         end
       end

--- a/test/acceptance/stubbing_non_existent_instance_method_test.rb
+++ b/test/acceptance/stubbing_non_existent_instance_method_test.rb
@@ -69,7 +69,7 @@ class StubbingNonExistentInstanceMethodTest < Mocha::TestCase
   def test_should_allow_stubbing_method_to_which_instance_responds
     Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
     klass = Class.new do
-      def respond_to?(method, _include_all = false)
+      def respond_to_missing?(method, _include_all = false)
         (method == :method_to_which_instance_responds)
       end
     end

--- a/test/acceptance/stubbing_non_public_class_method_test.rb
+++ b/test/acceptance/stubbing_non_public_class_method_test.rb
@@ -150,7 +150,7 @@ class StubbingNonPublicClassMethodTest < Mocha::TestCase
     Mocha.configure { |c| c.stubbing_non_public_method = :prevent }
     klass = Class.new do
       class << self
-        def respond_to?(method, _include_all = false)
+        def respond_to_missing?(method, _include_all = false)
           (method == :method_to_which_class_responds)
         end
       end

--- a/test/acceptance/stubbing_non_public_instance_method_test.rb
+++ b/test/acceptance/stubbing_non_public_instance_method_test.rb
@@ -131,7 +131,7 @@ class StubbingNonPublicInstanceMethodTest < Mocha::TestCase
   def test_should_allow_stubbing_method_to_which_instance_responds
     Mocha.configure { |c| c.stubbing_non_public_method = :prevent }
     instance = Class.new do
-      def respond_to?(method, _include_all = false)
+      def respond_to_missing?(method, _include_all = false)
         (method == :method_to_which_instance_responds)
       end
     end.new


### PR DESCRIPTION
Enhances the clarity of the code by explicitly indicating that the method is related to the stub functionality, which aids in understanding the code's intent.

# Key Changes:
1. **Method Existence Checks:**
    - Renamed `ClassMethods::AnyInstance#respond_to?`  to `ClassMethods::AnyInstance#stubba_respond_to?` to better reflect its purpose as part of a mocha contract.
    - `Mockery#on_stubbing` now uses `stubba_respond_to?` instead of the generic `respond_to?` to check if an object responds to a method before stubbing it.
    - Added `ObjectMethods#stubba_respond_to?` to provide a consistent interface for checking if an object responds to a method.
2. **RuboCop Configuration Updates:** Moved test-specific RuboCop rules from the global .rubocop.yml to a new test/.rubocop.yml file (as suggested in commits e423977, 33e373c, fddebc3).
 
Closes #713.

