### PR TITLE
Ensure every test can run in isolation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
               - equal: ["ruby:latest", << parameters.docker-image >>]
               - equal: ["Gemfile", << parameters.gemfile >>]
           steps:
+            - run: bundle exec rake test:isolated
             - run-fail-fast:
                 command: bundle exec rake test:performance
             - run: MOCHA_GENERATE_DOCS=1 bundle install --gemfile=<< parameters.gemfile >>

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,25 @@ namespace 'test' do
     t.warning = true
   end
 
+  desc 'Run each test in isolation'
+  task 'isolated' do
+    test_files = FileList['test/unit/**/*_test.rb', 'test/acceptance/*_test.rb']
+    failed_tests = []
+
+    test_files.each do |test_file|
+      puts "\n=== Running #{test_file} in isolation ==="
+      system("ruby -Itest -w #{test_file}") || (failed_tests << test_file)
+    end
+
+    if failed_tests.any?
+      puts "\n❌ #{failed_tests.size} test file(s) failed:"
+      failed_tests.each { |f| puts "  - #{f}" }
+      exit 1
+    else
+      puts "\n✅ All #{test_files.size} test files passed in isolation!"
+    end
+  end
+
   namespace 'integration' do
     desc 'Run Minitest integration tests (intended to be run in its own process)'
     Rake::TestTask.new('minitest') do |t|

--- a/test/unit/instance_method_test.rb
+++ b/test/unit/instance_method_test.rb
@@ -3,6 +3,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 require 'mocha/ruby_version'
 require 'method_definer'
+require 'simple_counter'
 require 'mocha/class_methods'
 require 'mocha/mockery'
 require 'mocha/mock'


### PR DESCRIPTION
The new `test:isolated` rake task runs each of the unit & acceptance tests in isolation to ensure that e.g. the have the relevant `require` statements. Note that the two integration tests are already run separately, so no need to include them.

This new rake task is run in the CI build as part of the `ruby:latest` & `Gemfile` combination in the matrix.

I've had to add one missing `require` statement in `test/unit/instance_method_test.rb` to make the tests pass.