### PR TITLE
Fix test:performance rake task for minitest v6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,15 +92,16 @@ task 'lint' do
   end
 end
 
-def benchmark_test_case(klass, iterations)
+def benchmark_test_case(klass, iterations) # rubocop:disable Metrics/AbcSize
   require 'benchmark'
   require 'mocha/detection/minitest'
 
   if defined?(Minitest)
     minitest_version = Gem::Version.new(Mocha::Detection::Minitest.version)
     if Gem::Requirement.new('>= 5.0.0').satisfied_by?(minitest_version)
+      run_method = Gem::Requirement.new('>= 6.0.0').satisfied_by?(minitest_version) ? :run_suite : :run
       Minitest.seed = 1
-      result = Benchmark.realtime { iterations.times { |_i| klass.run(Minitest::CompositeReporter.new) } }
+      result = Benchmark.realtime { iterations.times { |_i| klass.public_send(run_method, Minitest::CompositeReporter.new) } }
       Minitest::Runnable.runnables.delete(klass)
       result
     else


### PR DESCRIPTION
We need to call `run_suite` vs `run` due to [this change][1] in order to fix the error in [this build](https://app.circleci.com/pipelines/github/freerange/mocha/961/workflows/a28eba0d-0f1c-4bd9-ad32-69104431fce5/jobs/14497).

[1]: https://github.com/minitest/minitest/commit/d54d2f01d57378b4919870d1a0ef731bd9a8b869