### PR TITLE
Add Ruby v4.0 to CI build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,8 @@ workflows:
                 - ruby:3.2
                 - ruby:3.3
                 - ruby:3.4
+                - ruby:4.0
                 - ruby:latest
-                - ruby:4.0-rc
                 - jruby:latest
               gemfile:
                 - Gemfile


### PR DESCRIPTION
[Ruby v4.0 has just been released][1].

[1]: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/