### PR TITLE
Add documentation coverage check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           steps:
             - run: bundle exec rake test:performance
             - run: MOCHA_GENERATE_DOCS=1 bundle install --gemfile=<< parameters.gemfile >>
-            - run: RUBYOPT=--disable-frozen-string-literal MOCHA_GENERATE_DOCS=1 rake yardoc docs:coverage
+            - run: RUBYOPT=--disable-frozen-string-literal MOCHA_GENERATE_DOCS=1 rake docs docs:coverage
   lint:
     docker:
       - image: ruby:3.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           steps:
             - run: bundle exec rake test:performance
             - run: MOCHA_GENERATE_DOCS=1 bundle install --gemfile=<< parameters.gemfile >>
-            - run: MOCHA_GENERATE_DOCS=1 rake yardoc
+            - run: RUBYOPT=--disable-frozen-string-literal MOCHA_GENERATE_DOCS=1 rake yardoc docs:coverage
   lint:
     docker:
       - image: ruby:3.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -120,3 +120,7 @@ Naming/FileName:
     - lib/mocha/ruby_version.rb
     - lib/mocha/macos_version.rb
     - test/test_helper.rb
+
+Metrics/BlockLength:
+  Exclude:
+    - "Rakefile"

--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,6 @@
 --output-dir docs
 --no-private
+lib/mocha.rb
 lib/mocha/api.rb
 lib/mocha/hooks.rb
 lib/mocha/mock.rb
@@ -15,6 +16,7 @@ lib/mocha/expectation_error_factory.rb
 lib/mocha/expectation_error.rb
 lib/mocha/stubbing_error.rb
 lib/mocha/unexpected_invocation.rb
+lib/mocha/integration.rb
 lib/mocha/integration/test_unit/adapter.rb
 lib/mocha/integration/minitest/adapter.rb
 -

--- a/Rakefile
+++ b/Rakefile
@@ -157,7 +157,7 @@ if ENV['MOCHA_GENERATE_DOCS']
       abort 'Error: Could not determine documentation coverage.' unless match
 
       coverage_percentage = match[:coverage_percentage].to_f
-      minimum_percentage = 95.0
+      minimum_percentage = 100.0
 
       if coverage_percentage < minimum_percentage
         abort "Documentation coverage is #{coverage_percentage}%, which is below the required #{minimum_percentage}%."

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task 'test' do
   end
 end
 
-namespace 'test' do # rubocop:disable Metrics/BlockLength
+namespace 'test' do
   desc 'Run unit tests'
   Rake::TestTask.new('units') do |t|
     t.libs << 'test'
@@ -123,31 +123,28 @@ end
 if ENV['MOCHA_GENERATE_DOCS']
   require 'yard'
 
-  desc 'Remove generated documentation'
-  task 'clobber_yardoc' do
-    `rm -rf ./docs`
-  end
-
-  desc 'Generate documentation'
-  YARD::Rake::YardocTask.new('yardoc') do |task|
-    task.options = ['--title', "Mocha #{Mocha::VERSION}", '--fail-on-warning']
-  end
-
-  desc 'Ensure custom domain remains in place for docs on GitHub Pages'
-  task 'checkout_docs_cname' do
-    `git checkout docs/CNAME`
-  end
-
-  desc 'Ensure custom JavaScript files remain in place for docs on GitHub Pages'
-  task 'checkout_docs_js' do
-    `git checkout docs/js/app.js`
-    `git checkout docs/js/jquery.js`
-  end
-
-  desc 'Generate documentation'
-  task 'generate_docs' => %w[clobber_yardoc yardoc checkout_docs_cname checkout_docs_js]
-
   namespace :docs do
+    desc 'Remove generated documentation'
+    task :clobber do
+      `rm -rf ./docs`
+    end
+
+    desc 'Generate documentation'
+    YARD::Rake::YardocTask.new(:generate) do |task|
+      task.options = ['--title', "Mocha #{Mocha::VERSION}", '--fail-on-warning']
+    end
+
+    desc 'Ensure custom domain remains in place for docs on GitHub Pages'
+    task :ensure_cname do
+      `git checkout docs/CNAME`
+    end
+
+    desc 'Ensure custom JavaScript files remain in place for docs on GitHub Pages'
+    task :ensure_js do
+      `git checkout docs/js/app.js`
+      `git checkout docs/js/jquery.js`
+    end
+
     desc 'Check documentation coverage'
     task :coverage do
       stats_output = `yard stats --list-undoc`
@@ -166,6 +163,9 @@ if ENV['MOCHA_GENERATE_DOCS']
       end
     end
   end
+
+  desc 'Prepare documentation for publication on GitHub Pages'
+  task 'docs' => %w[docs:clobber docs:generate docs:ensure_cname docs:ensure_js]
 end
 
 task 'release' => ['default', 'rubygems:release']

--- a/Rakefile
+++ b/Rakefile
@@ -146,6 +146,26 @@ if ENV['MOCHA_GENERATE_DOCS']
 
   desc 'Generate documentation'
   task 'generate_docs' => %w[clobber_yardoc yardoc checkout_docs_cname checkout_docs_js]
+
+  namespace :docs do
+    desc 'Check documentation coverage'
+    task :coverage do
+      stats_output = `yard stats --list-undoc`
+      puts stats_output
+
+      match = stats_output.match(/(?<coverage_percentage>\d+\.\d+)% documented/);
+      abort 'Error: Could not determine documentation coverage.' unless match
+
+      coverage_percentage = match[:coverage_percentage].to_f
+      minimum_percentage = 95.0
+
+      if coverage_percentage < minimum_percentage
+        abort "Documentation coverage is #{coverage_percentage}%, which is below the required #{minimum_percentage}%."
+      else
+        puts "Documentation coverage is #{coverage_percentage}%, which is at or above the required #{minimum_percentage}%."
+      end
+    end
+  end
 end
 
 task 'release' => ['default', 'rubygems:release']

--- a/lib/mocha.rb
+++ b/lib/mocha.rb
@@ -2,5 +2,20 @@
 
 require 'mocha/version'
 
+# Mocha's top level namespace, which also provides the ability to {.configure configure} Mocha's behavior.
+#
+# Methods in the {API} are directly available in +Test::Unit::TestCase+, +Minitest::Unit::TestCase+.
+#
+# The mock creation methods are {API#mock mock}, {API#stub stub} and {API#stub_everything stub_everything}, all of which return a {Mock}
+#
+# A {Mock} {Mock#expects expects} or {Mock#stubs stubs} a method, which sets up (returns) an {Expectation}.
+#
+# An {Expectation} can be further qualified through its {Expectation fluent interface}.
+#
+# {ParameterMatchers} for {Expectation#with} restrict the parameter values which will match the {Expectation}.
+#
+# Adapters in {Integration} provide built-in support for +Minitest+ and +Test::Unit+.
+#
+# Integration {Hooks} enable support for other test frameworks.
 module Mocha
 end

--- a/lib/mocha/integration.rb
+++ b/lib/mocha/integration.rb
@@ -1,0 +1,5 @@
+module Mocha
+  # Contains adapters that provide built-in support for +Minitest+ and +Test::Unit+.
+  module Integration
+  end
+end

--- a/lib/mocha/integration/minitest/adapter.rb
+++ b/lib/mocha/integration/minitest/adapter.rb
@@ -6,6 +6,7 @@ require 'mocha/expectation_error_factory'
 
 module Mocha
   module Integration
+    # Contains {Adapter} that integrates Mocha into recent versions of Minitest.
     module Minitest
       # Integrates Mocha into recent versions of Minitest.
       #

--- a/lib/mocha/integration/test_unit/adapter.rb
+++ b/lib/mocha/integration/test_unit/adapter.rb
@@ -6,6 +6,7 @@ require 'mocha/expectation_error'
 
 module Mocha
   module Integration
+    # Contains {Adapter} that integrates Mocha into recent versions of Test::Unit.
     module TestUnit
       # Integrates Mocha into recent versions of Test::Unit.
       #


### PR DESCRIPTION
This supersedes #743. I've made a few minor changes to the first commit and moved the other documentation-related rake tasks into the new `docs` namespace - I felt as if not doing so would've left the code in a slightly confusing state.

Original description:

> Closes #707.
>
> Several improvements focused on documentation:
>
> - A new Rake task `docs:coverage` extracts the documented percentage from yard stats and fails the build if it is below the specified level (currently set to 100%).
> - CircleCI configuration runs the new docs:coverage task after generating YARD docs. Disables frozen string literals for the documentation generation step to prevent YARD throwing FrozenError.
> - Additional source files (`lib/mocha.rb` and `lib/mocha/integration.rb`) are part of the generated documentation.
> - Inline documentation in `lib/mocha.rb` provides an overview of the API, the mocking methods, and integration hooks.
> - The `Integration` module and the `Adapter`s under it include module-level comments to clarify their purpose.
