### PR TITLE
fix: cop Lint/LiteralAsCondition offence

### DIFF
--- a/lib/mocha/class_methods.rb
+++ b/lib/mocha/class_methods.rb
@@ -54,9 +54,13 @@ module Mocha
 
     # @private
     def __method_visibility__(method, include_public_methods: true)
-      (include_public_methods && public_method_defined?(method) && :public) ||
-        (protected_method_defined?(method) && :protected) ||
-        (private_method_defined?(method) && :private)
+      if include_public_methods && public_method_defined?(method)
+        :public
+      elsif protected_method_defined?(method)
+        :protected
+      else
+        private_method_defined?(method) ? :private : nil
+      end
     end
     alias_method :__method_exists__?, :__method_visibility__
   end


### PR DESCRIPTION
Fixes the offences flagged by [RuboCop v1.73.0](https://app.circleci.com/pipelines/github/freerange/mocha/827/workflows/067a16b5-1e76-47c6-ae48-89d035ea8aa9/jobs/12377?invite=true#step-105-950_23) on a [build for #481](https://app.circleci.com/pipelines/github/freerange/mocha/827/workflows/067a16b5-1e76-47c6-ae48-89d035ea8aa9/jobs/12377?invite=true#step-106-0_18)