### PR TITLE
Avoid `Kernel#caller` as much as possible

### DIFF
--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -150,13 +150,13 @@ module Mocha
 
     private
 
-    def check(action, description, signature_proc, backtrace = caller)
+    def check(action, description, signature_proc, backtrace = nil)
       treatment = Mocha.configuration.send(action)
       return if (treatment == :allow) || (block_given? && !yield)
 
       method_signature = signature_proc.call
       message = "stubbing #{description}: #{method_signature}"
-      raise StubbingError.new(message, backtrace) if treatment == :prevent
+      raise StubbingError.new(message, backtrace || caller) if treatment == :prevent
 
       Logger.warning(message) if treatment == :warn
     end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -97,7 +97,7 @@ module Mocha
         mockery.on_stubbing(self, method_name)
         method = stubba_method.new(stubba_object, method_name)
         mockery.stubba.stub(method)
-        expectation = mocha.expects(method_name, caller)
+        expectation = mocha.expects(method_name, caller_locations)
         expectation.returns(args.shift) unless args.empty?
       end
       expectation
@@ -143,7 +143,7 @@ module Mocha
         mockery.on_stubbing(self, method_name)
         method = stubba_method.new(stubba_object, method_name)
         mockery.stubba.stub(method)
-        expectation = mocha.stubs(method_name, caller)
+        expectation = mocha.stubs(method_name, caller_locations)
         expectation.returns(args.shift) unless args.empty?
       end
       expectation


### PR DESCRIPTION
Ref #574

`#on_stubbing` calls `#check` three times without passing a backtrace, so `#caller` is called three times as well. However, the backtrace isn't actually used unless an exception is raised by `#check`, so these (expensive) invocations are completely wasteful.

This commit makes `#caller` lazy, because it currently shows up as one of the top three hottest individual methods in our test suite (and more than 2% of all allocations).

The other changes from `#caller` to `#caller_locations` are less hot, but `#caller_locations` is more efficient than `#caller` so I included them as well.