### PR TITLE
Fix enable-frozen-string-literal and clean up step display in CircleCI UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,7 @@ commands:
       command:
         type: string
     steps:
-      - run: << parameters.command >> 2>&1 | tee output.log
-      - run: |
-          if grep -q "warning:" output.log; then
-            echo "Warnings found in test output. Failing the job."
-            exit 1
-          fi
+      - run: << parameters.command >> 2>&1 | tee >(grep -q "warning:" && exit 1)
 jobs:
   build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,11 @@ jobs:
       - run: gem --version
       - run: bundle --version
       - run: bundle install --gemfile=<< parameters.gemfile >>
-      - run: |
-          if [ "<< parameters.docker-image >>" > "ruby:2.2" ]; then
-            export RUBYOPT="--enable-frozen-string-literal"
-          fi
+      - unless:
+          condition:
+            equal: ["ruby:2.2", << parameters.docker-image >>]
+          steps:
+            - run: echo 'export RUBYOPT="--enable-frozen-string-literal"' >> "$BASH_ENV"
       - when:
           condition:
             equal: ["Gemfile", << parameters.gemfile >>]


### PR DESCRIPTION
1. **Make RUBYOPT available to all run steps.** The earlier export was (probably) having no effect. The circleci [Set an environment variable](https://circleci.com/docs/set-environment-variable/#set-an-environment-variable-in-a-step) doc states: Since every run step is a new shell, environment variables are not shared across steps. If you need an environment variable to be accessible in more than one step, export the value using BASH_ENV.
2. **enable-frozen-string-literal for ruby-latest**. It wouldn't have been enabled earlier as `ruby-latest > ruby:2.2` is false. So we now test for equality.
3. **Clean up the display of the `run-fail-fast` command on the CircleCI UI** by combining two commands into a one liner. So now we see a single step with a more readable command instead of the earlier 2 commands - the actual command to run, followed by a bash 'script' to grep the output file for 'warning:'.