### PR TITLE
Rename `#stubbee` -> `#stubba_object` and `#mock_owner` -> `#stubbee`

### DIFF
--- a/lib/mocha/any_instance_method.rb
+++ b/lib/mocha/any_instance_method.rb
@@ -6,16 +6,16 @@ module Mocha
   class AnyInstanceMethod < StubbedMethod
     private
 
-    def mock_owner
-      stubbee.any_instance
+    def stubbee
+      stubba_object.any_instance
     end
 
     def stubbee_method(method_name)
-      stubbee.instance_method(method_name)
+      stubba_object.instance_method(method_name)
     end
 
     def original_method_owner
-      stubbee
+      stubba_object
     end
   end
 end

--- a/lib/mocha/instance_method.rb
+++ b/lib/mocha/instance_method.rb
@@ -6,16 +6,16 @@ module Mocha
   class InstanceMethod < StubbedMethod
     private
 
-    def mock_owner
-      stubbee
+    def stubbee
+      stubba_object
     end
 
     def stubbee_method(method_name)
-      stubbee._method(method_name)
+      stubba_object._method(method_name)
     end
 
     def original_method_owner
-      stubbee.singleton_class
+      stubba_object.singleton_class
     end
   end
 end

--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -7,10 +7,10 @@ module Mocha
   class StubbedMethod
     PrependedModule = Class.new(Module)
 
-    attr_reader :stubbee, :method_name
+    attr_reader :stubba_object, :method_name
 
-    def initialize(stubbee, method_name)
-      @stubbee = stubbee
+    def initialize(stubba_object, method_name)
+      @stubba_object = stubba_object
       @original_method = nil
       @original_visibility = nil
       @method_name = method_name.to_sym
@@ -30,11 +30,11 @@ module Mocha
     end
 
     def mock
-      mock_owner.mocha
+      stubbee.mocha
     end
 
     def reset_mocha
-      mock_owner.reset_mocha
+      stubbee.reset_mocha
     end
 
     def hide_original_method
@@ -61,14 +61,14 @@ module Mocha
     def matches?(other)
       return false unless other.instance_of?(self.class)
 
-      (stubbee.object_id == other.stubbee.object_id) && # rubocop:disable Lint/IdentityComparison
+      (stubba_object.object_id == other.stubba_object.object_id) && # rubocop:disable Lint/IdentityComparison
         (method_name == other.method_name)
     end
 
     alias_method :==, :eql?
 
     def to_s
-      "#{stubbee}.#{method_name}"
+      "#{stubba_object}.#{method_name}"
     end
 
     private

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -184,7 +184,7 @@ class InstanceMethodTest < Mocha::TestCase
         self.reset_mocha_called = true
       end
     end.new
-    replace_instance_method(method, :stubbee) { stubbee }
+    replace_instance_method(method, :stubba_object) { stubbee }
 
     method.unstub
 


### PR DESCRIPTION
`stubbee` is the thing that's stubbed - more specifically, the object on which `.stubs` or `.mocks` is called. Therefore, it's also the object that holds a reference to `mocha`. That's why it was called `mock_owner` earlier.

`stubba_object` is the object through which we get hold of the `stubba_class` on which stubbed methods reside. In case of `AnyInstance`, that class is the `stubba_object` itself, while in case of an instance, it's the singleton class of the `stubba_object`.

Supersedes #463.