### PR TITLE
Automatically create GitHub releases

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,17 @@
+name: Main
+
+on: push
+
+jobs:
+  create-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extract Release Notes
+        run: awk -v ver="${{ github.ref_name }}" '/^## / { if (p) { exit }; if ("v"$2 == ver) { p=1; next } } p && NF' RELEASE.md > ${{ github.workspace }}-RELEASE_NOTES.txt
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ github.workspace }}-RELEASE_NOTES.txt


### PR DESCRIPTION
Introduces a new GitHub Actions workflow that automates the creation of GitHub releases. The workflow is triggered on push events to tags that start with 'v', and it extracts release notes from the RELEASE.md file based on the tag version. The extracted notes are then used as the body of the created release.

## Future considerations:
- Streamline more/the rest of the [release process](https://github.com/nitishr/mocha?tab=readme-ov-file#releasing-a-new-version) and reduce manual effort.
- Do this in a CircleCI instead of a GitHub workflow for uniformity and lower cognitive load. I didn't do that here because I didn't have the github token for use in CircleCI.

## Testing
Verified the outcome of this workflow by updating `RELEASE.md` and pushing a tag to a local branch. The [created release](https://github.com/nitishr/mocha/releases) contains the extracted notes for just that release.