### PR TITLE
Changes related to Kernel#caller & Kernel#caller_locations

### DIFF
--- a/lib/mocha/mock.rb
+++ b/lib/mocha/mock.rb
@@ -113,12 +113,12 @@ module Mocha
     #   object = mock()
     #   object.expects(:expected_method_one).returns(:result_one)
     #   object.expects(:expected_method_two).returns(:result_two)
-    def expects(method_name_or_hash, backtrace = nil)
+    def expects(method_name_or_hash, backtrace_locations = nil)
       expectation = nil
       iterator = ArgumentIterator.new(method_name_or_hash)
       iterator.each do |method_name, *args|
         ensure_method_not_already_defined(method_name)
-        expectation = Expectation.new(self, method_name, backtrace)
+        expectation = Expectation.new(self, method_name, backtrace_locations)
         expectation.in_sequence(@mockery.sequences.last) if @mockery.sequences.any?
         expectation.returns(args.shift) unless args.empty?
         @expectations.add(expectation)
@@ -151,12 +151,12 @@ module Mocha
     #   object = mock()
     #   object.stubs(:stubbed_method_one).returns(:result_one)
     #   object.stubs(:stubbed_method_two).returns(:result_two)
-    def stubs(method_name_or_hash, backtrace = nil)
+    def stubs(method_name_or_hash, backtrace_locations = nil)
       expectation = nil
       iterator = ArgumentIterator.new(method_name_or_hash)
       iterator.each do |method_name, *args|
         ensure_method_not_already_defined(method_name)
-        expectation = Expectation.new(self, method_name, backtrace)
+        expectation = Expectation.new(self, method_name, backtrace_locations)
         expectation.at_least(0)
         expectation.in_sequence(@mockery.sequences.last) if @mockery.sequences.any?
         expectation.returns(args.shift) unless args.empty?

--- a/lib/mocha/mockery.rb
+++ b/lib/mocha/mockery.rb
@@ -150,13 +150,13 @@ module Mocha
 
     private
 
-    def check(action, description, signature_proc, backtrace = caller)
+    def check(action, description, signature_proc, backtrace = nil)
       treatment = Mocha.configuration.send(action)
       return if (treatment == :allow) || (block_given? && !yield)
 
       method_signature = signature_proc.call
       message = "stubbing #{description}: #{method_signature}"
-      raise StubbingError.new(message, backtrace) if treatment == :prevent
+      raise StubbingError.new(message, backtrace || caller) if treatment == :prevent
 
       Logger.warning(message) if treatment == :warn
     end

--- a/lib/mocha/object_methods.rb
+++ b/lib/mocha/object_methods.rb
@@ -97,7 +97,7 @@ module Mocha
         mockery.on_stubbing(self, method_name)
         method = stubba_method.new(stubba_object, method_name)
         mockery.stubba.stub(method)
-        expectation = mocha.expects(method_name, caller)
+        expectation = mocha.expects(method_name, caller_locations)
         expectation.returns(args.shift) unless args.empty?
       end
       expectation
@@ -143,7 +143,7 @@ module Mocha
         mockery.on_stubbing(self, method_name)
         method = stubba_method.new(stubba_object, method_name)
         mockery.stubba.stub(method)
-        expectation = mocha.stubs(method_name, caller)
+        expectation = mocha.stubs(method_name, caller_locations)
         expectation.returns(args.shift) unless args.empty?
       end
       expectation


### PR DESCRIPTION
* [Avoid some unnecessary calls to Kernel#caller](https://github.com/freerange/mocha/commit/8d5c763bce780d72bbe72c4aec14f236a343abf8)
* [Fix ObjectMethods#expects & #stubs](https://github.com/freerange/mocha/commit/8aa7708384d9f863b0f454f091799bcbb6ce8a2f)

Supersedes #801.

Relates to #574.

