### PR TITLE
Fix prism gem install on JRuby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             equal: ["jruby:latest", << parameters.docker-image >>]
           steps:
             - run: apt-get update
-            - run: apt-get install -y git
+            - run: apt-get install -y git build-essential
       - run: gem --version
       - run: bundle --version
       - run: bundle install --gemfile=<< parameters.gemfile >>


### PR DESCRIPTION
Add `build-essential` package to provide a C compiler to install the native extensions for the `prism` gem which is now a dependency of `minitest`.