### PR TITLE
Fix Style/OneClassPerFile rubocop violations

### DIFF
--- a/lib/mocha/inspect.rb
+++ b/lib/mocha/inspect.rb
@@ -52,22 +52,12 @@ module Mocha
   end
 end
 
-class Object
-  include Mocha::Inspect::ObjectMethods
-end
+Object.include(Mocha::Inspect::ObjectMethods)
 
-class Array
-  include Mocha::Inspect::ArrayMethods
-end
+Array.include(Mocha::Inspect::ArrayMethods)
 
-class Hash
-  include Mocha::Inspect::HashMethods
-end
+Hash.include(Mocha::Inspect::HashMethods)
 
-class Time
-  include Mocha::Inspect::TimeMethods
-end
+Time.include(Mocha::Inspect::TimeMethods)
 
-class Date
-  include Mocha::Inspect::DateMethods
-end
+Date.include(Mocha::Inspect::DateMethods)

--- a/lib/mocha/parameter_matchers/instance_methods.rb
+++ b/lib/mocha/parameter_matchers/instance_methods.rb
@@ -23,6 +23,6 @@ module Mocha
 end
 
 # @private
-class Object
+class Object # rubocop:disable Style/OneClassPerFile
   include Mocha::ParameterMatchers::InstanceMethods
 end

--- a/test/acceptance/stubba_example_test.rb
+++ b/test/acceptance/stubba_example_test.rb
@@ -2,7 +2,7 @@
 
 require File.expand_path('../acceptance_test_helper', __FILE__)
 
-class Widget
+Widget = Class.new do
   def model
     'original_model'
   end
@@ -18,7 +18,7 @@ class Widget
   end
 end
 
-module Thingy
+Thingy = Module.new do
   def self.wotsit
     :hoojamaflip
   end

--- a/test/unit/mockery_never_setup_test.rb
+++ b/test/unit/mockery_never_setup_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../test_helper', __FILE__)
+require 'mocha/mockery'
+
+class MockeryNeverSetupTest < Mocha::TestCase
+  include Mocha
+
+  def test_should_raise_not_initialized_error
+    Mockery.instance_variable_set(:@instances, nil)
+    assert_raises(NotInitializedError) do
+      Mockery.teardown
+    end
+  end
+end

--- a/test/unit/mockery_test.rb
+++ b/test/unit/mockery_test.rb
@@ -6,17 +6,6 @@ require 'mocha/state_machine'
 require 'mocha/expectation_error_factory'
 require 'simple_counter'
 
-class MockeryNeverSetupTest < Mocha::TestCase
-  include Mocha
-
-  def test_should_raise_not_initialized_error
-    Mockery.instance_variable_set(:@instances, nil)
-    assert_raises(NotInitializedError) do
-      Mockery.teardown
-    end
-  end
-end
-
 class MockeryTest < Mocha::TestCase
   include Mocha
 


### PR DESCRIPTION
I ended up disabling this cop for one occurrence in `lib/mocha/parameter_matchers/instance_methods.rb` to avoid this YARD warning:

    [warn]: in YARD::Handlers::Ruby::MixinHandler: Undocumentable mixin:
            YARD::Handlers::NamespaceMissingError for class in file
            'lib/mocha/parameter_matchers/instance_methods.rb':25:

  	25: Object.include(Mocha::ParameterMatchers::InstanceMethods)

This wasn't a problem for the occurrences in `lib/mocha/inspect.rb`, because this file is not included in `.yardopts`, i.e. YARD doesn't attempt to generate documentation for these lines.

I think the warning is YARD saying that it can't generate documentation for core Ruby classes like `Object`. A better solution would probably be to only include the `Mocha::ParameterMatchers::InstanceMethods` module into `Object` at Mocha "activation" time, i.e. at runtime. This would mean that YARD wouldn't attempt to document the module's methods and the warning wouldn't arise.

Of course a better solution would be to avoid monkey-patching `Object` altogether, but that's a whole other can of worms!