### PR TITLE
Add missing quote to docstrings.

### DIFF
--- a/lib/mocha/parameter_matchers/equivalent_uri.rb
+++ b/lib/mocha/parameter_matchers/equivalent_uri.rb
@@ -14,13 +14,13 @@ module Mocha
     #
     # @example Actual URI is equivalent.
     #   object = mock()
-    #   object.expects(:method_1).with(equivalent_uri('http://example.com/foo?a=1&b=2))
+    #   object.expects(:method_1).with(equivalent_uri('http://example.com/foo?a=1&b=2'))
     #   object.method_1('http://example.com/foo?b=2&a=1')
     #   # no error raised
     #
     # @example Actual URI is not equivalent.
     #   object = mock()
-    #   object.expects(:method_1).with(equivalent_uri('http://example.com/foo?a=1&b=2))
+    #   object.expects(:method_1).with(equivalent_uri('http://example.com/foo?a=1&b=2'))
     #   object.method_1('http://example.com/foo?a=1&b=3')
     #   # error raised, because the query parameters were different
     def equivalent_uri(uri)


### PR DESCRIPTION
I was reading the docs for parameter matching in tests, and found there is a missing quote at the end of a url in the docstrings for the equivalent_uri matcher.

❤️ Mocha. Thanks.



