### PR TITLE
Auto-correct Style/RedundantParentheses violations

### DIFF
--- a/test/acceptance/stubbing_method_accepting_block_parameter_test.rb
+++ b/test/acceptance/stubbing_method_accepting_block_parameter_test.rb
@@ -23,7 +23,7 @@ class StubbingMethodAcceptingBlockParameterTest < Mocha::TestCase
       klass.stubs(:my_class_method)
     end
     assert_passed(test_result)
-    assert_equal :return_value, (klass.my_class_method { :return_value })
+    assert_equal(:return_value, klass.my_class_method { :return_value })
   end
 
   def test_stubbing_instance_method_accepting_block_parameter_should_restore_original_method
@@ -36,7 +36,7 @@ class StubbingMethodAcceptingBlockParameterTest < Mocha::TestCase
       instance.stubs(:my_instance_method)
     end
     assert_passed(test_result)
-    assert_equal :return_value, (instance.my_instance_method { :return_value })
+    assert_equal(:return_value, instance.my_instance_method { :return_value })
   end
 
   def test_stubbing_any_instance_method_accepting_block_parameter_should_restore_original_method
@@ -49,6 +49,6 @@ class StubbingMethodAcceptingBlockParameterTest < Mocha::TestCase
       klass.any_instance.stubs(:my_instance_method)
     end
     assert_passed(test_result)
-    assert_equal :return_value, (klass.new.my_instance_method { :return_value })
+    assert_equal(:return_value, klass.new.my_instance_method { :return_value })
   end
 end


### PR DESCRIPTION
Seems to relate to [this change][1] in rubocop v1.79.2.

[1]: https://github.com/rubocop/rubocop/pull/14407