### PR TITLE
Add a `:warn_with_location` option to stubbing non-existent methods

### DIFF
--- a/lib/mocha/configuration.rb
+++ b/lib/mocha/configuration.rb
@@ -134,9 +134,10 @@ module Mocha
     #
     # When +value+ is +:allow+, do nothing. This is the default.
     # When +value+ is +:warn+, display a warning.
+    # When +value+ is +:warn_with_location+, display a warning including file and line number where the stub was made.
     # When +value+ is +:prevent+, raise a {StubbingError}.
     #
-    # @param [Symbol] value one of +:allow+, +:warn+, +:prevent+.
+    # @param [Symbol] value one of +:allow+, +:warn+, +:warn_with_location+, +:prevent+.
     #
     # @example Preventing stubbing of a non-existent method
     #

--- a/lib/mocha/logger.rb
+++ b/lib/mocha/logger.rb
@@ -6,8 +6,10 @@ module Mocha
       @io = io
     end
 
-    def warn(message)
-      @io.puts "WARNING: #{message}"
+    def warn(message, location = nil)
+      output = "WARNING: #{message}"
+      output += " at #{location}" if location
+      @io.puts output
     end
   end
 end

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -13,6 +13,7 @@ require 'mocha/configuration'
 require 'mocha/stubbing_error'
 require 'mocha/not_initialized_error'
 require 'mocha/expectation_error_factory'
+require 'mocha/backtrace_filter'
 
 module Mocha
   class Mockery
@@ -166,6 +167,12 @@ module Mocha
       raise StubbingError.new(message, backtrace) if treatment == :prevent
 
       logger.warn(message) if treatment == :warn
+
+      return unless treatment == :warn_with_location
+
+      filter = BacktraceFilter.new
+      filtered_backtrace = filter.filtered(backtrace)
+      logger.warn(message, filtered_backtrace.first)
     end
 
     def expectations

--- a/test/acceptance/acceptance_test_helper.rb
+++ b/test/acceptance/acceptance_test_helper.rb
@@ -20,8 +20,10 @@ module AcceptanceTestHelper
       @warnings = []
     end
 
-    def warn(message)
-      @warnings << message
+    def warn(message, location = nil)
+      output = message
+      output += " at #{location}" if location
+      @warnings << output
     end
   end
 

--- a/test/acceptance/stubbing_non_existent_class_method_test.rb
+++ b/test/acceptance/stubbing_non_existent_class_method_test.rb
@@ -34,6 +34,17 @@ class StubbingNonExistentClassMethodTest < Mocha::TestCase
     assert @logger.warnings.include?("stubbing non-existent method: #{klass.mocha_inspect}.non_existent_method")
   end
 
+  def test_should_warn_with_location_when_stubbing_non_existent_class_method
+    Mocha.configure { |c| c.stubbing_non_existent_method = :warn_with_location }
+    klass = Class.new
+    test_result = run_as_test do
+      klass.stubs(:non_existent_method)
+    end
+    assert_passed(test_result)
+    warning = @logger.warnings.find { |w| w.include?("stubbing non-existent method: #{klass.mocha_inspect}.non_existent_method") }
+    assert warning.include?('stubbing_non_existent_class_method_test.rb:')
+  end
+
   def test_should_prevent_stubbing_non_existent_class_method
     Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
     klass = Class.new


### PR DESCRIPTION
- Display a warning message that includes the file and line number where the stub was made, making it easier to locate problematic stubs in test code when you're running a lot of tests at once right in front of you, or trying to search test run logs.
- I considered adding the file path to the existing `:warn` option, but that might break others' workflows?
- Is this _too_ verbose?

Before:

```
WARNING: stubbing non-existent method: #<#<Class:0x00007f2a9dc4e4c8>:0x2e9810>.user_ids
WARNING: stubbing non-existent method: #<#<Class:0x00007f36c3d47c80>:0x2e97c0>.repo_ids
```

After:

```
WARNING: stubbing non-existent method: #<#<Class:0x00007d4c1d557c60>:0x64140>.user_ids at foo_test:59:in 'block (2 levels) in <class:ViewTest>'
WARNING: stubbing non-existent method: #<#<Class:0x00007d4c1d557c60>:0x66e10>.repo_ids at foo_test.rb:38:in 'block (2 levels) in <class:ViewTest>'
```