### PR TITLE
Auto-correct Style/EmptyClassDefinition violation

### DIFF
--- a/lib/mocha/stubbed_method.rb
+++ b/lib/mocha/stubbed_method.rb
@@ -5,7 +5,8 @@ require 'mocha/ruby_version'
 
 module Mocha
   class StubbedMethod
-    PrependedModule = Class.new(Module)
+    class PrependedModule < Module
+    end
 
     attr_reader :stubba_object, :method_name
 

--- a/test/unit/any_instance_method_test.rb
+++ b/test/unit/any_instance_method_test.rb
@@ -60,7 +60,7 @@ class AnyInstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 51
+    expected_line_number = 52
 
     exception = assert_raises(Exception) { klass.new.method_x }
     matching_line = exception.backtrace.find do |line|

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -61,7 +61,7 @@ class InstanceMethodTest < Mocha::TestCase
     method.define_new_method
 
     expected_filename = 'stubbed_method.rb'
-    expected_line_number = 51
+    expected_line_number = 52
 
     exception = assert_raises(Exception) { klass.method_x }
     matching_line = exception.backtrace.find do |line|


### PR DESCRIPTION
I'm not totally convinced about this change which was [introduced in rubocop v1.84.0][1], but I don't feel strongly enough about it to add custom configuration for the cop.

The (IMHO weak) motivation behind this is documented in [the Single-line Classes section][2] of the Ruby style guide.

Unfortunately this change means we also need to change the line numbers in a couple of assertions, because the lines under the empty class definition have been bumped down one line.

[1]: https://github.com/rubocop/rubocop/releases/tag/v1.84.0
[2]: https://rubystyle.guide/#single-line-classes