### PR TITLE
Enhance documentation & enforce 100% coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           steps:
             - run: bundle exec rake test:performance
             - run: MOCHA_GENERATE_DOCS=1 bundle install --gemfile=<< parameters.gemfile >>
-            - run: MOCHA_GENERATE_DOCS=1 rake yardoc
+            - run: RUBYOPT=--disable-frozen-string-literal MOCHA_GENERATE_DOCS=1 rake yardoc docs:coverage
   lint:
     docker:
       - image: ruby:3.3

--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,6 @@
 --output-dir docs
 --no-private
+lib/mocha.rb
 lib/mocha/api.rb
 lib/mocha/hooks.rb
 lib/mocha/mock.rb
@@ -15,6 +16,7 @@ lib/mocha/expectation_error_factory.rb
 lib/mocha/expectation_error.rb
 lib/mocha/stubbing_error.rb
 lib/mocha/unexpected_invocation.rb
+lib/mocha/integration.rb
 lib/mocha/integration/test_unit/adapter.rb
 lib/mocha/integration/minitest/adapter.rb
 -

--- a/Rakefile
+++ b/Rakefile
@@ -161,7 +161,7 @@ if ENV['MOCHA_GENERATE_DOCS']
       end
 
       covered_percent = match[1].to_f
-      min_coverage = 95.0
+      min_coverage = 100.0
 
       if covered_percent < min_coverage
         puts "Documentation coverage is #{covered_percent}%, which is below the required #{min_coverage}%."

--- a/Rakefile
+++ b/Rakefile
@@ -146,6 +146,31 @@ if ENV['MOCHA_GENERATE_DOCS']
 
   desc 'Generate documentation'
   task 'generate_docs' => %w[clobber_yardoc yardoc checkout_docs_cname checkout_docs_js]
+
+  namespace :docs do
+    desc 'Check documentation coverage'
+    task :coverage do
+      stats_output = `yard stats --list-undoc`
+      puts stats_output
+
+      # Extract the documented percentage from the output
+      match = stats_output.match(/(\d+\.\d+)% documented/)
+      if match.nil?
+        puts 'Error: Could not determine documentation coverage.'
+        exit 1
+      end
+
+      covered_percent = match[1].to_f
+      min_coverage = 95.0
+
+      if covered_percent < min_coverage
+        puts "Documentation coverage is #{covered_percent}%, which is below the required #{min_coverage}%."
+        exit 1
+      else
+        puts "Documentation coverage is #{covered_percent}%, which is above the required #{min_coverage}%."
+      end
+    end
+  end
 end
 
 task 'release' => ['default', 'rubygems:release']

--- a/lib/mocha.rb
+++ b/lib/mocha.rb
@@ -2,5 +2,20 @@
 
 require 'mocha/version'
 
+# Mocha's top level namespace, which also provides the ability to {.configure configure} Mocha's behavior.
+#
+# Methods in the {API} are directly available in +Test::Unit::TestCase+, +Minitest::Unit::TestCase+.
+#
+# The mock creation methods are {API#mock mock}, {API#stub stub} and {API#stub_everything stub_everything}, all of which return a {Mock}
+#
+# A {Mock} {Mock#expects expects} or {Mock#stubs stubs} a method, which sets up (returns) an {Expectation}.
+#
+# An {Expectation} can be further qualified through its {Expectation fluent interface}.
+#
+# {ParameterMatchers} for {Expectation#with} restrict the parameter values which will match the {Expectation}.
+#
+# Adapters in {Integration} provide built-in support for +Minitest+ and +Test::Unit+.
+#
+# Integration {Hooks} enable support for other test frameworks.
 module Mocha
 end

--- a/lib/mocha/integration.rb
+++ b/lib/mocha/integration.rb
@@ -1,0 +1,5 @@
+module Mocha
+  # Contains adapters that provide built-in support for +Minitest+ and +Test::Unit+.
+  module Integration
+  end
+end

--- a/lib/mocha/integration/minitest/adapter.rb
+++ b/lib/mocha/integration/minitest/adapter.rb
@@ -6,6 +6,7 @@ require 'mocha/expectation_error_factory'
 
 module Mocha
   module Integration
+    # Contains {Adapter} that integrates Mocha into recent versions of Minitest.
     module Minitest
       # Integrates Mocha into recent versions of Minitest.
       #

--- a/lib/mocha/integration/test_unit/adapter.rb
+++ b/lib/mocha/integration/test_unit/adapter.rb
@@ -6,6 +6,7 @@ require 'mocha/expectation_error'
 
 module Mocha
   module Integration
+    # Contains {Adapter} that integrates Mocha into recent versions of Test::Unit.
     module TestUnit
       # Integrates Mocha into recent versions of Test::Unit.
       #


### PR DESCRIPTION
Closes #707.

Several improvements focused on documentation:

- A new Rake task `docs:coverage` extracts the documented percentage from yard stats and fails the build if it is below the specified level (currently set to 100%).
- CircleCI configuration runs the new docs:coverage task after generating YARD docs. Disables frozen string literals for the documentation generation step to prevent YARD throwing FrozenError.
- Additional source files (`lib/mocha.rb` and `lib/mocha/integration.rb`) are part of the generated documentation.
- Inline documentation in `lib/mocha.rb` provides an overview of the API, the mocking methods, and integration hooks.
- The `Integration` module and the `Adapter`s under it include module-level comments to clarify their purpose.
