### PR TITLE
Fix NoMethodError on deprecation warning

### DIFF
--- a/lib/mocha/deprecation.rb
+++ b/lib/mocha/deprecation.rb
@@ -5,7 +5,7 @@ require 'mocha/backtrace_filter'
 module Mocha
   class Deprecation
     class Logger
-      def warning(message)
+      def call(message)
         filter = BacktraceFilter.new
         location = filter.filtered(caller)[0]
         warn "Mocha deprecation warning at #{location}: #{message}"

--- a/test/unit/deprecation_test.rb
+++ b/test/unit/deprecation_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../test_helper', __FILE__)
+
+require 'execution_point'
+require 'mocha/deprecation'
+
+class DeprecationTest < Minitest::Test
+  def test_foo
+    execution_point = nil
+    _, stderr = capture_io do
+      Mocha::Deprecation.warning('test-message'); execution_point = ExecutionPoint.current
+    end
+    assert_equal "Mocha deprecation warning at #{execution_point.location}: test-message", stderr.chomp
+  end
+end


### PR DESCRIPTION
This was broken in [this commit][1] which was part of the v3.0.0 release. The "fake" logging used by `DeprecationCapture` in the tests was working fine, but the default logging outside tests was broken, because the instance method on `Mocha::Deprecation::Logger` was `#warning` but `#call` was being invoked.

I'm guessing this hasn't been noticed yet, because the only deprecation warning remaining is [a somewhat obscure one to do with keyword argument matching][2].

Ideally I'd like to use `#warning` vs `#call`, but that would be a more significant change. I hope to tackle that separately later.

[1]: https://github.com/freerange/mocha/commit/999cfa7bd4be7c4718768ada84deba8991705b51
[2]: https://github.com/freerange/mocha/blob/72fc6fe8b2cdca113617f7025bb9eb2261459673/lib/mocha/parameter_matchers/positional_or_keyword_hash.rb#L68-L74