### PR TITLE
Reinstate arg default in Hooks#mocha_setup

### DIFF
--- a/lib/mocha/hooks.rb
+++ b/lib/mocha/hooks.rb
@@ -18,10 +18,15 @@ module Mocha
   # @see Mocha::ExpectationErrorFactory
   # @see Mocha::API
   module Hooks
+    # @private
+    class NullAssertionCounter
+      def increment; end
+    end
+
     # Prepares Mocha before a test (only for use by authors of test libraries).
     #
     # This method should be called before each individual test starts (including before any "setup" code).
-    def mocha_setup(assertion_counter)
+    def mocha_setup(assertion_counter = NullAssertionCounter.new)
       Mockery.setup(assertion_counter)
     end
 


### PR DESCRIPTION
The argument default in `Mocha::Hooks#mocha_setup` was removed in [this commit][1] which was released in v3.0.0. However,
[`RSpec::Core::MockingAdapters::Mocha#MockingAdapters` calls that method without any arguments][2] and thus this breaks the RSpec/Mocha integration.

As reported by @mackuba.

Fixes https://github.com/freerange/mocha/issues/768.

[1]: https://github.com/freerange/mocha/commit/1c0fcab84d9c5b5e2b92f0524e74780aca8cab39
[2]: https://github.com/rspec/rspec/blob/f23626d9b41a614e8a54371d2e0bedef4690d119/rspec-core/lib/rspec/core/mocking_adapters/mocha.rb#L14-L16